### PR TITLE
Add flags context

### DIFF
--- a/examples/snippets/app/examples/flag-context/flags.ts
+++ b/examples/snippets/app/examples/flag-context/flags.ts
@@ -1,0 +1,26 @@
+import type { ReadonlyRequestCookies } from '@vercel/flags';
+import { flag, dedupe } from '@vercel/flags/next';
+
+interface Entities {
+  user?: { id: string };
+}
+
+const identify = dedupe(
+  ({ cookies }: { cookies: ReadonlyRequestCookies }): Entities => {
+    const userId = cookies.get('dashboard-user-id')?.value;
+    return { user: userId ? { id: userId } : undefined };
+  },
+);
+
+export const dashboardFlag = flag<boolean, Entities>({
+  key: 'dashboard-flag',
+  identify,
+  description: 'Flag used on the Dashboard Pages example',
+  decide({ entities }) {
+    if (!entities?.user) return false;
+    // Allowed users could be loaded from Edge Config or elsewhere
+    const allowedUsers = ['user1'];
+
+    return allowedUsers.includes(entities.user.id);
+  },
+});

--- a/examples/snippets/app/examples/flag-context/layout.tsx
+++ b/examples/snippets/app/examples/flag-context/layout.tsx
@@ -1,0 +1,16 @@
+import { FlagContextProvider } from '@vercel/flags/react';
+import { dashboardFlag } from './flags';
+
+export default async function Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const dashboard = await dashboardFlag();
+
+  return (
+    <FlagContextProvider values={{ [dashboardFlag.key]: dashboard }}>
+      {children}
+    </FlagContextProvider>
+  );
+}

--- a/examples/snippets/app/examples/flag-context/page.tsx
+++ b/examples/snippets/app/examples/flag-context/page.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { useFlagContext } from '@vercel/flags/react';
+import { DemoFlag } from '@/components/demo-flag';
+import { useRouter } from 'next/navigation';
+import type { FlagValuesType } from '@vercel/flags';
+
+export default function Page() {
+  const dashboard = useFlagContext<boolean>('dashboard-flag');
+  const router = useRouter();
+  return (
+    <>
+      <DemoFlag name="dashboard-flag" value={dashboard} />
+      <div className="flex gap-2">
+        <Button
+          onClick={() => {
+            document.cookie = 'dashboard-user-id=user1; path=/';
+            router.refresh();
+          }}
+          variant="outline"
+        >
+          Act as a flagged in user
+        </Button>
+        <Button
+          onClick={() => {
+            document.cookie = 'dashboard-user-id=user2; path=/';
+            router.refresh();
+          }}
+          variant="outline"
+        >
+          Act as a regular user
+        </Button>
+        <Button
+          onClick={() => {
+            document.cookie =
+              'dashboard-user-id=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+            router.refresh();
+          }}
+          variant="outline"
+        >
+          Clear cookie
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/packages/flags/src/react/index.tsx
+++ b/packages/flags/src/react/index.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import type { FlagDefinitionsType, FlagValuesType } from '../types';
 import { safeJsonStringify } from '../lib/safe-json-stringify';
@@ -41,4 +43,29 @@ export function FlagValues({
       }}
     />
   );
+}
+
+const emptyValues: FlagValuesType = {};
+const FlagContext = React.createContext<FlagValuesType>(emptyValues);
+
+export function FlagContextProvider<T>({
+  children,
+  values,
+}: {
+  children: React.ReactNode;
+  values: FlagValuesType;
+}) {
+  return <FlagContext.Provider value={values}>{children}</FlagContext.Provider>;
+}
+
+export function useFlagContext<T>(): T;
+export function useFlagContext<T>(key: string): T;
+export function useFlagContext<T>(key?: string): T {
+  const values = React.useContext(FlagContext);
+
+  if (values === emptyValues) {
+    throw new Error('FlagContextProvider not found');
+  }
+
+  return typeof key === 'string' ? (values[key] as T) : (values as T);
 }


### PR DESCRIPTION
Adds a flags context for use in dashboard applications where lots of client components need access to the flags state.

The DX of traditional feature flag SDKs which bootstrap on the client is great, as people can simply use hooks to load their flags. But their huge downside is that this leads to poor UX. Loading your flags client-side comes with extra latency, and will lead to layout shift if any flag ever influences the actual rendering. I wrote about their tradeoffs here https://flags-sdk.dev/knowledge-base/server-side-vs-client-side

The following approach should provide the same benefits, without any of the downsides
- avoids bootstrapping from client / waterfall request
- avoids layout shift
- allows overriding flags with [Flags Explorer](https://vercel.com/docs/workflow-collaboration/feature-flags/using-vercel-toolbar)

There are downsides to this approach though
- feature flags are no longer called as functions but rather need to be referred to by their keys
- any server components downstream of the layout won't have access to the context, and need to call the flag on their own

## 1. Use a layout to determine your feature flags, and provide them as context

```tsx
// layout.tsx
import { FlagContextProvider } from './flag-context'; // shown below
import { dashboardFlag } from './flags';

export default async function Layout({
  children,
}: {
  children: React.ReactNode;
}) {
  const dashboard = await dashboardFlag();

  return (
    <FlagContextProvider values={{ [dashboardFlag.key]: dashboard }}>
      {children}
    </FlagContextProvider>
  );
}
```

## 2. Consume your flags in any client component

```tsx
// page.tsx
'use client';

import { useFlagContext } from './flag-context';

export default function Page() {
  // provide a key to read a single flag
  const dashboard = useFlagContext<boolean>('dashboard-flag');

  // provide no key to read all flags
  const allFlags = useFlagContext<{ "dashboard-flag": boolean }>();

  const router = useRouter();
  return <>{dashboard ? "dashboard is on" : "dashboard is off"}</>;
}
```

## 3. Create a flag context

```ts
// flag-context.ts
'use client';

import React from 'react';
import type { FlagValuesType } from '@vercel/flags';

const emptyValues: FlagValuesType = {};
const FlagContext = React.createContext<FlagValuesType>(emptyValues);

export function FlagContextProvider<T>({
  children,
  values,
}: {
  children: React.ReactNode;
  values: FlagValuesType;
}) {
  return <FlagContext.Provider value={values}>{children}</FlagContext.Provider>;
}

export function useFlagContext<T>(): T;
export function useFlagContext<T>(key: string): T;
export function useFlagContext<T>(key?: string): T {
  const values = React.useContext(FlagContext);

  if (values === emptyValues) {
    throw new Error('FlagContextProvider not found');
  }

  return typeof key === 'string' ? (values[key] as T) : (values as T);
}
```