### PR TITLE
docs: add  text server-side only.

### DIFF
--- a/packages/flags/README.md
+++ b/packages/flags/README.md
@@ -4,7 +4,7 @@
 
 The feature flags toolkit for Next.js and SvelteKit.
 
-From the creators of Next.js, the Flags SDK is a free open-source library that gives you the tools you need to use feature flags in Next.js and SvelteKit applications.
+From the creators of Next.js, the Flags SDK is a free open-source library that gives you the tools you need to use feature flags in Next.js and SvelteKit applications, exclusively on the server side.
 
 - Works with any flag provider, custom setups or no flag provider at all
 - Compatible with App Router, Pages Router, and Edge Middleware


### PR DESCRIPTION
## Summary of the Change

This pull request updates the description of **Flags SDK** to clarify that it works exclusively on the server side. Previously, the documentation could be misinterpreted, leading users to believe the SDK could also run on the client side.

### Why This Change?

- **Clarity for Developers**: By emphasizing that Flags SDK is server-side only, we prevent confusion in Next.js and SvelteKit setups.
- **Fewer Errors**: Without this clarification, users might attempt to use the library client-side, causing unexpected failures or behavior.

### What Changed?

- The phrase "exclusively on the server side" was added to the main documentation sentence describing the SDK’s scope.
- No other sections were modified to keep the changes minimal.

### Verification and Review

- This change only affects documentation, so there is no impact on functionality or risk introduced.
- The text was reviewed for consistency and spelling before submitting this pull request.
