### PR TITLE
add @flags-sdk/edge-config adapter

### DIFF
--- a/.changeset/nasty-bottles-sip.md
+++ b/.changeset/nasty-bottles-sip.md
@@ -1,0 +1,5 @@
+---
+'@flags-sdk/edge-config': minor
+---
+
+initial release

--- a/examples/snippets/app/concepts/adapters/edge-config-adapter.ts
+++ b/examples/snippets/app/concepts/adapters/edge-config-adapter.ts
@@ -2,7 +2,7 @@ import type { Adapter } from '@vercel/flags';
 import { createClient, type EdgeConfigClient } from '@vercel/edge-config';
 
 /**
- * Allows creating a custom Edge Config adapter for feature flags
+ * An Edge Config adapter for the Flags SDK
  */
 export function createEdgeConfigAdapter(
   connectionString: string | EdgeConfigClient,
@@ -38,14 +38,14 @@ export function createEdgeConfigAdapter(
         // if a defaultValue was provided this error will be caught and the defaultValue will be used
         if (!definitions) {
           throw new Error(
-            `Edge Config Adapter: Edge Config item "${edgeConfigItemKey}" not found`,
+            `@flags-sdk/edge-config: Edge Config item "${edgeConfigItemKey}" not found`,
           );
         }
 
         // if a defaultValue was provided this error will be caught and the defaultValue will be used
         if (!(key in definitions)) {
           throw new Error(
-            `Edge Config Adapter: Flag "${key}" not found in Edge Config item "${edgeConfigItemKey}"`,
+            `@flags-sdk/edge-config: Flag "${key}" not found in Edge Config item "${edgeConfigItemKey}"`,
           );
         }
         return definitions[key] as ValueType;

--- a/packages/adapter-edge-config/.eslintrc.cjs
+++ b/packages/adapter-edge-config/.eslintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: [require.resolve('@pyra/eslint-config/components')],
+};

--- a/packages/adapter-edge-config/README.md
+++ b/packages/adapter-edge-config/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```bash
-npm install @flags-sdk/edge-config @vercel/edge-config
+npm install @flags-sdk/edge-config
 ```
 
 ## Usage

--- a/packages/adapter-edge-config/README.md
+++ b/packages/adapter-edge-config/README.md
@@ -1,0 +1,64 @@
+# `@flags-sdk/edge-config`
+
+## Installation
+
+```bash
+npm install @flags-sdk/edge-config @vercel/edge-config
+```
+
+## Usage
+
+## Using the default adapter
+
+This adapter will connect to the Edge Config available under the `EDGE_CONFIG` environment variable, and read items from a key in the Edge Config called `flags`.
+
+```ts
+import { flag } from '@vercel/flags/next';
+import { edgeConfigAdapter } from '@flags-sdk/edge-config';
+
+export const exampleFlag = flag({
+  key: 'example-flag',
+  adapter: edgeConfigAdapter(),
+});
+```
+
+Your Edge Config should look like this:
+
+```json
+{
+  "flags": {
+    "example-flag": true
+  }
+}
+```
+
+## Using a custom adapter
+
+You can specify a custom adapter which connects to a different Edge Config, and reads
+
+```ts
+import { flag } from '@vercel/flags/next';
+import { createEdgeConfigAdapter } from '@flags-sdk/edge-config';
+
+const edgeConfigAdapter = createEdgeConfigAdapter(process.env.EDGE_CONFIG, {
+  teamSlug: 'your-team-slug',
+  edgeConfigItemKey: 'my-flags',
+});
+
+export const exampleFlag = flag({
+  key: 'example-flag',
+  adapter: edgeConfigAdapter(),
+});
+```
+
+Your Edge Config should look like this:
+
+```json
+{
+  "my-flags": {
+    "example-flag": true
+  }
+}
+```
+
+Supplying the custom `teamSlug` allows the adapter to generate an `origin` for your flags, which in turn allows the Flags Explorer to link to your Edge Config. This is optional and does not affect runtime behavior.

--- a/packages/adapter-edge-config/package.json
+++ b/packages/adapter-edge-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flags-sdk/edge-config",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "",
   "keywords": [],
   "license": "MIT",

--- a/packages/adapter-edge-config/package.json
+++ b/packages/adapter-edge-config/package.json
@@ -39,7 +39,6 @@
     "@vercel/edge-config": "1.2.0",
     "@vercel/flags": "workspace:*",
     "eslint-config-custom": "workspace:*",
-    "msw": "2.6.4",
     "rimraf": "6.0.1",
     "tsconfig": "workspace:*",
     "tsup": "8.0.1",

--- a/packages/adapter-edge-config/package.json
+++ b/packages/adapter-edge-config/package.json
@@ -34,6 +34,9 @@
     "test:watch": "vitest",
     "type-check": "tsc --noEmit"
   },
+  "dependencies": {
+    "@vercel/edge-config": "^1.2.0"
+  },
   "devDependencies": {
     "@types/node": "20.11.17",
     "@vercel/edge-config": "1.2.0",
@@ -45,9 +48,6 @@
     "typescript": "5.6.3",
     "vite": "5.1.1",
     "vitest": "1.4.0"
-  },
-  "peerDependencies": {
-    "@vercel/edge-config": "^1.2.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/adapter-edge-config/package.json
+++ b/packages/adapter-edge-config/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@flags-sdk/edge-config",
+  "version": "0.1.0",
+  "description": "",
+  "keywords": [],
+  "license": "MIT",
+  "author": "",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "main": "./dist/index.js",
+  "typesVersions": {
+    "*": {
+      ".": [
+        "dist/*.d.ts",
+        "dist/*.d.cts"
+      ]
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "rimraf dist && tsup",
+    "dev": "tsup --watch --clean=false",
+    "eslint": "eslint-runner",
+    "eslint:fix": "eslint-runner --fix",
+    "test": "vitest --run",
+    "test:watch": "vitest",
+    "type-check": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.17",
+    "@vercel/edge-config": "1.2.0",
+    "@vercel/flags": "workspace:*",
+    "eslint-config-custom": "workspace:*",
+    "msw": "2.6.4",
+    "rimraf": "6.0.1",
+    "tsconfig": "workspace:*",
+    "tsup": "8.0.1",
+    "typescript": "5.6.3",
+    "vite": "5.1.1",
+    "vitest": "1.4.0"
+  },
+  "peerDependencies": {
+    "@vercel/edge-config": "^1.2.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/adapter-edge-config/src/index.test.ts
+++ b/packages/adapter-edge-config/src/index.test.ts
@@ -1,0 +1,35 @@
+import { expect, it, describe, beforeEach, afterEach } from 'vitest';
+import {
+  createHappyKitAdapter,
+  happyKitAdapter,
+  resetDefaultHappyKitAdapter,
+} from '.';
+
+describe('createHappyKitAdapter', () => {
+  it('should work', () => {
+    const adapter = createHappyKitAdapter({
+      endpoint: 'https://example.com',
+      envKey: 'flags_pub_production_0000',
+    });
+
+    expect(adapter).toBeDefined();
+  });
+});
+
+describe('happyKitAdapter', () => {
+  beforeEach(() => {
+    process.env.HAPPYKIT_ENDPOINT = 'https://example.com';
+    process.env.HAPPYKIT_ENV_KEY = 'flags_pub_production_0000';
+  });
+
+  afterEach(() => {
+    resetDefaultHappyKitAdapter();
+    delete process.env.HAPPYKIT_ENDPOINT;
+    delete process.env.HAPPYKIT_ENV_KEY;
+  });
+
+  it('should work', () => {
+    const adapter = happyKitAdapter();
+    expect(adapter).toBeDefined();
+  });
+});

--- a/packages/adapter-edge-config/src/index.test.ts
+++ b/packages/adapter-edge-config/src/index.test.ts
@@ -1,35 +1,59 @@
-import { expect, it, describe, beforeEach, afterEach } from 'vitest';
+import { expect, it, describe, vi, beforeEach } from 'vitest';
 import {
-  createHappyKitAdapter,
-  happyKitAdapter,
-  resetDefaultHappyKitAdapter,
+  createEdgeConfigAdapter,
+  edgeConfigAdapter,
+  resetDefaultEdgeConfigAdapter,
 } from '.';
+import type { EdgeConfigClient } from '@vercel/edge-config';
+import type { ReadonlyRequestCookies } from '@vercel/flags';
 
-describe('createHappyKitAdapter', () => {
-  it('should work', () => {
-    const adapter = createHappyKitAdapter({
-      endpoint: 'https://example.com',
-      envKey: 'flags_pub_production_0000',
-    });
-
+describe('createEdgeConfigAdapter', () => {
+  it('should allow creating an adapter with a client', () => {
+    const fakeEdgeConfigClient = {} as EdgeConfigClient;
+    const adapter = createEdgeConfigAdapter(fakeEdgeConfigClient);
     expect(adapter).toBeDefined();
+  });
+
+  it('should allow creating an adapter with a connection string', () => {
+    const adapter = createEdgeConfigAdapter(
+      'https://edge-config.vercel.com/ecfg_xxx?token=yyy',
+    );
+    expect(adapter).toBeDefined();
+  });
+
+  it('should allow deciding', async () => {
+    const fakeEdgeConfigClient = {
+      get: vi.fn(async () => ({ 'test-key': true })),
+    } as unknown as EdgeConfigClient;
+    const adapter = createEdgeConfigAdapter(fakeEdgeConfigClient);
+    await expect(
+      adapter().decide({
+        key: 'test-key',
+        entities: {},
+        headers: new Headers(),
+        cookies: {} as ReadonlyRequestCookies,
+      }),
+    ).resolves.toEqual(true);
+    expect(fakeEdgeConfigClient.get).toHaveBeenCalledWith('flags');
   });
 });
 
-describe('happyKitAdapter', () => {
+describe('edgeConfigAdapter', () => {
   beforeEach(() => {
-    process.env.HAPPYKIT_ENDPOINT = 'https://example.com';
-    process.env.HAPPYKIT_ENV_KEY = 'flags_pub_production_0000';
+    resetDefaultEdgeConfigAdapter();
   });
 
-  afterEach(() => {
-    resetDefaultHappyKitAdapter();
-    delete process.env.HAPPYKIT_ENDPOINT;
-    delete process.env.HAPPYKIT_ENV_KEY;
+  it('default adapter should throw on usage when EDGE_CONFIG is not set', () => {
+    expect(() => edgeConfigAdapter()).toThrowError(
+      '@flags-sdk/edge-config: Missing EDGE_CONFIG env var',
+    );
   });
 
-  it('should work', () => {
-    const adapter = happyKitAdapter();
+  it('should export a default adapter', () => {
+    process.env.EDGE_CONFIG =
+      'https://edge-config.vercel.com/ecfg_xxx?token=yyy';
+    const adapter = edgeConfigAdapter();
     expect(adapter).toBeDefined();
+    delete process.env.EDGE_CONFIG;
   });
 });

--- a/packages/adapter-edge-config/src/index.ts
+++ b/packages/adapter-edge-config/src/index.ts
@@ -21,7 +21,7 @@ export function edgeConfigAdapter<ValueType, EntitiesType>(): Adapter<
   // Initialized lazily to avoid warning when it is not actually used and env vars are missing.
   if (!defaultEdgeConfigAdapter) {
     if (!process.env.EDGE_CONFIG) {
-      throw new Error('Edge Config Adapter: Missing EDGE_CONFIG env var');
+      throw new Error('@flags-sdk/edge-config: Missing EDGE_CONFIG env var');
     }
 
     defaultEdgeConfigAdapter = createEdgeConfigAdapter(process.env.EDGE_CONFIG);
@@ -45,7 +45,7 @@ export function createEdgeConfigAdapter(
   },
 ) {
   if (!connectionString) {
-    throw new Error('Edge Config Adapter: Missing connection string');
+    throw new Error('@flags-sdk/edge-config: Missing connection string');
   }
   const edgeConfigClient =
     typeof connectionString === 'string'
@@ -71,14 +71,14 @@ export function createEdgeConfigAdapter(
         // if a defaultValue was provided this error will be caught and the defaultValue will be used
         if (!definitions) {
           throw new Error(
-            `Edge Config Adapter: Edge Config item "${edgeConfigItemKey}" not found`,
+            `@flags-sdk/edge-config: Edge Config item "${edgeConfigItemKey}" not found`,
           );
         }
 
         // if a defaultValue was provided this error will be caught and the defaultValue will be used
         if (!(key in definitions)) {
           throw new Error(
-            `Edge Config Adapter: Flag "${key}" not found in Edge Config item "${edgeConfigItemKey}"`,
+            `@flags-sdk/edge-config: Flag "${key}" not found in Edge Config item "${edgeConfigItemKey}"`,
           );
         }
         return definitions[key] as ValueType;

--- a/packages/adapter-edge-config/src/index.ts
+++ b/packages/adapter-edge-config/src/index.ts
@@ -1,0 +1,88 @@
+import type { Adapter } from '@vercel/flags';
+import { createClient, type EdgeConfigClient } from '@vercel/edge-config';
+
+export type EdgeConfigFlags = {
+  [key: string]: boolean | number | string | null;
+};
+
+// extend the adapter definition to expose a default adapter
+let defaultEdgeConfigAdapter:
+  | ReturnType<typeof createEdgeConfigAdapter>
+  | undefined;
+
+/**
+ * A default Vercel adapter for Edge Config
+ *
+ */
+export function edgeConfigAdapter<ValueType, EntitiesType>(): Adapter<
+  ValueType,
+  EntitiesType
+> {
+  // Initialized lazily to avoid warning when it is not actually used and env vars are missing.
+  if (!defaultEdgeConfigAdapter) {
+    if (!process.env.EDGE_CONFIG) {
+      throw new Error('Edge Config Adapter: Missing EDGE_CONFIG env var');
+    }
+
+    defaultEdgeConfigAdapter = createEdgeConfigAdapter(process.env.EDGE_CONFIG);
+  }
+
+  return defaultEdgeConfigAdapter<ValueType, EntitiesType>();
+}
+
+export function resetDefaultEdgeConfigAdapter() {
+  defaultEdgeConfigAdapter = undefined;
+}
+
+/**
+ * Allows creating a custom Edge Config adapter for feature flags
+ */
+export function createEdgeConfigAdapter(
+  connectionString: string | EdgeConfigClient,
+  options?: {
+    edgeConfigItemKey?: string;
+    teamSlug?: string;
+  },
+) {
+  if (!connectionString) {
+    throw new Error('Edge Config Adapter: Missing connection string');
+  }
+  const edgeConfigClient =
+    typeof connectionString === 'string'
+      ? createClient(connectionString)
+      : connectionString;
+
+  const edgeConfigItemKey = options?.edgeConfigItemKey ?? 'flags';
+
+  return function edgeConfigAdapter<ValueType, EntitiesType>(): Adapter<
+    ValueType,
+    EntitiesType
+  > {
+    return {
+      origin: options?.teamSlug
+        ? `https://vercel.com/${options.teamSlug}/~/stores/edge-config/${edgeConfigClient.connection.id}/items#item=${edgeConfigItemKey}`
+        : undefined,
+      async decide({ key }): Promise<ValueType> {
+        const definitions =
+          await edgeConfigClient.get<Record<string, boolean>>(
+            edgeConfigItemKey,
+          );
+
+        // if a defaultValue was provided this error will be caught and the defaultValue will be used
+        if (!definitions) {
+          throw new Error(
+            `Edge Config Adapter: Edge Config item "${edgeConfigItemKey}" not found`,
+          );
+        }
+
+        // if a defaultValue was provided this error will be caught and the defaultValue will be used
+        if (!(key in definitions)) {
+          throw new Error(
+            `Edge Config Adapter: Flag "${key}" not found in Edge Config item "${edgeConfigItemKey}"`,
+          );
+        }
+        return definitions[key] as ValueType;
+      },
+    };
+  };
+}

--- a/packages/adapter-edge-config/tsconfig.json
+++ b/packages/adapter-edge-config/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "tsconfig/base.json",
+  "include": ["src"],
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "resolveJsonModule": true,
+    "target": "ES2020"
+  }
+}

--- a/packages/adapter-edge-config/tsup.config.js
+++ b/packages/adapter-edge-config/tsup.config.js
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup';
+
+// eslint-disable-next-line import/no-default-export -- [@vercel/style-guide@5 migration]
+export default defineConfig({
+  entry: ['src/index.ts', 'src/provider/index.ts'],
+  format: ['esm', 'cjs'],
+  splitting: true,
+  sourcemap: true,
+  minify: false,
+  clean: false,
+  skipNodeModulesBundle: true,
+  dts: true,
+  external: ['node_modules'],
+});

--- a/packages/adapter-edge-config/tsup.config.js
+++ b/packages/adapter-edge-config/tsup.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup';
 
 // eslint-disable-next-line import/no-default-export -- [@vercel/style-guide@5 migration]
 export default defineConfig({
-  entry: ['src/index.ts', 'src/provider/index.ts'],
+  entry: ['src/index.ts'],
   format: ['esm', 'cjs'],
   splitting: true,
   sourcemap: true,

--- a/packages/adapter-edge-config/vitest.config.ts
+++ b/packages/adapter-edge-config/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [],
+  test: { environment: 'node' },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,39 @@ importers:
         specifier: ^5.0.3
         version: 5.1.1(@types/node@22.9.0)
 
+  packages/adapter-edge-config:
+    devDependencies:
+      '@types/node':
+        specifier: 20.11.17
+        version: 20.11.17
+      '@vercel/edge-config':
+        specifier: 1.2.0
+        version: 1.2.0
+      '@vercel/flags':
+        specifier: workspace:*
+        version: link:../flags
+      eslint-config-custom:
+        specifier: workspace:*
+        version: link:../../tooling/eslint-config-custom
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      tsconfig:
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      tsup:
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.6.3)
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
+      vite:
+        specifier: 5.1.1
+        version: 5.1.1(@types/node@20.11.17)
+      vitest:
+        specifier: 1.4.0
+        version: 1.4.0(@types/node@20.11.17)
+
   packages/adapter-happykit:
     dependencies:
       '@happykit/flags':
@@ -471,7 +504,7 @@ importers:
         version: 5.9.6
       react-dom:
         specifier: '*'
-        version: 19.0.0(react@19.1.0-canary-cd90a4d8-20250210)
+        version: 19.0.0(react@19.1.0-canary-32b0cad8-20250213)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 0.17.3
@@ -493,10 +526,10 @@ importers:
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       next:
         specifier: 15.1.4
-        version: 15.1.4(@babel/core@7.26.0)(react-dom@19.0.0)(react@19.1.0-canary-cd90a4d8-20250210)
+        version: 15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0)(react@19.1.0-canary-32b0cad8-20250213)
       react:
         specifier: canary
-        version: 19.1.0-canary-cd90a4d8-20250210
+        version: 19.1.0-canary-32b0cad8-20250213
       tsconfig:
         specifier: workspace:*
         version: link:../../tooling/tsconfig
@@ -1500,6 +1533,7 @@ packages:
     dependencies:
       eslint: 8.56.0
       eslint-visitor-keys: 3.4.3
+    dev: true
 
   /@eslint-community/regexpp@4.12.1:
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
@@ -1528,6 +1562,7 @@ packages:
   /@eslint/js@8.56.0:
     resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
 
   /@floating-ui/core@1.6.8:
     resolution: {integrity: sha512-7XJ9cPU+yI2QeLS+FCSlqNFZJq8arvswefkZrYI1yQBbftw6FyrZOxYSh+9S7z7TpeWlRt9zJ5IhM1WIL334jA==}
@@ -2544,7 +2579,6 @@ packages:
   /@opentelemetry/api@1.9.0:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
-    dev: false
 
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -3224,7 +3258,7 @@ packages:
       sirv: 3.0.0
       svelte: 4.2.19
       tiny-glob: 0.2.9
-      vite: 5.1.1(@types/node@22.9.0)
+      vite: 5.1.1(@types/node@20.11.17)
 
   /@sveltejs/vite-plugin-svelte-inspector@2.1.0(@sveltejs/vite-plugin-svelte@3.1.2)(svelte@4.2.19)(vite@5.1.1):
     resolution: {integrity: sha512-9QX28IymvBlSCqsCll5t0kQVxipsfhFFL+L2t3nTWfXnddYwxBuAEtTtlaVQpRz9c37BhJjltSeY4AJSC03SSg==}
@@ -3237,7 +3271,7 @@ packages:
       '@sveltejs/vite-plugin-svelte': 3.1.2(svelte@4.2.19)(vite@5.1.1)
       debug: 4.4.0
       svelte: 4.2.19
-      vite: 5.1.1(@types/node@22.9.0)
+      vite: 5.1.1(@types/node@20.11.17)
     transitivePeerDependencies:
       - supports-color
 
@@ -3255,7 +3289,7 @@ packages:
       magic-string: 0.30.15
       svelte: 4.2.19
       svelte-hmr: 0.16.0(svelte@4.2.19)
-      vite: 5.1.1(@types/node@22.9.0)
+      vite: 5.1.1(@types/node@20.11.17)
       vitefu: 0.2.5(vite@5.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -3747,6 +3781,7 @@ packages:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@typescript-eslint/parser@8.18.0(eslint@8.56.0)(typescript@5.6.3):
     resolution: {integrity: sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==}
@@ -4136,6 +4171,7 @@ packages:
 
   /@ungap/structured-clone@1.2.1:
     resolution: {integrity: sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==}
+    dev: true
 
   /@vercel/edge-config-fs@0.1.0:
     resolution: {integrity: sha512-NRIBwfcS0bUoUbRWlNGetqjvLSwgYH/BqKqDN7vK1g32p7dN96k0712COgaz6VFizAm9b0g6IG6hR6+hc0KCPg==}
@@ -5709,7 +5745,7 @@ packages:
     peerDependencies:
       eslint-plugin-import: '>=1.4.0'
     dependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.7.0)(eslint@8.48.0)
 
   /eslint-import-resolver-node@0.3.9:
     resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
@@ -5763,7 +5799,7 @@ packages:
       debug: 4.4.0
       enhanced-resolve: 5.17.1
       eslint: 8.56.0
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.18.0)(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.3.0
@@ -5771,6 +5807,7 @@ packages:
       stable-hash: 0.0.4
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.48.0):
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
@@ -5829,6 +5866,7 @@ packages:
       eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /eslint-module-utils@2.12.0(@typescript-eslint/parser@8.18.0)(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0):
     resolution: {integrity: sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==}
@@ -5952,6 +5990,7 @@ packages:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+    dev: true
 
   /eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.18.0)(eslint-import-resolver-typescript@3.7.0)(eslint@8.56.0):
     resolution: {integrity: sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==}
@@ -6426,6 +6465,7 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /esm-env@1.2.1:
     resolution: {integrity: sha512-U9JedYYjCnadUlXk7e1Kr+aENQhtUaoaV9+gZm1T8LC/YBAPJx3NSPIAurFOC0U5vrdSevnUJS2/wUVxGwPhng==}
@@ -8533,6 +8573,52 @@ packages:
       - babel-plugin-macros
     dev: false
 
+  /next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0)(react@19.1.0-canary-32b0cad8-20250213):
+    resolution: {integrity: sha512-mTaq9dwaSuwwOrcu3ebjDYObekkxRnXpuVL21zotM8qE2W0HBOdVIdg2Li9QjMEZrj73LN96LcWcz62V19FjAg==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.41.2
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 15.1.4
+      '@opentelemetry/api': 1.9.0
+      '@swc/counter': 0.1.3
+      '@swc/helpers': 0.5.15
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001688
+      postcss: 8.4.31
+      react: 19.1.0-canary-32b0cad8-20250213
+      react-dom: 19.0.0(react@19.1.0-canary-32b0cad8-20250213)
+      styled-jsx: 5.1.6(@babel/core@7.26.0)(react@19.1.0-canary-32b0cad8-20250213)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.1.4
+      '@next/swc-darwin-x64': 15.1.4
+      '@next/swc-linux-arm64-gnu': 15.1.4
+      '@next/swc-linux-arm64-musl': 15.1.4
+      '@next/swc-linux-x64-gnu': 15.1.4
+      '@next/swc-linux-x64-musl': 15.1.4
+      '@next/swc-win32-arm64-msvc': 15.1.4
+      '@next/swc-win32-x64-msvc': 15.1.4
+      sharp: 0.33.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    dev: true
+
   /next@15.1.4(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028):
     resolution: {integrity: sha512-mTaq9dwaSuwwOrcu3ebjDYObekkxRnXpuVL21zotM8qE2W0HBOdVIdg2Li9QjMEZrj73LN96LcWcz62V19FjAg==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
@@ -8623,51 +8709,6 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
     dev: false
-
-  /next@15.1.4(@babel/core@7.26.0)(react-dom@19.0.0)(react@19.1.0-canary-cd90a4d8-20250210):
-    resolution: {integrity: sha512-mTaq9dwaSuwwOrcu3ebjDYObekkxRnXpuVL21zotM8qE2W0HBOdVIdg2Li9QjMEZrj73LN96LcWcz62V19FjAg==}
-    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.41.2
-      babel-plugin-react-compiler: '*'
-      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@playwright/test':
-        optional: true
-      babel-plugin-react-compiler:
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 15.1.4
-      '@swc/counter': 0.1.3
-      '@swc/helpers': 0.5.15
-      busboy: 1.6.0
-      caniuse-lite: 1.0.30001688
-      postcss: 8.4.31
-      react: 19.1.0-canary-cd90a4d8-20250210
-      react-dom: 19.0.0(react@19.1.0-canary-cd90a4d8-20250210)
-      styled-jsx: 5.1.6(@babel/core@7.26.0)(react@19.1.0-canary-cd90a4d8-20250210)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.1.4
-      '@next/swc-darwin-x64': 15.1.4
-      '@next/swc-linux-arm64-gnu': 15.1.4
-      '@next/swc-linux-arm64-musl': 15.1.4
-      '@next/swc-linux-x64-gnu': 15.1.4
-      '@next/swc-linux-x64-musl': 15.1.4
-      '@next/swc-win32-arm64-msvc': 15.1.4
-      '@next/swc-win32-x64-msvc': 15.1.4
-      sharp: 0.33.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    dev: true
 
   /next@15.2.0-canary.3(@babel/core@7.26.0)(react-dom@19.0.0-rc-02c0e824-20241028)(react@19.0.0-rc-02c0e824-20241028):
     resolution: {integrity: sha512-mnlR2nZEsYCd6+wiLKJh09KVIRbsjybPfTQnqdVSq7TWkeK/zuLMug4IgwZ3bI9+fSjh/7zrpde84SdFMvJNIg==}
@@ -9327,12 +9368,12 @@ packages:
       scheduler: 0.23.2
     dev: false
 
-  /react-dom@19.0.0(react@19.1.0-canary-cd90a4d8-20250210):
+  /react-dom@19.0.0(react@19.1.0-canary-32b0cad8-20250213):
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
       react: ^19.0.0
     dependencies:
-      react: 19.1.0-canary-cd90a4d8-20250210
+      react: 19.1.0-canary-32b0cad8-20250213
       scheduler: 0.25.0
 
   /react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028):
@@ -9418,8 +9459,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /react@19.1.0-canary-cd90a4d8-20250210:
-    resolution: {integrity: sha512-1u9LWIuGKTxfH280X76vJSLLzIBt0EH5BuV6P6AkkcOZncLequ+0JzzyMr2+Lgu8lxVdMkBsht7Lo/v4k8NQag==}
+  /react@19.1.0-canary-32b0cad8-20250213:
+    resolution: {integrity: sha512-Gfrqvqx0z5hOpPc4+OxRwVgm+/BXQ+uQnW5Yidcpa1yCpJmXugX0/IUuCO1yDZAq0x+cuRP7SnwGHxmWRNaGtA==}
     engines: {node: '>=0.10.0'}
 
   /read-cache@1.0.0:
@@ -10274,7 +10315,7 @@ packages:
       react: 19.0.0-rc-02c0e824-20241028
     dev: false
 
-  /styled-jsx@5.1.6(@babel/core@7.26.0)(react@19.1.0-canary-cd90a4d8-20250210):
+  /styled-jsx@5.1.6(@babel/core@7.26.0)(react@19.1.0-canary-32b0cad8-20250213):
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -10289,7 +10330,7 @@ packages:
     dependencies:
       '@babel/core': 7.26.0
       client-only: 0.0.1
-      react: 19.1.0-canary-cd90a4d8-20250210
+      react: 19.1.0-canary-32b0cad8-20250213
     dev: true
 
   /sucrase@3.35.0:
@@ -11117,7 +11158,6 @@ packages:
       rollup: 4.28.1
     optionalDependencies:
       fsevents: 2.3.3
-    dev: true
 
   /vite@5.1.1(@types/node@22.9.0):
     resolution: {integrity: sha512-wclpAgY3F1tR7t9LL5CcHC41YPkQIpKUGeIuT8MdNwNZr6OqOTLs7JX5vIHAtzqLWXts0T+GDrh9pN2arneKqg==}
@@ -11162,7 +11202,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      vite: 5.1.1(@types/node@22.9.0)
+      vite: 5.1.1(@types/node@20.11.17)
 
   /vitest@1.4.0(@types/node@20.11.17):
     resolution: {integrity: sha512-gujzn0g7fmwf83/WzrDTnncZt2UiXP41mHuFYFrdwaLRVQ6JYQEiME2IfEjU3vcFL3VKa75XhI3lFgn+hfVsQw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,13 +241,14 @@ importers:
         version: 5.1.1(@types/node@22.9.0)
 
   packages/adapter-edge-config:
+    dependencies:
+      '@vercel/edge-config':
+        specifier: ^1.2.0
+        version: 1.2.0
     devDependencies:
       '@types/node':
         specifier: 20.11.17
         version: 20.11.17
-      '@vercel/edge-config':
-        specifier: 1.2.0
-        version: 1.2.0
       '@vercel/flags':
         specifier: workspace:*
         version: link:../flags


### PR DESCRIPTION
This adapter allows using Edge Config as the feature flag provider / direct source of feature flags.

This adapter is not required if you are using provider-specific adapters which integrate with Edge Config on their own.