### PR TITLE
fix use node: protocol for async_hooks import

### DIFF
--- a/.changeset/hot-clocks-hunt.md
+++ b/.changeset/hot-clocks-hunt.md
@@ -1,0 +1,5 @@
+---
+'@vercel/flags': patch
+---
+
+fix use node: protocol for async_hooks import

--- a/packages/flags/src/lib/tracing.ts
+++ b/packages/flags/src/lib/tracing.ts
@@ -4,8 +4,9 @@ import type {
   TracerProvider,
   AttributeValue,
 } from '@opentelemetry/api';
+import { AsyncLocalStorage } from 'node:async_hooks';
+
 import { name as pkgName, version } from '../../package.json';
-import { AsyncLocalStorage } from 'async_hooks';
 
 // Use a symbol to avoid having global variable that is scoped to this file,
 // as it can lead to issues with cjs and mjs being used at the same time.


### PR DESCRIPTION
This PR updates the import of the `async_hooks` module to use the `node:` protocol, as recommended by Node.js. This change aligns with best practices and ensures better compatibility and clarity in the codebase.

### Changes
- Updated `import { AsyncLocalStorage } from "async_hooks";` to `import { AsyncLocalStorage } from "node:async_hooks";`.

### References
- [Node.js Documentation: `node:` protocol](https://nodejs.org/api/esm.html#node-imports)
- [Node.js Documentation: `async_hooks` module](https://nodejs.org/api/async_hooks.html)

close #51 