### PR TITLE
allow using shirt-shop as a template

### DIFF
--- a/examples/shirt-shop/scripts/replace-workspace-version.mjs
+++ b/examples/shirt-shop/scripts/replace-workspace-version.mjs
@@ -1,0 +1,29 @@
+import fs from 'fs/promises';
+
+async function prepareTemplate() {
+  // Skip when not used as a template
+  if (process.env.VERCEL_PROJECT_ID === 'prj_6Km3AvCCo0QgJSoEb3cFQwwB9x0Y') {
+    return;
+  }
+
+  // Read the package.json
+  const packageJson = JSON.parse(await fs.readFile('./package.json', 'utf8'));
+
+  // Create a copy for the template
+  const templatePackageJson = { ...packageJson };
+
+  // Replace workspace dependencies with real versions
+  for (const [dep, version] of Object.entries(
+    templatePackageJson.dependencies || {},
+  )) {
+    if (version.startsWith('workspace:')) {
+      // Replace with the actual version you want
+      templatePackageJson.dependencies[dep] = 'latest';
+    }
+  }
+
+  // Write the template package.json
+  await fs.writeFile('./package.json', JSON.stringify(templatePackageJson));
+}
+
+prepareTemplate();

--- a/examples/shirt-shop/vercel.json
+++ b/examples/shirt-shop/vercel.json
@@ -1,0 +1,3 @@
+{
+  "installCommand": "node scripts/replace-workspace-version.js && pnpm install"
+}

--- a/examples/shirt-shop/vercel.json
+++ b/examples/shirt-shop/vercel.json
@@ -1,3 +1,3 @@
 {
-  "installCommand": "node scripts/replace-workspace-version.js && pnpm install"
+  "installCommand": "node scripts/replace-workspace-version.mjs && pnpm install"
 }


### PR DESCRIPTION
We must replace the `workspace:*` dependencies to allow using `shirt-shop` as a template.
