### PR TITLE
Allow intercepting evaluations

### DIFF
--- a/.changeset/pink-rings-dream.md
+++ b/.changeset/pink-rings-dream.md
@@ -1,0 +1,5 @@
+---
+'@vercel/flags': minor
+---
+
+allow intercepting flag evaluations

--- a/packages/flags/src/next/index.ts
+++ b/packages/flags/src/next/index.ts
@@ -282,12 +282,21 @@ function getRun<ValueType, EntitiesType>(
     // fall back to defaultValue if it is set,
     let decisionPromise: Promise<ValueType> | ValueType;
     try {
+      const decideOptions = {
+        headers: readonlyHeaders,
+        cookies: readonlyCookies,
+        entities,
+      };
+
       decisionPromise = Promise.resolve<ValueType>(
-        decide({
-          headers: readonlyHeaders,
-          cookies: readonlyCookies,
-          entities,
-        }),
+        definition.intercept
+          ? definition.intercept(
+              decideOptions,
+              // creats the next() function and ensures it is always async to
+              // simplify the types
+              async (interceptedOptions) => decide(interceptedOptions),
+            )
+          : decide(decideOptions),
       )
         // catch errors in async "decide" functions
         .then<ValueType, ValueType>(

--- a/packages/flags/src/types.ts
+++ b/packages/flags/src/types.ts
@@ -205,6 +205,32 @@ export type FlagDeclaration<ValueType, EntitiesType> = {
    * This function can establish entities which the `decide` function will be called with.
    */
   identify?: Identify<EntitiesType>;
+  /**
+   * This function can be used to intercept the call to the `decide` function or adapters, and post-process the result.
+   *
+   * Intercepting allows you to
+   * - act before `decide()` or adapters are called
+   * - handle any errors that occur in decide() or adapters
+   * - post-process the result
+   *
+   * If intercept itself throws, the Flags SDK will handle it by
+   *  - falling back to the default value if it's set
+   *  - otherwise re-throwing the error
+   *
+   * The default intercept implementation is:
+   *
+   * ```
+   *   async intercept(options, next) {
+   *     return next(options)
+   *   }
+   * ```
+   */
+  intercept?: (
+    options: FlagParamsType & { entities?: EntitiesType },
+    next: (
+      options: FlagParamsType & { entities?: EntitiesType },
+    ) => Promise<ValueType>,
+  ) => Promise<ValueType>;
 } & (
   | {
       adapter: Adapter<ValueType, EntitiesType>;


### PR DESCRIPTION
This is an exploration of adding an `intercept` mechanism to flags. It is not guaranteed to be shipped.

Adds a concept called `intercept` would allow modifying or skipping the `decide()` function or `adapter().decide()` function call.

```ts
import { flag } from '@vercel/flags/next';

export const exampleFlag = flag<boolean>({
  key: 'example-flag',
  async intercept(options, next) {
    return next(options)
  },
  decide() {
    return false;
  },
});
```

Interception happens after overrides and after the `identify` call. This means modifications made within `intercept` will not be cached under the originally provided `identify`.

# Usage examples

## Add your own error handling

This is powerful in case you want full control over error handling and report errors to your own systems, even when the flag itself falls back to a `defaultValue`.

```ts
import { flag } from '@vercel/flags/next';

export const exampleFlag = flag<boolean>({
  key: 'example-flag',
  async intercept(options, next) {
    return next(options).catch(error => {
      /* handle errors here or re-throw to use the default error handling */
      reportError(error) // report error to your observability tooling
      throw error // re-throw error so the defaultValue can be applied
    })
  },
  defaultValue: false,
  decide() {/* skipped */},
});
```

## Time flag evaluations

```ts
import { flag } from '@vercel/flags/next';

export const exampleFlag = flag<boolean>({
  key: 'example-flag',
  async intercept(options, next) {
    const before = Date.now()
    const value = await next(options)
    console.log(`evaluation took ${Date.now() - before}ms`);
    return value
  },
  decide() {/* skipped */},
});
```

## Modify options

There isn't usually a use case for this, and you should rely on `identify` instead, as the entities determined by `intercept` will not become part of the cache key. The evaluation will instead be cached for the duration of the request under the entities returned by `identify`.

```ts
import { flag } from '@vercel/flags/next';

export const exampleFlag = flag<boolean>({
  key: 'example-flag',
  async intercept(options, next) {
    return next({ ...options, entities: {/* custom entities */} })
  },
  decide() {/* skipped */},
});
```
