### PR TITLE
draft: Add PostHog feature flag adapter

### DIFF
--- a/packages/adapter-posthog/src/index.test.ts
+++ b/packages/adapter-posthog/src/index.test.ts
@@ -1,0 +1,28 @@
+import { expect, it, describe, vi, beforeEach, afterEach } from 'vitest';
+import { createPostHogAdapter } from '.';
+import posthog from 'posthog-js';
+
+describe('createPostHogAdapter', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('should initialize PostHog with the provided API key', () => {
+    const apiKey = 'test-api-key';
+    createPostHogAdapter(apiKey);
+    expect(posthog.init).toHaveBeenCalledWith(apiKey);
+  });
+
+  it('should resolve flags correctly', async () => {
+    const apiKey = 'test-api-key';
+    const adapter = createPostHogAdapter(apiKey);
+    const flagKey = 'test-flag';
+    const flagValue = true;
+
+    posthog.isFeatureEnabled = vi.fn().mockReturnValue(flagValue);
+
+    const result = await adapter.decide({ key: flagKey });
+    expect(result).toBe(flagValue);
+    expect(posthog.isFeatureEnabled).toHaveBeenCalledWith(flagKey);
+  });
+});

--- a/packages/adapter-posthog/src/index.ts
+++ b/packages/adapter-posthog/src/index.ts
@@ -1,0 +1,12 @@
+import { Adapter } from 'flags';
+import posthog from 'posthog-js';
+
+export function createPostHogAdapter(apiKey: string): Adapter<boolean, any> {
+  posthog.init(apiKey);
+
+  return {
+    decide: async ({ key }) => {
+      return posthog.isFeatureEnabled(key);
+    },
+  };
+}

--- a/packages/flags/src/index.ts
+++ b/packages/flags/src/index.ts
@@ -28,3 +28,4 @@ export {
   RequestCookiesAdapter,
 } from './spec-extension/adapters/request-cookies';
 export { mergeProviderData } from './lib/merge-provider-data';
+export { createPostHogAdapter } from '@flags-sdk/posthog';


### PR DESCRIPTION
Add a new PostHog feature flag adapter to the repository.

* **PostHog Adapter Implementation**
  - Create `packages/adapter-posthog/src/index.ts` to implement the `createPostHogAdapter` function.
  - Initialize PostHog with the provided API key.
  - Implement the `decide` method to resolve feature flags using PostHog.

* **PostHog Adapter Tests**
  - Create `packages/adapter-posthog/src/index.test.ts` to test the PostHog adapter.
  - Test the initialization of PostHog with the provided API key.
  - Test the flag resolution functionality of the PostHog adapter.

* **Export PostHog Adapter**
  - Modify `packages/flags/src/index.ts` to export the new PostHog adapter.

