### PR TITLE
add tests for inferred options

### DIFF
--- a/packages/flags/src/next/index.test.ts
+++ b/packages/flags/src/next/index.test.ts
@@ -147,6 +147,16 @@ describe('flag on app router', () => {
     expect(decide).toHaveBeenCalledTimes(1);
   });
 
+  it('uses precomputed values even when options are inferred', async () => {
+    const decide = vi.fn(() => true);
+    const f = flag({ key: 'first-flag', decide });
+    const flagGroup = [f];
+    const code = await precompute(flagGroup);
+    expect(decide).toHaveBeenCalledTimes(1);
+    await expect(f(code, flagGroup)).resolves.toEqual(true);
+    expect(decide).toHaveBeenCalledTimes(1);
+  });
+
   it('falls back to the defaultValue if an async decide throws', async () => {
     let rejectPromise: () => void;
     const promise = new Promise<boolean>((resolve, reject) => {


### PR DESCRIPTION
Adds a few more tests to ensure inferred options can be used when deserializing precomputed values

Relates to #40 