### PR TITLE
Fix import in README

### DIFF
--- a/packages/flags/README.md
+++ b/packages/flags/README.md
@@ -52,7 +52,7 @@ Call your feature flag in a React Server Component:
 
 ```tsx
 // app/page.tsx
-import { exampleFlag } from '../flags';
+import { exampleFlag } from './flags';
 
 export default async function Page() {
   const example = await exampleFlag();


### PR DESCRIPTION
Since both files are in the `app` directory, the import should be `./flags`, not `../flags`. 