### PR TITLE
Statsig adapter

### DIFF
--- a/.changeset/tidy-years-divide.md
+++ b/.changeset/tidy-years-divide.md
@@ -1,0 +1,5 @@
+---
+'@flags-sdk/statsig': minor
+---
+
+Statsig adapter: Use Feature Gates, Experiments, Dynamic Configs, and Autotunes with `statsig-node` and Edge Config via `statsig-node-vercel`

--- a/packages/adapter-statsig/package.json
+++ b/packages/adapter-statsig/package.json
@@ -9,16 +9,27 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./provider": {
+      "types": "./dist/provider/index.d.ts",
+      "import": "./dist/provider/index.js",
+      "require": "./dist/provider/index.cjs"
     }
   },
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "typesVersions": {
     "*": {
       ".": [
-        "dist/*.d.ts",
-        "dist/*.d.cts"
+        "./dist/index.d.ts",
+        "./dist/index.d.cts"
+      ],
+      "provider": [
+        "./dist/provider/index.d.ts",
+        "./dist/provider/index.d.cts"
       ]
     }
   },
@@ -42,10 +53,13 @@
   },
   "devDependencies": {
     "@types/node": "20.11.17",
+    "@vercel/edge-config": "1.2.0",
     "@vercel/flags": "workspace:*",
     "eslint-config-custom": "workspace:*",
     "msw": "2.6.4",
     "rimraf": "6.0.1",
+    "statsig-node": "5.31.0",
+    "statsig-node-vercel": "0.4.0",
     "tsconfig": "workspace:*",
     "tsup": "8.0.1",
     "typescript": "5.6.3",

--- a/packages/adapter-statsig/package.json
+++ b/packages/adapter-statsig/package.json
@@ -35,7 +35,11 @@
     "test:watch": "vitest",
     "type-check": "tsc --noEmit"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@vercel/edge-config": "1.2.0",
+    "statsig-node": "5.31.0",
+    "statsig-node-vercel": "0.4.0"
+  },
   "devDependencies": {
     "@types/node": "20.11.17",
     "@vercel/flags": "workspace:*",

--- a/packages/adapter-statsig/src/index.ts
+++ b/packages/adapter-statsig/src/index.ts
@@ -1,52 +1,123 @@
 export { getProviderData } from './provider';
+import { Adapter } from '@vercel/flags';
+import { Statsig, type StatsigUser, type StatsigOptions } from 'statsig-node';
+import { EdgeConfigDataAdapter } from 'statsig-node-vercel';
+import { createClient } from '@vercel/edge-config';
 
-// import { Adapter } from '@vercel/flags';
-// import { flag } from '@vercel/flags/next';
+interface StatsigUserEntities {
+  statsigUser: StatsigUser;
+}
 
-// // TODO allow adapter factories like createStatsigAdapter to set a default identify function
-// // TODO implement adapter.flush
-// // TODO go the AI SDK route and create a fully configured client?
-// // TODO expose adapter.client
-// function createStatsigAdapter(options: {}) {
-//   // per adapter instance
-//   return function statsigAdapter<ValueType, EntitiesType>(): Adapter<
-//     ValueType,
-//     EntitiesType
-//   > {
-//     // per flag instance
-//     return {
-//       initialize: () => {
-//         return Promise.resolve();
-//       },
-//       identify: (): EntitiesType => {
-//         return {} as EntitiesType;
-//       },
-//       decide: () => {
-//         return 1 as ValueType;
-//       },
-//     };
-//   };
-// }
+/**
+ * Create a Statsig adapter for use with the Flags SDK.
+ *
+ * The adapter expects to use `statsig-node` and `@vercel/edge-config` to resolve flags via
+ * Statsig Feature Gates, Experiments, DynamicConfigs, Autotunes, and so on.
+ *
+ * It will initialize Statsig and resolve values, and will not log exposures. Exposures
+ * should be logged on the client side to prevent prefetching or middleware from accidentally
+ * triggering exposures when the user has not engaged with a page yet.
+ *
+ * Methods:
+ * - `.()` - Checks a feature gate and returns a boolean value
+ * - `.featureGate()` - Checks a feature gate and returns a value based on the result and rule ID
+ * - `.experiment()` - Checks an experiment and returns a value based on the result and rule ID
+ */
+function createStatsigAdapter(options: {
+  statsigSecretKey: string;
+  statsigOptions?: StatsigOptions;
+  edgeConfig?: {
+    connectionString: string;
+    itemKey: string;
+  };
+}) {
+  const edgeConfigClient = options.edgeConfig
+    ? createClient(options.edgeConfig.connectionString)
+    : undefined;
 
-// const statsigAdapter = createStatsigAdapter({
-//   consoleApiKey: 'consoleApiKey',
-// });
+  const dataAdapter =
+    edgeConfigClient && options.edgeConfig?.itemKey
+      ? new EdgeConfigDataAdapter({
+          edgeConfigItemKey: options.edgeConfig.itemKey,
+          edgeConfigClient,
+        })
+      : undefined;
 
-// type ET = { user: { id: string } };
+  let _statsigClient: ReturnType<typeof Statsig.initialize>;
+  const getStatsigClient = () => {
+    if (!_statsigClient) {
+      throw new Error('Statsig client not initialized');
+    }
+    return _statsigClient;
+  };
 
-// export const exampleFlag = flag<string, ET>({
-//   key: 'example',
-//   adapter: statsigAdapter(),
-//   async decide() {
-//     return 'test';
-//   },
-// });
+  const initialize = async () => {
+    _statsigClient = Statsig.initialize(options.statsigSecretKey, {
+      dataAdapter,
+      initStrategyForIDLists: 'none',
+      disableIdListsSync: true,
+      ...options.statsigOptions,
+    });
+    await _statsigClient;
+  };
 
-// // export const exampleFlag2 = flag(
-// //   statsigAdapter<string, ET>({
-// //     key: 'example',
-// //     identify() {
-// //       return { user: { id: 'joe' } };
-// //     },
-// //   }),
-// // );
+  /**
+   * Resolve a Feature Gate and return an object with the boolean value and rule ID
+   *
+   * The key is based on the `key` property of the flag
+   * The entities should extend `{ statsigUser: StatsigUser }`
+   */
+  const featureGate = <T>(
+    mapValue: (value: boolean, ruleId: string) => T,
+  ): Adapter<T, StatsigUserEntities> => {
+    return {
+      initialize,
+      decide: async ({ key, entities }) => {
+        await getStatsigClient();
+        const result = Statsig.getFeatureGateWithExposureLoggingDisabledSync(
+          entities?.statsigUser as StatsigUser,
+          key,
+        );
+        return mapValue(result.value, result.ruleID);
+      },
+    };
+  };
+
+  /**
+   * Resolve a Dynamic Config and return a value based on the result and rule ID.
+   *
+   * The key is based on the `key` property of the flag
+   * The entities should extend `{ statsigUser: StatsigUser }`
+   */
+  const resolveDynamicConfig = <T>(
+    mapValue: (value: Record<string, unknown>, ruleId: string) => T,
+  ): Adapter<T, StatsigUserEntities> => {
+    return {
+      initialize,
+      decide: async ({ key, entities }) => {
+        await getStatsigClient();
+        const result = Statsig.getConfigWithExposureLoggingDisabledSync(
+          entities?.statsigUser as StatsigUser,
+          key,
+        );
+        return mapValue(result.value, result.getRuleID());
+      },
+    };
+  };
+
+  /** Check a feature gate and return a boolean value */
+  function statsigAdapter(): Adapter<boolean, StatsigUserEntities> {
+    return featureGate((value) => value);
+  }
+  // while statsigAdapter() works well as a feature flag, when metric lifts are tracked
+  // through exposures on the client, it's better to use statsigAdapter.featureGate(...)
+  // ...and map the rule ID into the return value
+  statsigAdapter.featureGate = featureGate;
+  // experiment, dynamicConfig, and autotune are all DynamicConfig objects
+  statsigAdapter.experiment = resolveDynamicConfig;
+  statsigAdapter.dynamicConfig = resolveDynamicConfig;
+  statsigAdapter.autotune = resolveDynamicConfig;
+  return statsigAdapter;
+}
+
+export { createStatsigAdapter };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,16 @@ importers:
         version: 1.4.0(@types/node@20.11.17)
 
   packages/adapter-statsig:
+    dependencies:
+      '@vercel/edge-config':
+        specifier: 1.2.0
+        version: 1.2.0
+      statsig-node:
+        specifier: 5.31.0
+        version: 5.31.0
+      statsig-node-vercel:
+        specifier: 0.4.0
+        version: 0.4.0(@vercel/edge-config@1.2.0)
     devDependencies:
       '@types/node':
         specifier: 20.11.17
@@ -458,7 +468,7 @@ importers:
         version: 5.9.6
       react-dom:
         specifier: '*'
-        version: 19.0.0(react@19.1.0-canary-056073de-20250109)
+        version: 19.0.0(react@19.1.0-canary-b3a95caf-20250113)
     devDependencies:
       '@types/node':
         specifier: 20.11.17
@@ -477,10 +487,10 @@ importers:
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       next:
         specifier: 15.1.4
-        version: 15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0)(react@19.1.0-canary-056073de-20250109)
+        version: 15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0)(react@19.1.0-canary-b3a95caf-20250113)
       react:
         specifier: canary
-        version: 19.1.0-canary-056073de-20250109
+        version: 19.1.0-canary-b3a95caf-20250113
       rimraf:
         specifier: 6.0.1
         version: 6.0.1
@@ -1449,7 +1459,6 @@ packages:
     dependencies:
       eslint: 8.56.0
       eslint-visitor-keys: 3.4.3
-    dev: true
 
   /@eslint-community/regexpp@4.12.1:
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
@@ -1478,7 +1487,6 @@ packages:
   /@eslint/js@8.56.0:
     resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: true
 
   /@floating-ui/core@1.6.8:
     resolution: {integrity: sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==}
@@ -3169,7 +3177,7 @@ packages:
       sirv: 3.0.0
       svelte: 4.2.19
       tiny-glob: 0.2.9
-      vite: 5.1.1(@types/node@20.11.17)
+      vite: 5.1.1(@types/node@22.9.0)
 
   /@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.2)(svelte@4.2.19)(vite@5.1.1):
     resolution: {integrity: sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==}
@@ -3182,7 +3190,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.19)(vite@5.1.1)
       debug: 4.4.0
       svelte: 4.2.19
-      vite: 5.1.1(@types/node@20.11.17)
+      vite: 5.1.1(@types/node@22.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3200,7 +3208,7 @@ packages:
       magic-string: 0.30.15
       svelte: 4.2.19
       svelte-hmr: 0.16.0(svelte@4.2.19)
-      vite: 5.1.1(@types/node@20.11.17)
+      vite: 5.1.1(@types/node@22.9.0)
       vitefu: 0.2.5(vite@5.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -3549,6 +3557,7 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.48.0)(typescript@5.6.3):
     resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
@@ -3577,7 +3586,6 @@ packages:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.56.0)(typescript@5.6.3):
     resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
@@ -3651,6 +3659,7 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.6.3):
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
@@ -3671,7 +3680,6 @@ packages:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.6.3):
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
@@ -3692,7 +3700,6 @@ packages:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/parser@8.18.0(eslint@8.56.0)(typescript@5.6.3):
     resolution: {integrity: sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==}
@@ -3752,6 +3759,7 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/type-utils@6.21.0(eslint@8.48.0)(typescript@5.6.3):
     resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
@@ -3771,7 +3779,6 @@ packages:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
-    dev: false
 
   /@typescript-eslint/type-utils@6.21.0(eslint@8.56.0)(typescript@5.6.3):
     resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
@@ -3842,6 +3849,7 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/typescript-estree@5.62.0(typescript@5.6.3):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
@@ -3883,6 +3891,7 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/typescript-estree@6.21.0(typescript@5.6.3):
     resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
@@ -3942,6 +3951,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: true
 
   /@typescript-eslint/utils@5.62.0(eslint@8.48.0)(typescript@5.6.3):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
@@ -3961,7 +3971,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: false
 
   /@typescript-eslint/utils@5.62.0(eslint@8.56.0)(typescript@5.6.3):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
@@ -4000,6 +4009,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: true
 
   /@typescript-eslint/utils@6.21.0(eslint@8.48.0)(typescript@5.6.3):
     resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
@@ -4018,7 +4028,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: false
 
   /@typescript-eslint/utils@6.21.0(eslint@8.56.0)(typescript@5.6.3):
     resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
@@ -4080,7 +4089,6 @@ packages:
 
   /@ungap/structured-clone@1.2.1:
     resolution: {integrity: sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==}
-    dev: true
 
   /@vercel/edge-config-fs@0.1.0:
     resolution: {integrity: sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==}
@@ -5610,7 +5618,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.7.0)(eslint@8.48.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0)
 
   /eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
@@ -5664,7 +5672,7 @@ packages:
       debug: 4.4.0
       enhanced-resolve: 5.17.1
       eslint: 8.56.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.18.0)(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.3.0
@@ -5672,7 +5680,6 @@ packages:
       stable-hash: 0.0.4
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.48.0):
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
@@ -5695,7 +5702,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.48.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.48.0)(typescript@5.6.3)
       debug: 3.2.7
       eslint: 8.48.0
       eslint-import-resolver-node: 0.3.9
@@ -5731,7 +5738,6 @@ packages:
       eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /eslint-module-utils@2.12.0(@typescript-eslint/parser@8.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0):
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
@@ -5795,7 +5801,7 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 6.21.0(eslint@8.48.0)(typescript@5.3.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.48.0)(typescript@5.6.3)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.3
@@ -5855,7 +5861,6 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
-    dev: true
 
   /eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.0)(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0):
     resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
@@ -5914,6 +5919,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: true
 
   /eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.48.0)(jest@29.7.0)(typescript@5.6.3):
     resolution: {integrity: sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==}
@@ -5935,7 +5941,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: false
 
   /eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.56.0)(jest@29.7.0)(typescript@5.6.3):
     resolution: {integrity: sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==}
@@ -6016,7 +6021,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.48.0
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.48.0)(jest@29.7.0)(typescript@5.3.3)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.48.0)(jest@29.7.0)(typescript@5.6.3)
 
   /eslint-plugin-playwright@0.16.0(eslint-plugin-jest@27.9.0)(eslint@8.56.0):
     resolution: {integrity: sha512-DcHpF0SLbNeh9MT4pMzUGuUSnJ7q5MWbP8sSEFIMS6j7Ggnduq8ghNlfhURgty4c1YFny7Ge9xYTO1FSAoV2Vw==}
@@ -6330,7 +6335,6 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /esm-env@1.2.1:
     resolution: {integrity: sha512-U9JedYYjCnadUlXk7e1Kr+aENQhtUaoaV9+gZm1T8LC/YBAPJx3NSPIAurFOC0U5vrdSevnUJS2/wUVxGwPhng==}
@@ -6949,6 +6953,10 @@ packages:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  /ip3country@5.0.0:
+    resolution: {integrity: sha512-lcFLMFU4eO1Z7tIpbVFZkaZ5ltqpeaRx7L9NsAbA9uA7/O/rj3RF8+evE5gDitooaTTIqjdzZrenFO/OOxQ2ew==}
+    dev: false
 
   /ipaddr.js@2.2.0:
     resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
@@ -8394,7 +8402,7 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0)(react@19.1.0-canary-056073de-20250109):
+  /next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0)(react@19.1.0-canary-b3a95caf-20250113):
     resolution: {integrity: sha512-mTaq9dwaSuwwOrcu3ebjDYObekkxRnXpuVL21zotM8qE2W0HBOdVIdg2Li9QjMEZrj73LN96LcWcz62V19FjAg==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
@@ -8422,9 +8430,9 @@ packages:
       busboy: 1.6.0
       caniuse-lite: 1.0.30001688
       postcss: 8.4.31
-      react: 19.1.0-canary-056073de-20250109
-      react-dom: 19.0.0(react@19.1.0-canary-056073de-20250109)
-      styled-jsx: 5.1.6(@babel/core@7.26.0)(react@19.1.0-canary-056073de-20250109)
+      react: 19.1.0-canary-b3a95caf-20250113
+      react-dom: 19.0.0(react@19.1.0-canary-b3a95caf-20250113)
+      styled-jsx: 5.1.6(@babel/core@7.26.0)(react@19.1.0-canary-b3a95caf-20250113)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.1.4
       '@next/swc-darwin-x64': 15.1.4
@@ -8574,6 +8582,18 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+    dev: false
+
+  /node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
     dev: false
 
   /node-int64@0.4.0:
@@ -9153,12 +9173,12 @@ packages:
       scheduler: 0.23.2
     dev: false
 
-  /react-dom@19.0.0(react@19.1.0-canary-056073de-20250109):
+  /react-dom@19.0.0(react@19.1.0-canary-b3a95caf-20250113):
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
       react: ^19.0.0
     dependencies:
-      react: 19.1.0-canary-056073de-20250109
+      react: 19.1.0-canary-b3a95caf-20250113
       scheduler: 0.25.0
 
   /react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028):
@@ -9244,8 +9264,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /react@19.1.0-canary-056073de-20250109:
-    resolution: {integrity: sha512-/oh0HJ0iDcPeoDYTJPjgMJpX2pFopmcbGANxRjED7tS4yrxX32ABdALPPStYTXaPwNUm/cnJFZwZWJiesWANVw==}
+  /react@19.1.0-canary-b3a95caf-20250113:
+    resolution: {integrity: sha512-2TnspIIMpVpvtOlT1SuTy4CZnpl60VN6rbl8s5oYVEklfoij3yQSXJCe9IR6iP4CsFLTbKqoPJxRWSpG+06mPw==}
     engines: {node: '>=0.10.0'}
 
   /read-cache@1.0.0:
@@ -9834,6 +9854,39 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
+  /statsig-node-vercel@0.4.0(@vercel/edge-config@1.2.0):
+    resolution: {integrity: sha512-Q0jOfOqb/jTDJbgI/4O4TFODPOLYlPE4FCaNJzjr+8EiIPJ7lWbOQ8bq1d06MSQk33axZ0XaRKQsz6L5vEAhvQ==}
+    peerDependencies:
+      '@vercel/edge-config': ^0.1.4
+    dependencies:
+      '@vercel/edge-config': 1.2.0
+      statsig-node: 5.22.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /statsig-node@5.22.0:
+    resolution: {integrity: sha512-g3ULqEbC6o5pu4FhOg1IjJp8IDGA7IUeMbaX+v2DUyk0cja7jH13TPznuHgJxy4ICyOlTBMV1JLagMGNtQdXSg==}
+    dependencies:
+      ip3country: 5.0.0
+      node-fetch: 2.7.0
+      ua-parser-js: 1.0.40
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /statsig-node@5.31.0:
+    resolution: {integrity: sha512-QxuLBdEGjzrUU4Tj3WvaactJQN0C8qSogVp1TdGallz/Wmm/0FCZswwtMoMjVePQW+kwAwxK/nvsmqig9xG4ew==}
+    dependencies:
+      ip3country: 5.0.0
+      node-fetch: 2.7.0
+      ua-parser-js: 1.0.40
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -10060,7 +10113,7 @@ packages:
       react: 19.0.0-rc-02c0e824-20241028
     dev: false
 
-  /styled-jsx@5.1.6(@babel/core@7.26.0)(react@19.1.0-canary-056073de-20250109):
+  /styled-jsx@5.1.6(@babel/core@7.26.0)(react@19.1.0-canary-b3a95caf-20250113):
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -10075,7 +10128,7 @@ packages:
     dependencies:
       '@babel/core': 7.26.0
       client-only: 0.0.1
-      react: 19.1.0-canary-056073de-20250109
+      react: 19.1.0-canary-b3a95caf-20250113
     dev: true
 
   /sucrase@3.35.0:
@@ -10351,6 +10404,10 @@ packages:
       url-parse: 1.5.10
     dev: true
 
+  /tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: false
+
   /tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
     dependencies:
@@ -10378,6 +10435,7 @@ packages:
       typescript: '>=4.2.0'
     dependencies:
       typescript: 5.3.3
+    dev: true
 
   /ts-api-utils@1.4.3(typescript@5.6.3):
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
@@ -10485,6 +10543,7 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 5.3.3
+    dev: true
 
   /tsutils@3.21.0(typescript@5.6.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -10655,11 +10714,17 @@ packages:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
 
   /typescript@5.6.3:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  /ua-parser-js@1.0.40:
+    resolution: {integrity: sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==}
+    hasBin: true
+    dev: false
 
   /ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
@@ -10779,6 +10844,11 @@ packages:
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  /uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+    dev: false
+
   /v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
     engines: {node: '>=10.12.0'}
@@ -10862,6 +10932,7 @@ packages:
       rollup: 4.28.1
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
 
   /vite@5.1.1(@types/node@22.9.0):
     resolution: {integrity: sha512-wclpAgY3F1tR7t9LL5CcHC41YPkQIpKUGeIuT8MdNwNZr6OqOTLs7JX5vIHAtzqLWXts0T+GDrh9pN2arneKqg==}
@@ -10906,7 +10977,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 5.1.1(@types/node@20.11.17)
+      vite: 5.1.1(@types/node@22.9.0)
 
   /vitest@1.4.0(@types/node@20.11.17):
     resolution: {integrity: sha512-gujzn0g7fmwf83/WzrDTnncZt2UiXP41mHuFYFrdwaLRVQ6JYQEiME2IfEjU3vcFL3VKa75XhI3lFgn+hfVsQw==}
@@ -10983,9 +11054,20 @@ packages:
       defaults: 1.0.4
     dev: true
 
+  /webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+    dev: false
+
   /webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
     dev: true
+
+  /whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: false
 
   /whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}


### PR DESCRIPTION
## Statsig Adapter

Implements a Statsig adapter using `statsig-node` and `statsig-node-vercel`.

The adapter takes initialization details for Statsig and the Edge Config adapter, and returns an interface that can be used to declare Feature Gates, Feature Gates with metric lifts, Experiments, DynamicConfigs, and Autotunes.

The adapter will initialize Statsig, notably with defaults where IDLists are not synced and there is no strategy to sync them. This can be changed by passing alternatives in `statsigOptions`, but these defaults reduce network fetching when flags are precomputed in middleware.

The decide function will not log events to Statsig — Instead, it's expected that this will be done client side. The reasoning for this is that Next.js may prefetch routes, and we do not want to expose a user to experiments or gates just because they were prefetched. Additionally, because of the serverless runtime context, the buffering and flushing of logs can be unreliable.

For this reason, we will expect the client to log events, for which they will either need to log events manually with a rule ID, or take these results as initial values while checking them again with exposures on the client side.

### Simple usage

The usage of calling the adapter directly is the simplest case — A feature gate without metric lifts.

```typescript
const statsigAdapter = createStatsigAdapter({
  statsigSecretKey: 'statsigSecretKey',
});

export const exampleFlag = flag<boolean, StatsigUserEntities>({
  key: 'example',
  adapter: statsigAdapter(),
});
```

### Methods

`featureGate` — Receives the boolean value and ruleID and can map the result to a flag value

```typescript
export const featureGateFlag = flag<[boolean, string], StatsigUserEntities>({
  key: 'example-gate',
  adapter: statsigAdapter.featureGate((value, ruleId) => [value, ruleId]),
});
```

`dynamicConfig` — Receives the evaluated value of a DynamicConfig object and ruleId and can map the result to a flag value

```typescript
export const dynamicConfigFlag = flag<string, StatsigUserEntities>({
  key: 'example-config',
  adapter: statsigAdapter.dynamicConfig((value) => value.heroText),
});
```

`experiment` — Receives the evaluated value of an Experiment object and ruleId and can map the result to a flag value

```typescript
export const dynamicConfigFlag = flag<'control' | 'test', StatsigUserEntities>({
  key: 'example-experiment',
  adapter: statsigAdapter.experiment((value, ruleId) => value.experimentGroup),
});
```

`autotune` — Receives the evaluated value of an Autotune and ruleId and can map the result to a flag value

```typescript
const experimentGroups = ['control', 'variant1', 'variant2'] as const;
type ExperimentGroup = (typeof experimentGroups)[number];

export const dynamicConfigFlag = flag<ExperimentGroup, StatsigUserEntities>({
  key: 'example-autotune',
  adapter: statsigAdapter.autotune((value, ruleId) => value.experimentGroup),
});
```

`initialize` — Statsig.initialize will be called lazily, when a flag's `decide` method is invoked. To initialize Statsig earlier using the adapter's implementation:

```typescript
statsigAdapter.initialize()
```