### PR TITLE
unify and simplify adapters

### DIFF
--- a/packages/adapter-happykit/package.json
+++ b/packages/adapter-happykit/package.json
@@ -11,10 +11,6 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
-    },
-    "./provider": {
-      "import": "./dist/provider/index.js",
-      "require": "./dist/provider/index.cjs"
     }
   },
   "main": "./dist/index.js",
@@ -23,10 +19,6 @@
       ".": [
         "dist/*.d.ts",
         "dist/*.d.cts"
-      ],
-      "provider": [
-        "dist/provider/index.d.ts",
-        "dist/provider/index.d.cts"
       ]
     }
   },

--- a/packages/adapter-happykit/src/index.ts
+++ b/packages/adapter-happykit/src/index.ts
@@ -5,6 +5,8 @@ import { createGetFlags } from '@happykit/flags/server';
 import type { GetDefinitions, Definitions } from '@happykit/flags/api-route';
 import { get } from '@vercel/edge-config';
 
+export { getProviderData } from './provider';
+
 export const getDefinitions: GetDefinitions = async (
   projectId,
   envKey,

--- a/packages/adapter-happykit/src/provider/index.test.ts
+++ b/packages/adapter-happykit/src/provider/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, describe } from 'vitest';
-import { getHappyKitData } from '.';
+import { getProviderData } from '..';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import { HttpResponse, http } from 'msw';
@@ -36,11 +36,11 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterAll(() => server.close());
 afterEach(() => server.resetHandlers());
 
-describe('getHappyKitData', () => {
+describe('getProviderData', () => {
   describe('when called with valid params', () => {
     it('should fetch and return', async () => {
       await expect(
-        getHappyKitData({
+        getProviderData({
           apiToken: 'this-is-my-api-token',
           envKey: 'flags_pub_development_272357356657967622',
         }),
@@ -65,7 +65,7 @@ describe('getHappyKitData', () => {
   describe('when called with invalid params', () => {
     it('should return appropriate hints', async () => {
       // @ts-expect-error this is the case we are testing
-      await expect(getHappyKitData({})).resolves.toEqual({
+      await expect(getProviderData({})).resolves.toEqual({
         definitions: {},
         hints: [
           {
@@ -81,7 +81,7 @@ describe('getHappyKitData', () => {
 
       await expect(
         // @ts-expect-error this is the case we are testing
-        getHappyKitData({ apiToken: 'some-api-token' }),
+        getProviderData({ apiToken: 'some-api-token' }),
       ).resolves.toEqual({
         definitions: {},
         hints: [
@@ -94,7 +94,7 @@ describe('getHappyKitData', () => {
 
       await expect(
         // @ts-expect-error this is the case we are testing
-        getHappyKitData({
+        getProviderData({
           envKey: 'flags_pub_development_272357356657967622',
         }),
       ).resolves.toEqual({

--- a/packages/adapter-happykit/src/provider/index.ts
+++ b/packages/adapter-happykit/src/provider/index.ts
@@ -23,7 +23,7 @@ interface ProjectResponseBody {
   }[];
 }
 
-export async function getHappyKitData(options: {
+export async function getProviderData(options: {
   /**
    * The private API Token used to load your feature flags from HappyKit's API.
    */

--- a/packages/adapter-hypertune/package.json
+++ b/packages/adapter-hypertune/package.json
@@ -11,10 +11,6 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
-    },
-    "./provider": {
-      "import": "./dist/provider/index.js",
-      "require": "./dist/provider/index.cjs"
     }
   },
   "main": "./dist/index.js",
@@ -23,10 +19,6 @@
       ".": [
         "dist/*.d.ts",
         "dist/*.d.cts"
-      ],
-      "provider": [
-        "dist/provider/index.d.ts",
-        "dist/provider/index.d.cts"
       ]
     }
   },

--- a/packages/adapter-hypertune/src/index.ts
+++ b/packages/adapter-hypertune/src/index.ts
@@ -1,0 +1,1 @@
+export { getProviderData } from './provider';

--- a/packages/adapter-hypertune/src/provider/index.test.ts
+++ b/packages/adapter-hypertune/src/provider/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, describe } from 'vitest';
-import { getHypertuneData } from '.';
+import { getProviderData } from '..';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import { HttpResponse, http } from 'msw';
@@ -33,32 +33,32 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterAll(() => server.close());
 afterEach(() => server.resetHandlers());
 
-describe('getHypertuneData', () => {
+describe('getProviderData', () => {
   describe('when called with valid params', () => {
     it('should fetch and return', async () => {
-      await expect(
-        getHypertuneData({ token: hypertuneToken }),
-      ).resolves.toEqual({
-        hints: [],
-        definitions: {
-          'some-test-flag': {
-            description: 'some-test-description',
-            options: [
-              { label: 'Off', value: false },
-              { label: 'On', value: true },
-            ],
-            origin:
-              'https://app.hypertune.com/projects/2645/draft?view=logic&selected_field_path=root%3EexampleFlag',
+      await expect(getProviderData({ token: hypertuneToken })).resolves.toEqual(
+        {
+          hints: [],
+          definitions: {
+            'some-test-flag': {
+              description: 'some-test-description',
+              options: [
+                { label: 'Off', value: false },
+                { label: 'On', value: true },
+              ],
+              origin:
+                'https://app.hypertune.com/projects/2645/draft?view=logic&selected_field_path=root%3EexampleFlag',
+            },
           },
         },
-      });
+      );
     });
   });
 
   describe('when called with invalid params', () => {
     it('should return appropriate hints', async () => {
       // @ts-expect-error this is the case we are testing
-      await expect(getHypertuneData({})).resolves.toEqual({
+      await expect(getProviderData({})).resolves.toEqual({
         definitions: {},
         hints: [
           {

--- a/packages/adapter-hypertune/src/provider/index.ts
+++ b/packages/adapter-hypertune/src/provider/index.ts
@@ -1,6 +1,6 @@
 import type { ProviderData } from '@vercel/flags';
 
-export async function getHypertuneData(options: {
+export async function getProviderData(options: {
   token: string;
 }): Promise<ProviderData> {
   if (!options.token) {

--- a/packages/adapter-launchdarkly/package.json
+++ b/packages/adapter-launchdarkly/package.json
@@ -11,10 +11,6 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
-    },
-    "./provider": {
-      "import": "./dist/provider/index.js",
-      "require": "./dist/provider/index.cjs"
     }
   },
   "main": "./dist/index.js",
@@ -23,10 +19,6 @@
       ".": [
         "dist/*.d.ts",
         "dist/*.d.cts"
-      ],
-      "provider": [
-        "dist/provider/index.d.ts",
-        "dist/provider/index.d.cts"
       ]
     }
   },

--- a/packages/adapter-launchdarkly/src/index.ts
+++ b/packages/adapter-launchdarkly/src/index.ts
@@ -1,0 +1,1 @@
+export { getProviderData } from './provider';

--- a/packages/adapter-launchdarkly/src/provider/index.test.ts
+++ b/packages/adapter-launchdarkly/src/provider/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, describe, vi } from 'vitest';
-import { getLaunchDarklyData } from '.';
+import { getProviderData } from '..';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import { HttpResponse, http } from 'msw';
@@ -55,13 +55,13 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterAll(() => server.close());
 afterEach(() => server.resetHandlers());
 
-describe('getLaunchDarklyData', () => {
+describe('getProviderData', () => {
   describe('when called with valid params', () => {
     it('should fetch and return', async () => {
       const fetchSpy = vi.spyOn(global, 'fetch');
 
       await expect(
-        getLaunchDarklyData({
+        getProviderData({
           apiKey: 'some-api-key',
           environment: 'some-environment',
           projectKey: 'some-project-key',
@@ -110,7 +110,7 @@ describe('getLaunchDarklyData', () => {
   describe('when called with invalid params', () => {
     it('should return appropriate hints', async () => {
       // @ts-expect-error this is the case we are testing
-      await expect(getLaunchDarklyData({})).resolves.toEqual({
+      await expect(getProviderData({})).resolves.toEqual({
         definitions: {},
         hints: [
           {
@@ -130,7 +130,7 @@ describe('getLaunchDarklyData', () => {
 
       await expect(
         // @ts-expect-error this is the case we are testing
-        getLaunchDarklyData({ apiKey: 'some-api-key' }),
+        getProviderData({ apiKey: 'some-api-key' }),
       ).resolves.toEqual({
         definitions: {},
         hints: [
@@ -147,7 +147,7 @@ describe('getLaunchDarklyData', () => {
 
       await expect(
         // @ts-expect-error this is the case we are testing
-        getLaunchDarklyData({
+        getProviderData({
           apiKey: 'some-api-key',
           environment: 'production',
         }),
@@ -172,7 +172,7 @@ describe('getLaunchDarklyData', () => {
         },
       } as Response);
       await expect(
-        getLaunchDarklyData({
+        getProviderData({
           apiKey: 'some-api-key',
           environment: 'some-environment',
           projectKey: 'some-project-key',
@@ -198,7 +198,7 @@ describe('getLaunchDarklyData', () => {
       } as Response);
 
       await expect(
-        getLaunchDarklyData({
+        getProviderData({
           apiKey: 'some-api-key',
           environment: 'some-environment',
           projectKey: 'some-project-key',

--- a/packages/adapter-launchdarkly/src/provider/index.ts
+++ b/packages/adapter-launchdarkly/src/provider/index.ts
@@ -18,7 +18,7 @@ interface LaunchDarklyApiData {
   totalCount: number;
 }
 
-export async function getLaunchDarklyData(options: {
+export async function getProviderData(options: {
   apiKey: string;
   environment: string;
   projectKey: string;

--- a/packages/adapter-optimizely/package.json
+++ b/packages/adapter-optimizely/package.json
@@ -11,10 +11,6 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
-    },
-    "./provider": {
-      "import": "./dist/provider/index.js",
-      "require": "./dist/provider/index.cjs"
     }
   },
   "main": "./dist/index.js",
@@ -23,10 +19,6 @@
       ".": [
         "dist/*.d.ts",
         "dist/*.d.cts"
-      ],
-      "provider": [
-        "dist/provider/index.d.ts",
-        "dist/provider/index.d.cts"
       ]
     }
   },

--- a/packages/adapter-optimizely/src/index.ts
+++ b/packages/adapter-optimizely/src/index.ts
@@ -1,0 +1,1 @@
+export { getProviderData } from './provider';

--- a/packages/adapter-optimizely/src/provider/index.test.ts
+++ b/packages/adapter-optimizely/src/provider/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, describe } from 'vitest';
-import { getOptimizelyData } from '.';
+import { getProviderData } from '..';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import { HttpResponse, http } from 'msw';
@@ -516,11 +516,11 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterAll(() => server.close());
 afterEach(() => server.resetHandlers());
 
-describe('getOptimizelyData', () => {
+describe('getProviderData', () => {
   describe('when called with valid params', () => {
     it('should fetch and return', async () => {
       await expect(
-        getOptimizelyData({
+        getProviderData({
           apiKey: 'test-api-key',
           projectId: '1000000',
         }),
@@ -671,7 +671,7 @@ describe('getOptimizelyData', () => {
   describe('when called with invalid params', () => {
     it('should return appropriate hints', async () => {
       // @ts-expect-error this is the case we are testing
-      await expect(getOptimizelyData({})).resolves.toEqual({
+      await expect(getProviderData({})).resolves.toEqual({
         definitions: {},
         hints: [
           {

--- a/packages/adapter-optimizely/src/provider/index.ts
+++ b/packages/adapter-optimizely/src/provider/index.ts
@@ -40,7 +40,7 @@ interface OptimizelyVariationsResponseBody {
   next_url?: [string];
 }
 
-export async function getOptimizelyData(options: {
+export async function getProviderData(options: {
   projectId: string;
   apiKey: string;
 }): Promise<ProviderData> {

--- a/packages/adapter-split/package.json
+++ b/packages/adapter-split/package.json
@@ -11,10 +11,6 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
-    },
-    "./provider": {
-      "import": "./dist/provider/index.js",
-      "require": "./dist/provider/index.cjs"
     }
   },
   "main": "./dist/index.js",
@@ -23,10 +19,6 @@
       ".": [
         "dist/*.d.ts",
         "dist/*.d.cts"
-      ],
-      "provider": [
-        "dist/provider/index.d.ts",
-        "dist/provider/index.d.cts"
       ]
     }
   },

--- a/packages/adapter-split/src/index.ts
+++ b/packages/adapter-split/src/index.ts
@@ -1,0 +1,1 @@
+export { getProviderData } from './provider';

--- a/packages/adapter-split/src/provider/index.test.ts
+++ b/packages/adapter-split/src/provider/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, describe } from 'vitest';
-import { getSplitData } from '.';
+import { getProviderData } from '.';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import { HttpResponse, http } from 'msw';
@@ -64,11 +64,11 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterAll(() => server.close());
 afterEach(() => server.resetHandlers());
 
-describe('getSplitData', () => {
+describe('getProviderData', () => {
   describe('when called with valid params', () => {
     it('should fetch and return', async () => {
       await expect(
-        getSplitData({
+        getProviderData({
           adminApiKey: 'this-is-my-api-key',
           organizationId: 'af791880-d541-11ee-8a6b-2a4bfd0c2d76',
           environmentId: 'cda1af20-d541-11fe-8c6b-2a4bfd0c2d76',
@@ -101,7 +101,7 @@ describe('getSplitData', () => {
   describe('when called with invalid params', () => {
     it('should return appropriate hints', async () => {
       // @ts-expect-error this is the case we are testing
-      await expect(getSplitData({})).resolves.toEqual({
+      await expect(getProviderData({})).resolves.toEqual({
         definitions: {},
         hints: [
           {
@@ -125,7 +125,7 @@ describe('getSplitData', () => {
 
       await expect(
         // @ts-expect-error this is the case we are testing
-        getSplitData({ adminApiKey: 'some-api-key' }),
+        getProviderData({ adminApiKey: 'some-api-key' }),
       ).resolves.toEqual({
         definitions: {},
         hints: [
@@ -146,7 +146,7 @@ describe('getSplitData', () => {
 
       await expect(
         // @ts-expect-error this is the case we are testing
-        getSplitData({
+        getProviderData({
           adminApiKey: 'this-is-my-api-key',
           organizationId: 'af791880-d541-11ee-8a6b-2a4bfd0c2d76',
           environmentId: 'cda1af20-d541-11fe-8c6b-2a4bfd0c2d76',

--- a/packages/adapter-split/src/provider/index.ts
+++ b/packages/adapter-split/src/provider/index.ts
@@ -17,7 +17,7 @@ interface ListFeatureFlagsResponseBody {
   totalCount: number;
 }
 
-export async function getSplitData(options: {
+export async function getProviderData(options: {
   adminApiKey: string;
   workspaceId: string;
   organizationId: string;

--- a/packages/adapter-statsig/package.json
+++ b/packages/adapter-statsig/package.json
@@ -11,10 +11,6 @@
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
-    },
-    "./provider": {
-      "import": "./dist/provider/index.js",
-      "require": "./dist/provider/index.cjs"
     }
   },
   "main": "./dist/index.js",
@@ -23,10 +19,6 @@
       ".": [
         "dist/*.d.ts",
         "dist/*.d.cts"
-      ],
-      "provider": [
-        "dist/provider/index.d.ts",
-        "dist/provider/index.d.cts"
       ]
     }
   },

--- a/packages/adapter-statsig/src/index.ts
+++ b/packages/adapter-statsig/src/index.ts
@@ -1,3 +1,5 @@
+export { getProviderData } from './provider';
+
 // import { Adapter } from '@vercel/flags';
 // import { flag } from '@vercel/flags/next';
 

--- a/packages/adapter-statsig/src/provider/index.test.ts
+++ b/packages/adapter-statsig/src/provider/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, describe } from 'vitest';
-import { getStatsigData } from '.';
+import { getProviderData } from '..';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 import { HttpResponse, http } from 'msw';
@@ -195,11 +195,11 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterAll(() => server.close());
 afterEach(() => server.resetHandlers());
 
-describe('getStatsigData', () => {
+describe('getProviderData', () => {
   describe('when called with valid params', () => {
     it('should fetch and return', async () => {
       await expect(
-        getStatsigData({
+        getProviderData({
           consoleApiKey: 'console-this-is-a-test-token',
           projectId: 'project-id-placeholder',
         }),
@@ -301,7 +301,7 @@ describe('getStatsigData', () => {
   describe('when called with invalid params', () => {
     it('should return appropriate hints', async () => {
       await expect(
-        getStatsigData({
+        getProviderData({
           consoleApiKey: '',
         }),
       ).resolves.toEqual({

--- a/packages/adapter-statsig/src/provider/index.ts
+++ b/packages/adapter-statsig/src/provider/index.ts
@@ -43,7 +43,7 @@ interface StatsigExperimentsResponse {
   };
 }
 
-export async function getStatsigData(options: {
+export async function getProviderData(options: {
   consoleApiKey: string;
   /**
    * Required to set the `origin` property on the flag definitions.


### PR DESCRIPTION
Previously every adapter package was split into
- `@flags-sdk/statsig`
- `@flags-sdk/statsig/provider` which exported `getStatsigProvider`

Now there is a single export, and the function is consistently named `getProviderData` for all providers
- `@flags-sdk/statsig` exports `getProviderData`

The idea here is to reduce the number of concepts, or at least the number of submodules.