### PR TITLE
throw on undefined unless defaultValue is defined

### DIFF
--- a/.changeset/few-wombats-reply.md
+++ b/.changeset/few-wombats-reply.md
@@ -4,5 +4,6 @@
 
 - fix: Fall back to `defaultValue` when a feature flag returns `undefined`
 - fix: Throw error when a flag resolves to `undefined` and no `defaultValue` is present
+- fix: Export `Identify` and `Decide` types
 
 The value `undefined` can not be serialized so feature flags should never resolve to `undefined`. Use `null` instead.

--- a/.changeset/few-wombats-reply.md
+++ b/.changeset/few-wombats-reply.md
@@ -1,0 +1,8 @@
+---
+'@vercel/flags': patch
+---
+
+- fix: Fall back to `defaultValue` when a feature flag returns `undefined`
+- fix: Throw error when a flag resolves to `undefined` and no `defaultValue` is present
+
+The value `undefined` can not be serialized so feature flags should never resolve to `undefined`. Use `null` instead.

--- a/examples/snippets/app/concepts/precompute/automatic/[code]/flags.tsx
+++ b/examples/snippets/app/concepts/precompute/automatic/[code]/flags.tsx
@@ -1,11 +1,11 @@
 import { flag } from '@vercel/flags/next';
 
-export const firstPrecomputedFlag = flag({
+export const firstPrecomputedFlag = flag<boolean>({
   key: 'first-precomputed-flag',
   decide: () => Math.random() > 0.5,
 });
 
-export const secondPrecomputedFlag = flag({
+export const secondPrecomputedFlag = flag<boolean>({
   key: 'second-precomputed-flag',
   decide: () => Date.now() % 2 === 0,
 });

--- a/examples/snippets/app/examples/feature-flags-in-edge-middleware/flags.ts
+++ b/examples/snippets/app/examples/feature-flags-in-edge-middleware/flags.ts
@@ -1,6 +1,6 @@
 import { flag } from '@vercel/flags/next';
 
-export const basicEdgeMiddlewareFlag = flag({
+export const basicEdgeMiddlewareFlag = flag<boolean>({
   key: 'basic-edge-middleware-flag',
   decide({ cookies }) {
     return cookies.get('basic-edge-middleware-flag')?.value === '1';

--- a/examples/snippets/app/getting-started/overview/page.tsx
+++ b/examples/snippets/app/getting-started/overview/page.tsx
@@ -3,7 +3,7 @@ import { DemoFlag } from '@/components/demo-flag';
 import { ReloadButton } from './reload-button';
 
 // declare a feature flag
-const randomFlag = flag({
+const randomFlag = flag<boolean>({
   key: 'random-flag',
   decide() {
     // this flag will be on for 50% of visitors

--- a/examples/snippets/flags.ts
+++ b/examples/snippets/flags.ts
@@ -1,6 +1,6 @@
 import { flag } from '@vercel/flags/next';
 
-export const exampleFlag = flag({
+export const exampleFlag = flag<boolean>({
   key: 'example-flag',
   decide() {
     return true;

--- a/examples/snippets/lib/pages-router-precomputed/flags.ts
+++ b/examples/snippets/lib/pages-router-precomputed/flags.ts
@@ -1,6 +1,6 @@
 import { flag } from '@vercel/flags/next';
 
-export const exampleFlag = flag({
+export const exampleFlag = flag<boolean>({
   key: 'pages-router-precomputed-example-flag',
   decide() {
     return true;

--- a/examples/summer-sale/flags.ts
+++ b/examples/summer-sale/flags.ts
@@ -37,10 +37,11 @@ export const showFreeDeliveryBannerFlag = flag<boolean>({
   ],
 });
 
-export const countryFlag = flag<boolean>({
+export const countryFlag = flag<string>({
   key: 'country',
+  defaultValue: 'no accept-lanugage header',
   async decide({ headers }) {
-    return headers.get('accept-language') || 'no accept-lanugage header';
+    return headers.get('accept-language') ?? this.defaultValue!;
   },
 });
 

--- a/examples/summer-sale/flags.ts
+++ b/examples/summer-sale/flags.ts
@@ -37,7 +37,7 @@ export const showFreeDeliveryBannerFlag = flag<boolean>({
   ],
 });
 
-export const countryFlag = flag({
+export const countryFlag = flag<boolean>({
   key: 'country',
   async decide({ headers }) {
     return headers.get('accept-language') || 'no accept-lanugage header';

--- a/packages/flags/README.md
+++ b/packages/flags/README.md
@@ -40,7 +40,7 @@ Create a file called flags.ts in your project and declare your first feature fla
 // app/flags.tsx
 import { flag } from '@vercel/flags/next';
 
-export const exampleFlag = flag({
+export const exampleFlag = flag<boolean>({
   key: 'example-flag',
   decide() {
     return true;

--- a/packages/flags/src/index.ts
+++ b/packages/flags/src/index.ts
@@ -12,6 +12,8 @@ export type {
   FlagOverridesType,
   FlagDeclaration,
   GenerousOption,
+  Identify,
+  Decide,
 } from './types';
 export { safeJsonStringify } from './lib/safe-json-stringify';
 export { encrypt, decrypt } from './lib/crypto';

--- a/packages/flags/src/next/index.test.ts
+++ b/packages/flags/src/next/index.test.ts
@@ -3,7 +3,7 @@ import { flag, precompute } from '.';
 import { IncomingMessage } from 'node:http';
 import { NextApiRequestCookies } from 'next/dist/server/api-utils';
 import { Readable } from 'node:stream';
-import { encrypt } from '..';
+import { type Adapter, encrypt } from '..';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -50,7 +50,7 @@ describe('flag on app router', () => {
   it('allows declaring a flag', async () => {
     mocks.headers.mockReturnValueOnce(new Headers());
 
-    const f = await flag({
+    const f = flag({
       key: 'first-flag',
       decide: () => false,
     });
@@ -62,7 +62,7 @@ describe('flag on app router', () => {
   it('caches for the duration of a request', async () => {
     let i = 0;
     const decide = vi.fn(() => i++);
-    const f = await flag({ key: 'first-flag', decide });
+    const f = flag({ key: 'first-flag', decide });
 
     // first request using the flag twice
     const headersOfFirstRequest = new Headers();
@@ -94,7 +94,7 @@ describe('flag on app router', () => {
 
     const mockDecide = vi.fn(() => promise);
 
-    const f = await flag({
+    const f = flag({
       key: 'first-flag',
       decide: mockDecide,
     });
@@ -119,7 +119,7 @@ describe('flag on app router', () => {
 
   it('respects overrides', async () => {
     const decide = vi.fn(() => false);
-    const f = await flag({ key: 'first-flag', decide });
+    const f = flag({ key: 'first-flag', decide });
 
     // first request using the flag twice
     const headersOfFirstRequest = new Headers();
@@ -166,7 +166,7 @@ describe('flag on app router', () => {
     const mockDecide = vi.fn(() => promise);
     const catchFn = vi.fn();
 
-    const f = await flag({
+    const f = flag({
       key: 'first-flag',
       decide: mockDecide,
       defaultValue: false,
@@ -185,6 +185,48 @@ describe('flag on app router', () => {
     expect(catchFn).not.toHaveBeenCalled();
     expect(mockDecide).toHaveBeenCalledTimes(1);
   });
+
+  it('falls back to the defaultValue when a decide function returns undefined', async () => {
+    const syncFlag = flag({
+      key: 'sync-flag',
+      // @ts-expect-error this is the case we are testing
+      decide: () => undefined,
+      defaultValue: true,
+    });
+
+    await expect(syncFlag()).resolves.toEqual(true);
+
+    const asyncFlag = flag({
+      key: 'async-flag',
+      // @ts-expect-error this is the case we are testing
+      decide: async () => undefined,
+      defaultValue: true,
+    });
+
+    await expect(asyncFlag()).resolves.toEqual(true);
+  });
+
+  it('throws an error when the decide function returns undefined and no defaultValue is provided (sync)', async () => {
+    const syncFlag = flag({
+      key: 'sync-flag',
+      // @ts-expect-error this is the case we are testing
+      decide: () => undefined,
+    });
+
+    await expect(syncFlag()).rejects.toThrow(
+      '@vercel/flags: Flag "sync-flag" must have a defaultValue or a decide function that returns a value',
+    );
+
+    const asyncFlag = flag<string>({
+      key: 'async-flag',
+      // @ts-expect-error this is the case we are testing
+      decide: async () => undefined,
+    });
+
+    await expect(asyncFlag()).rejects.toThrow(
+      '@vercel/flags: Flag "async-flag" must have a defaultValue or a decide function that returns a value',
+    );
+  });
 });
 
 describe('flag on pages router', () => {
@@ -196,7 +238,7 @@ describe('flag on pages router', () => {
   it('allows declaring a flag', async () => {
     mocks.headers.mockReturnValueOnce(new Headers());
 
-    const f = await flag({
+    const f = flag({
       key: 'first-flag',
       decide: () => false,
     });
@@ -214,7 +256,7 @@ describe('flag on pages router', () => {
   it('caches for the duration of a request', async () => {
     let i = 0;
     const decide = vi.fn(() => i++);
-    const f = await flag({ key: 'first-flag', decide });
+    const f = flag({ key: 'first-flag', decide });
 
     const [firstRequest, socket1] = createRequest();
     const [secondRequest, socket2] = createRequest();
@@ -246,7 +288,7 @@ describe('flag on pages router', () => {
 
     const mockDecide = vi.fn(() => promise);
 
-    const f = await flag({
+    const f = flag({
       key: 'first-flag',
       decide: mockDecide,
     });
@@ -272,18 +314,69 @@ describe('flag on pages router', () => {
     const mockDecide = vi.fn(() => {
       throw new Error('custom error');
     });
-    const f = await flag({
+    const f = flag({
       key: 'first-flag',
       decide: mockDecide,
     });
+
+    const [firstRequest, socket1] = createRequest();
     expect(mockDecide).toHaveBeenCalledTimes(0);
-    await expect(() => f()).rejects.toThrow('custom error');
+    await expect(() => f(firstRequest)).rejects.toThrow('custom error');
     expect(mockDecide).toHaveBeenCalledTimes(1);
+    socket1.destroy();
+  });
+
+  it('falls back to the defaultValue when a decide function returns undefined', async () => {
+    const [firstRequest, socket1] = createRequest();
+    const syncFlag = flag({
+      key: 'sync-flag',
+      // @ts-expect-error this is the case we are testing
+      decide: () => undefined,
+      defaultValue: true,
+    });
+
+    await expect(syncFlag(firstRequest)).resolves.toEqual(true);
+
+    const asyncFlag = flag({
+      key: 'async-flag',
+      // @ts-expect-error this is the case we are testing
+      decide: async () => undefined,
+      defaultValue: true,
+    });
+
+    await expect(asyncFlag(firstRequest)).resolves.toEqual(true);
+
+    socket1.destroy();
+  });
+
+  it('throws an error when the decide function returns undefined and no defaultValue is provided (sync)', async () => {
+    const [firstRequest, socket1] = createRequest();
+    const syncFlag = flag({
+      key: 'sync-flag',
+      // @ts-expect-error this is the case we are testing
+      decide: () => undefined,
+    });
+
+    await expect(syncFlag(firstRequest)).rejects.toThrow(
+      '@vercel/flags: Flag "sync-flag" must have a defaultValue or a decide function that returns a value',
+    );
+
+    const asyncFlag = flag<string>({
+      key: 'async-flag',
+      // @ts-expect-error this is the case we are testing
+      decide: async () => undefined,
+    });
+
+    await expect(asyncFlag(firstRequest)).rejects.toThrow(
+      '@vercel/flags: Flag "async-flag" must have a defaultValue or a decide function that returns a value',
+    );
+
+    socket1.destroy();
   });
 
   it('respects overrides', async () => {
     const decide = vi.fn(() => false);
-    const f = await flag({ key: 'first-flag', decide });
+    const f = flag({ key: 'first-flag', decide });
     const override = await encrypt({ 'first-flag': true });
 
     const [firstRequest, socket1] = createRequest({
@@ -313,7 +406,7 @@ describe('flag on pages router', () => {
     const mockDecide = vi.fn(() => promise);
     const catchFn = vi.fn();
 
-    const f = await flag({
+    const f = flag({
       key: 'first-flag',
       decide: mockDecide,
       defaultValue: false,
@@ -341,7 +434,7 @@ describe('dynamic io', () => {
       (error as any).digest = 'DYNAMIC_SERVER_USAGE;dynamic usage error';
       throw error;
     });
-    const f = await flag({
+    const f = flag({
       key: 'first-flag',
       decide: mockDecide,
       defaultValue: false,
@@ -349,5 +442,50 @@ describe('dynamic io', () => {
     expect(mockDecide).toHaveBeenCalledTimes(0);
     await expect(() => f()).rejects.toThrow('dynamic usage error');
     expect(mockDecide).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('adapters', () => {
+  function createTestAdapter() {
+    return function testAdapter<ValueType, EntitiesType>(
+      value: ValueType,
+    ): Adapter<ValueType, EntitiesType> {
+      return {
+        decide: () => value,
+        origin: (key) => `fake-origin#${key}`,
+      };
+    };
+  }
+
+  it("should use the adapter's decide function when provided", async () => {
+    const testAdapter = createTestAdapter();
+
+    mocks.headers.mockReturnValueOnce(new Headers());
+
+    const f = flag({
+      key: 'adapter-flag',
+      adapter: testAdapter(5),
+    });
+
+    expect(f).toHaveProperty('key', 'adapter-flag');
+    await expect(f()).resolves.toEqual(5);
+    expect(f).toHaveProperty('origin', 'fake-origin#adapter-flag');
+  });
+
+  it("should throw when an adapter's decide function returns undefined", async () => {
+    const testAdapter = createTestAdapter();
+
+    mocks.headers.mockReturnValueOnce(new Headers());
+
+    const f = flag({
+      key: 'adapter-flag',
+      adapter: testAdapter(undefined),
+    });
+
+    expect(f).toHaveProperty('key', 'adapter-flag');
+    await expect(f()).rejects.toThrow(
+      '@vercel/flags: Flag "adapter-flag" must have a defaultValue or a decide function that returns a value',
+    );
+    expect(f).toHaveProperty('origin', 'fake-origin#adapter-flag');
   });
 });

--- a/packages/flags/src/next/index.test.ts
+++ b/packages/flags/src/next/index.test.ts
@@ -50,7 +50,7 @@ describe('flag on app router', () => {
   it('allows declaring a flag', async () => {
     mocks.headers.mockReturnValueOnce(new Headers());
 
-    const f = flag({
+    const f = flag<boolean>({
       key: 'first-flag',
       decide: () => false,
     });
@@ -62,7 +62,7 @@ describe('flag on app router', () => {
   it('caches for the duration of a request', async () => {
     let i = 0;
     const decide = vi.fn(() => i++);
-    const f = flag({ key: 'first-flag', decide });
+    const f = flag<number>({ key: 'first-flag', decide });
 
     // first request using the flag twice
     const headersOfFirstRequest = new Headers();
@@ -94,7 +94,7 @@ describe('flag on app router', () => {
 
     const mockDecide = vi.fn(() => promise);
 
-    const f = flag({
+    const f = flag<boolean>({
       key: 'first-flag',
       decide: mockDecide,
     });
@@ -119,7 +119,7 @@ describe('flag on app router', () => {
 
   it('respects overrides', async () => {
     const decide = vi.fn(() => false);
-    const f = flag({ key: 'first-flag', decide });
+    const f = flag<boolean>({ key: 'first-flag', decide });
 
     // first request using the flag twice
     const headersOfFirstRequest = new Headers();
@@ -139,7 +139,11 @@ describe('flag on app router', () => {
 
   it('uses precomputed values', async () => {
     const decide = vi.fn(() => true);
-    const f = flag({ key: 'first-flag', decide, options: [false, true] });
+    const f = flag<boolean>({
+      key: 'first-flag',
+      decide,
+      options: [false, true],
+    });
     const flagGroup = [f];
     const code = await precompute(flagGroup);
     expect(decide).toHaveBeenCalledTimes(1);
@@ -149,7 +153,7 @@ describe('flag on app router', () => {
 
   it('uses precomputed values even when options are inferred', async () => {
     const decide = vi.fn(() => true);
-    const f = flag({ key: 'first-flag', decide });
+    const f = flag<boolean>({ key: 'first-flag', decide });
     const flagGroup = [f];
     const code = await precompute(flagGroup);
     expect(decide).toHaveBeenCalledTimes(1);
@@ -166,7 +170,7 @@ describe('flag on app router', () => {
     const mockDecide = vi.fn(() => promise);
     const catchFn = vi.fn();
 
-    const f = flag({
+    const f = flag<boolean>({
       key: 'first-flag',
       decide: mockDecide,
       defaultValue: false,
@@ -187,16 +191,18 @@ describe('flag on app router', () => {
   });
 
   it('falls back to the defaultValue when a decide function returns undefined', async () => {
-    const syncFlag = flag({
+    const syncFlag = flag<boolean>({
       key: 'sync-flag',
+      // @ts-expect-error this is the case we are testing
       decide: () => undefined,
       defaultValue: true,
     });
 
     await expect(syncFlag()).resolves.toEqual(true);
 
-    const asyncFlag = flag({
+    const asyncFlag = flag<boolean>({
       key: 'async-flag',
+      // @ts-expect-error this is the case we are testing
       decide: async () => undefined,
       defaultValue: true,
     });
@@ -205,8 +211,9 @@ describe('flag on app router', () => {
   });
 
   it('throws an error when the decide function returns undefined and no defaultValue is provided', async () => {
-    const syncFlag = flag({
+    const syncFlag = flag<boolean>({
       key: 'sync-flag',
+      // @ts-expect-error this is the case we are testing
       decide: () => undefined,
     });
 
@@ -235,7 +242,7 @@ describe('flag on pages router', () => {
   it('allows declaring a flag', async () => {
     mocks.headers.mockReturnValueOnce(new Headers());
 
-    const f = flag({
+    const f = flag<boolean>({
       key: 'first-flag',
       decide: () => false,
     });
@@ -253,7 +260,7 @@ describe('flag on pages router', () => {
   it('caches for the duration of a request', async () => {
     let i = 0;
     const decide = vi.fn(() => i++);
-    const f = flag({ key: 'first-flag', decide });
+    const f = flag<number>({ key: 'first-flag', decide });
 
     const [firstRequest, socket1] = createRequest();
     const [secondRequest, socket2] = createRequest();
@@ -285,7 +292,7 @@ describe('flag on pages router', () => {
 
     const mockDecide = vi.fn(() => promise);
 
-    const f = flag({
+    const f = flag<boolean>({
       key: 'first-flag',
       decide: mockDecide,
     });
@@ -311,7 +318,7 @@ describe('flag on pages router', () => {
     const mockDecide = vi.fn(() => {
       throw new Error('custom error');
     });
-    const f = flag({
+    const f = flag<boolean>({
       key: 'first-flag',
       decide: mockDecide,
     });
@@ -325,16 +332,18 @@ describe('flag on pages router', () => {
 
   it('falls back to the defaultValue when a decide function returns undefined', async () => {
     const [firstRequest, socket1] = createRequest();
-    const syncFlag = flag({
+    const syncFlag = flag<boolean>({
       key: 'sync-flag',
+      // @ts-expect-error this is the case we are testing
       decide: () => undefined,
       defaultValue: true,
     });
 
     await expect(syncFlag(firstRequest)).resolves.toEqual(true);
 
-    const asyncFlag = flag({
+    const asyncFlag = flag<boolean>({
       key: 'async-flag',
+      // @ts-expect-error this is the case we are testing
       decide: async () => undefined,
       defaultValue: true,
     });
@@ -346,8 +355,9 @@ describe('flag on pages router', () => {
 
   it('throws an error when the decide function returns undefined and no defaultValue is provided', async () => {
     const [firstRequest, socket1] = createRequest();
-    const syncFlag = flag({
+    const syncFlag = flag<boolean>({
       key: 'sync-flag',
+      // @ts-expect-error this is the case we are testing
       decide: () => undefined,
     });
 
@@ -370,7 +380,7 @@ describe('flag on pages router', () => {
 
   it('respects overrides', async () => {
     const decide = vi.fn(() => false);
-    const f = flag({ key: 'first-flag', decide });
+    const f = flag<boolean>({ key: 'first-flag', decide });
     const override = await encrypt({ 'first-flag': true });
 
     const [firstRequest, socket1] = createRequest({
@@ -383,7 +393,11 @@ describe('flag on pages router', () => {
 
   it('uses precomputed values', async () => {
     const decide = vi.fn(() => true);
-    const f = flag({ key: 'first-flag', decide, options: [false, true] });
+    const f = flag<boolean>({
+      key: 'first-flag',
+      decide,
+      options: [false, true],
+    });
     const flagGroup = [f];
     const code = await precompute(flagGroup);
     expect(decide).toHaveBeenCalledTimes(1);
@@ -400,7 +414,7 @@ describe('flag on pages router', () => {
     const mockDecide = vi.fn(() => promise);
     const catchFn = vi.fn();
 
-    const f = flag({
+    const f = flag<boolean>({
       key: 'first-flag',
       decide: mockDecide,
       defaultValue: false,
@@ -428,7 +442,7 @@ describe('dynamic io', () => {
       (error as any).digest = 'DYNAMIC_SERVER_USAGE;dynamic usage error';
       throw error;
     });
-    const f = flag({
+    const f = flag<boolean>({
       key: 'first-flag',
       decide: mockDecide,
       defaultValue: false,
@@ -456,7 +470,7 @@ describe('adapters', () => {
 
     mocks.headers.mockReturnValueOnce(new Headers());
 
-    const f = flag({
+    const f = flag<number>({
       key: 'adapter-flag',
       adapter: testAdapter(5),
     });
@@ -471,8 +485,9 @@ describe('adapters', () => {
 
     mocks.headers.mockReturnValueOnce(new Headers());
 
-    const f = flag({
+    const f = flag<boolean>({
       key: 'adapter-flag',
+      // @ts-expect-error this is the case we are testing
       adapter: testAdapter(undefined),
     });
 

--- a/packages/flags/src/next/index.test.ts
+++ b/packages/flags/src/next/index.test.ts
@@ -206,7 +206,7 @@ describe('flag on app router', () => {
     await expect(asyncFlag()).resolves.toEqual(true);
   });
 
-  it('throws an error when the decide function returns undefined and no defaultValue is provided (sync)', async () => {
+  it('throws an error when the decide function returns undefined and no defaultValue is provided', async () => {
     const syncFlag = flag({
       key: 'sync-flag',
       // @ts-expect-error this is the case we are testing
@@ -349,7 +349,7 @@ describe('flag on pages router', () => {
     socket1.destroy();
   });
 
-  it('throws an error when the decide function returns undefined and no defaultValue is provided (sync)', async () => {
+  it('throws an error when the decide function returns undefined and no defaultValue is provided', async () => {
     const [firstRequest, socket1] = createRequest();
     const syncFlag = flag({
       key: 'sync-flag',

--- a/packages/flags/src/next/index.test.ts
+++ b/packages/flags/src/next/index.test.ts
@@ -189,7 +189,6 @@ describe('flag on app router', () => {
   it('falls back to the defaultValue when a decide function returns undefined', async () => {
     const syncFlag = flag({
       key: 'sync-flag',
-      // @ts-expect-error this is the case we are testing
       decide: () => undefined,
       defaultValue: true,
     });
@@ -198,7 +197,6 @@ describe('flag on app router', () => {
 
     const asyncFlag = flag({
       key: 'async-flag',
-      // @ts-expect-error this is the case we are testing
       decide: async () => undefined,
       defaultValue: true,
     });
@@ -209,7 +207,6 @@ describe('flag on app router', () => {
   it('throws an error when the decide function returns undefined and no defaultValue is provided', async () => {
     const syncFlag = flag({
       key: 'sync-flag',
-      // @ts-expect-error this is the case we are testing
       decide: () => undefined,
     });
 
@@ -330,7 +327,6 @@ describe('flag on pages router', () => {
     const [firstRequest, socket1] = createRequest();
     const syncFlag = flag({
       key: 'sync-flag',
-      // @ts-expect-error this is the case we are testing
       decide: () => undefined,
       defaultValue: true,
     });
@@ -339,7 +335,6 @@ describe('flag on pages router', () => {
 
     const asyncFlag = flag({
       key: 'async-flag',
-      // @ts-expect-error this is the case we are testing
       decide: async () => undefined,
       defaultValue: true,
     });
@@ -353,7 +348,6 @@ describe('flag on pages router', () => {
     const [firstRequest, socket1] = createRequest();
     const syncFlag = flag({
       key: 'sync-flag',
-      // @ts-expect-error this is the case we are testing
       decide: () => undefined,
     });
 

--- a/packages/flags/src/next/index.ts
+++ b/packages/flags/src/next/index.ts
@@ -10,6 +10,7 @@ import type {
   FlagDeclaration,
   FlagParamsType,
   Identify,
+  JsonValue,
   Origin,
 } from '../types';
 import type { Flag, PrecomputedFlag, PagesRouterFlag } from './types';
@@ -375,7 +376,10 @@ function getOrigin<ValueType, EntitiesType>(
  * @param definition - Information about the feature flag.
  * @returns - A feature flag declaration
  */
-export function flag<ValueType = boolean | string | number, EntitiesType = any>(
+export function flag<
+  ValueType extends JsonValue = boolean | string | number,
+  EntitiesType = any,
+>(
   definition: FlagDeclaration<ValueType, EntitiesType>,
 ): Flag<ValueType, EntitiesType> {
   const decide = getDecide<ValueType, EntitiesType>(definition);

--- a/packages/flags/src/next/precompute.test.ts
+++ b/packages/flags/src/next/precompute.test.ts
@@ -35,7 +35,7 @@ describe('generatePermutations', () => {
     it('should infer boolean options', async () => {
       process.env.FLAGS_SECRET = crypto.randomBytes(32).toString('base64url');
 
-      const flagA = flag({ key: 'a', decide: () => false });
+      const flagA = flag<boolean>({ key: 'a', decide: () => false });
       await expectPermutations([flagA], [{ a: false }, { a: true }]);
     });
   });
@@ -44,7 +44,11 @@ describe('generatePermutations', () => {
     it('should not infer any options', async () => {
       process.env.FLAGS_SECRET = crypto.randomBytes(32).toString('base64url');
 
-      const flagA = flag({ key: 'a', decide: () => false, options: [] });
+      const flagA = flag<boolean>({
+        key: 'a',
+        decide: () => false,
+        options: [],
+      });
       await expectPermutations([flagA], []);
     });
   });
@@ -89,12 +93,12 @@ describe('generatePermutations', () => {
     it('should generate permutations', async () => {
       process.env.FLAGS_SECRET = crypto.randomBytes(32).toString('base64url');
 
-      const flagA = flag({
+      const flagA = flag<boolean>({
         key: 'a',
         decide: () => false,
       });
 
-      const flagB = flag({
+      const flagB = flag<boolean>({
         key: 'b',
         decide: () => false,
       });
@@ -115,17 +119,17 @@ describe('generatePermutations', () => {
     it('should generate permutations', async () => {
       process.env.FLAGS_SECRET = crypto.randomBytes(32).toString('base64url');
 
-      const flagA = flag({
+      const flagA = flag<boolean>({
         key: 'a',
         decide: () => false,
       });
 
-      const flagB = flag({
+      const flagB = flag<boolean>({
         key: 'b',
         decide: () => false,
       });
 
-      const flagC = flag({
+      const flagC = flag<string>({
         key: 'c',
         decide: () => 'two',
         options: ['one', 'two', 'three'],
@@ -157,17 +161,17 @@ describe('generatePermutations', () => {
     it('should generate permutations', async () => {
       process.env.FLAGS_SECRET = crypto.randomBytes(32).toString('base64url');
 
-      const flagA = flag({
+      const flagA = flag<boolean>({
         key: 'a',
         decide: () => false,
       });
 
-      const flagB = flag({
+      const flagB = flag<boolean>({
         key: 'b',
         decide: () => false,
       });
 
-      const flagC = flag({
+      const flagC = flag<string>({
         key: 'c',
         decide: () => 'two',
         options: ['one', 'two', 'three'],
@@ -189,8 +193,8 @@ describe('getPrecomputed', () => {
   it('should return the precomputed value', async () => {
     process.env.FLAGS_SECRET = crypto.randomBytes(32).toString('base64url');
 
-    const flagA = flag({ key: 'a', decide: () => true });
-    const flagB = flag({ key: 'b', decide: () => false });
+    const flagA = flag<boolean>({ key: 'a', decide: () => true });
+    const flagB = flag<boolean>({ key: 'b', decide: () => false });
 
     const group = [flagA, flagB];
     const code = await serialize(group, [true, false]);

--- a/packages/flags/src/next/precompute.ts
+++ b/packages/flags/src/next/precompute.ts
@@ -94,7 +94,7 @@ export async function deserialize(
  * @param code - The code returned from `serialize`
  * @param secret - The secret to use for verifying the signature
  */
-export async function getPrecomputed<T>(
+export async function getPrecomputed<T extends JsonValue>(
   flag: Flag<T, any>,
   precomputeFlags: FlagsArray,
   code: string,

--- a/packages/flags/src/sveltekit/index.test.ts
+++ b/packages/flags/src/sveltekit/index.test.ts
@@ -9,7 +9,7 @@ describe('getProviderData', () => {
 
 describe('flag', () => {
   it('defines a key', async () => {
-    const f = flag({ key: 'first-flag', decide: () => false });
+    const f = flag<boolean>({ key: 'first-flag', decide: () => false });
     expect(f).toHaveProperty('key', 'first-flag');
   });
 });

--- a/packages/flags/src/types.ts
+++ b/packages/flags/src/types.ts
@@ -127,13 +127,11 @@ export type GenerousOption<T> = boolean extends T
     ? T | FlagOption<T>
     : FlagOption<T>;
 
-type NonUndefined<T> = T extends undefined | Promise<undefined> ? never : T;
-
 export type Decide<ValueType, EntitiesType> = (
   params: FlagParamsType & {
     entities?: EntitiesType;
   },
-) => Promise<NonUndefined<ValueType>> | NonUndefined<ValueType>;
+) => Promise<ValueType> | ValueType;
 
 export type Identify<EntitiesType> = (
   params: FlagParamsType,

--- a/packages/flags/src/types.ts
+++ b/packages/flags/src/types.ts
@@ -127,11 +127,13 @@ export type GenerousOption<T> = boolean extends T
     ? T | FlagOption<T>
     : FlagOption<T>;
 
+type NonUndefined<T> = T extends undefined | Promise<undefined> ? never : T;
+
 export type Decide<ValueType, EntitiesType> = (
   params: FlagParamsType & {
     entities?: EntitiesType;
   },
-) => Promise<ValueType> | ValueType;
+) => Promise<NonUndefined<ValueType>> | NonUndefined<ValueType>;
 
 export type Identify<EntitiesType> = (
   params: FlagParamsType,


### PR DESCRIPTION
Flags may not return an `undefined` value, as `undefined` can not be serialized.

Specifically, the `decide` function may not return undefined unless a `defaultValue` is provided.

When a `decide` function returns `undefined` and no `defaultValue` was provided the flag will throw:

```ts
const syncFlag = flag({
  key: '....',
  decide: () => undefined,
});
```

```
@vercel/flags: Flag "xxx" must have a defaultValue or a decide function that returns a value
```

When a `decide` function returns `undefined` and a `defaultValue` was provided the defaultValue will be used:

```ts
const syncFlag = flag({
  key: '....',
  decide: () => undefined,
  defaultValue: false
});
```

By default the `decide` function's types will not warn when you return undefined as you might have a defaultValue in place. Specify the flag type using `flag<boolean>` etc to ensure your `decide` function may not return `undefined` on a typescript level.

```ts
const syncFlag = flag<boolean>({
  key: '....',
  decide: () => undefined, // a typescript warning will now be shown, as we specified the boolean flag type
});
```