### PR TITLE
ensure id on first-ever request

### DIFF
--- a/examples/snippets/app/examples/marketing-pages/flags.tsx
+++ b/examples/snippets/app/examples/marketing-pages/flags.tsx
@@ -1,4 +1,4 @@
-import type { ReadonlyRequestCookies } from '@vercel/flags';
+import type { ReadonlyHeaders, ReadonlyRequestCookies } from '@vercel/flags';
 import { dedupe, flag } from '@vercel/flags/next';
 import { getOrGenerateVisitorId } from './get-or-generate-visitor-id';
 
@@ -9,10 +9,12 @@ interface Entities {
 const identify = dedupe(
   async ({
     cookies,
+    headers,
   }: {
     cookies: ReadonlyRequestCookies;
+    headers: ReadonlyHeaders;
   }): Promise<Entities> => {
-    const visitorId = await getOrGenerateVisitorId(cookies);
+    const visitorId = await getOrGenerateVisitorId(cookies, headers);
     return { visitor: visitorId ? { id: visitorId } : undefined };
   },
 );

--- a/examples/snippets/app/examples/marketing-pages/get-or-generate-visitor-id.tsx
+++ b/examples/snippets/app/examples/marketing-pages/get-or-generate-visitor-id.tsx
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid';
 import { dedupe } from '@vercel/flags/next';
-import type { ReadonlyRequestCookies } from '@vercel/flags';
+import type { ReadonlyHeaders, ReadonlyRequestCookies } from '@vercel/flags';
 import type { NextRequest } from 'next/server';
 
 const generateId = dedupe(async () => nanoid());
@@ -8,11 +8,21 @@ const generateId = dedupe(async () => nanoid());
 // This function is not deduplicated, as it is called with
 // two different cookies objects, so it can not be deduplicated.
 //
-// However, the generateId function will always generate the same id of the
+// However, the generateId function will always generate the same id for the
 // same request, so it is safe to call it multiple times within the same runtime.
 export const getOrGenerateVisitorId = async (
   cookies: ReadonlyRequestCookies | NextRequest['cookies'],
+  headers: ReadonlyHeaders | NextRequest['headers'],
 ) => {
-  const visitorId = cookies.get('marketing-visitor-id')?.value;
-  return visitorId ?? generateId();
+  // check cookies first
+  const cookieVisitorId = cookies.get('marketing-visitor-id')?.value;
+  if (cookieVisitorId) return cookieVisitorId;
+
+  // check headers in case middleware set a cookie on the response, as it will
+  // not be present on the initial request
+  const headerVisitorId = headers.get('x-marketing-visitor-id');
+  if (headerVisitorId) return headerVisitorId;
+
+  // if no visitor id is found, generate a new one
+  return generateId();
 };

--- a/examples/snippets/app/examples/marketing-pages/middleware.tsx
+++ b/examples/snippets/app/examples/marketing-pages/middleware.tsx
@@ -5,7 +5,10 @@ import { getOrGenerateVisitorId } from './get-or-generate-visitor-id';
 
 export async function marketingMiddleware(request: NextRequest) {
   // assign a cookie to the visitor
-  const visitorId = await getOrGenerateVisitorId(request.cookies);
+  const visitorId = await getOrGenerateVisitorId(
+    request.cookies,
+    request.headers,
+  );
 
   // precompute the flags
   const code = await precompute(marketingFlags);
@@ -13,6 +16,16 @@ export async function marketingMiddleware(request: NextRequest) {
   // rewrite the page with the code and set the cookie
   return NextResponse.rewrite(
     new URL(`/examples/marketing-pages/${code}`, request.url),
-    { headers: { 'Set-Cookie': `marketing-visitor-id=${visitorId}; Path=/` } },
+    {
+      headers: {
+        // Set the cookie on the response
+        'Set-Cookie': `marketing-visitor-id=${visitorId}; Path=/`,
+        // Add a request header, so the page knows the generated id even
+        // on the first-ever request which has no request cookie yet.
+        //
+        // This is later used by the getOrGenerateVisitorId function.
+        'x-marketing-visitor-id': visitorId,
+      },
+    },
   );
 }


### PR DESCRIPTION
There is a specific situation in which the generated id was not available to the page.

When the page is dynamic and uses `getOrGenerateVisitorId` it would not see the cookie generated by Edge Middleware, as the cookie was not present on the request. Instead, the cookie was only present on the `set-cookie` response header, which we have no access to inside of the page.

To work around this, we make Edge Middleware set a `x-marketing-visitor-id` header which also holds the generated id. We can then read this header in `getOrGenerateVisitorId` so we know the generated id even on the initial cookie-less request.

Alternatively we could have mangled the request cookies by adding the generated id to them, but I do not like this approach as we lose information, as the page can no longer trust the request cookies are what was actually sent by the client. With the taken approach the page can still know whether the cookie was present originally in case that ever becomes relevant.