### PR TITLE
use color which does not look like an error message

### DIFF
--- a/examples/snippets/components/demo-flag.tsx
+++ b/examples/snippets/components/demo-flag.tsx
@@ -1,10 +1,10 @@
 export function DemoFlag({ value, name }: { value: boolean; name: string }) {
   return (
     <div
-      className={`rounded-md ${value ? 'bg-green-100 dark:bg-green-800' : 'bg-red-100 dark:bg-red-800'}`}
+      className={`rounded-md ${value ? 'bg-green-100 dark:bg-green-800' : 'bg-fuchsia-100 dark:bg-fuchsia-800'}`}
     >
       <p
-        className={`p-4 text-sm font-medium ${value ? 'text-green-800 dark:text-green-100' : 'text-red-800 dark:text-red-100'}`}
+        className={`p-4 text-sm font-medium ${value ? 'text-green-800 dark:text-green-100' : 'text-fuchsia-800 dark:text-fuchsia-100'}`}
       >
         The feature flag <span className="font-semibold">{name}</span> evaluated
         to <span className="font-semibold">{JSON.stringify(value)}</span>.


### PR DESCRIPTION
Changes the color of the Demo component when the value is `false` to prevent it from looking like something went wrong.