### PR TITLE
allow usage without FLAGS_SECRET

### DIFF
--- a/packages/flags/src/lib/verify-access.ts
+++ b/packages/flags/src/lib/verify-access.ts
@@ -30,6 +30,11 @@ export const verifyAccess = trace(
     secret: string | undefined = process?.env?.FLAGS_SECRET,
   ) {
     if (!authHeader) return false;
+    if (!secret)
+      throw new Error(
+        '@vercel/flags: verifyAccess was called without a secret. Please set FLAGS_SECRET environment variable.',
+      );
+
     const data = await decrypt<{}>(
       authHeader?.replace(/^Bearer /i, ''),
       secret,

--- a/packages/flags/src/next/index.ts
+++ b/packages/flags/src/next/index.ts
@@ -379,13 +379,6 @@ export function flag<
 
   const flag = trace(
     async (...args: any[]) => {
-      // defining flags throws since a FLAGS_SECRET is necessary for encrypting the flag code
-      if (!process.env.FLAGS_SECRET) {
-        throw new Error(
-          '@vercel/flags: Missing FLAGS_SECRET env var. Will not respect any overrides until this secret is added as an environment variable.',
-        );
-      }
-
       // Default method, may be overwritten by `getPrecomputed` or `run`
       // which is why we must not trace them directly in here,
       // as the attribute should be part of the `flag` function.

--- a/packages/flags/src/next/precompute.ts
+++ b/packages/flags/src/next/precompute.ts
@@ -133,6 +133,12 @@ export async function getPrecomputed<T extends JsonValue>(
   code: string,
   secret: string | undefined = process.env.FLAGS_SECRET,
 ): Promise<any> {
+  if (!secret) {
+    throw new Error(
+      '@vercel/flags: getPrecomputed was called without a secret. Please set FLAGS_SECRET environment variable.',
+    );
+  }
+
   const flagSet = await deserialize(precomputeFlags, code, secret);
 
   if (Array.isArray(flagOrFlags)) {
@@ -162,6 +168,12 @@ export async function generatePermutations(
   filter: ((permutation: Record<string, JsonValue>) => boolean) | null = null,
   secret: string = process.env.FLAGS_SECRET!,
 ): Promise<string[]> {
+  if (!secret) {
+    throw new Error(
+      '@vercel/flags: generatePermutations was called without a secret. Please set FLAGS_SECRET environment variable.',
+    );
+  }
+
   const options = flags.map((flag) => {
     // no permutations if you don't declare any options
     if (!flag.options) return [];


### PR DESCRIPTION
Allow using the Flags SDK in Next.js without having a `FLAGS_SECRET` yet for a more progressive disclosure of complexity.