### PR TITLE
Add LaunchDarkly adapter

### DIFF
--- a/.changeset/kind-carpets-unite.md
+++ b/.changeset/kind-carpets-unite.md
@@ -1,0 +1,5 @@
+---
+'@flags-sdk/launchdarkly': minor
+---
+
+Add LaunchDarkly adapter

--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -84,9 +84,10 @@ jobs:
           EDGE_CONFIG: ${{ secrets.EDGE_CONFIG }}
           FLAGS_SECRET: ${{ secrets.FLAGS_SECRET }}
           FLAGS: ${{ secrets.FLAGS }}
-          LAUNCHDARKLY_API_TOKEN: ${{ secrets.LAUNCHDARKLY_API_TOKEN }}
           HAPPYKIT_API_TOKEN: ${{ secrets.HAPPYKIT_API_TOKEN }}
           HAPPYKIT_ENV_KEY: ${{ secrets.HAPPYKIT_ENV_KEY }}
+          LAUNCHDARKLY_CLIENT_SIDE_ID: ${{ secrets.LAUNCHDARKLY_CLIENT_SIDE_ID }}
+          LAUNCHDARKLY_PROJECT_SLUG: ${{ secrets.LAUNCHDARKLY_PROJECT_SLUG }}
 
       - name: Publish Snapshot Release
         run: pnpm changeset publish --no-git-tag --tag snapshot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
           EDGE_CONFIG: ${{ secrets.EDGE_CONFIG }}
           FLAGS_SECRET: ${{ secrets.FLAGS_SECRET }}
-          LAUNCHDARKLY_API_TOKEN: ${{ secrets.LAUNCHDARKLY_API_TOKEN }}
           HAPPYKIT_API_TOKEN: ${{ secrets.HAPPYKIT_API_TOKEN }}
           HAPPYKIT_ENV_KEY: ${{ secrets.HAPPYKIT_ENV_KEY }}
+          LAUNCHDARKLY_CLIENT_SIDE_ID: ${{ secrets.LAUNCHDARKLY_CLIENT_SIDE_ID }}
+          LAUNCHDARKLY_PROJECT_SLUG: ${{ secrets.LAUNCHDARKLY_PROJECT_SLUG }}

--- a/examples/snippets/app/.well-known/vercel/flags/route.ts
+++ b/examples/snippets/app/.well-known/vercel/flags/route.ts
@@ -10,6 +10,7 @@ import * as topLevelFlags from '../../../../flags';
 import * as basicEdgeMiddlewareFlags from '../../../examples/feature-flags-in-edge-middleware/flags';
 import * as basicIdentifyFlags from '../../../concepts/identify/basic/flags';
 import * as fullIdentifyFlags from '../../../concepts/identify/full/flags';
+import * as adapterLaunchDarklyFlags from '../../../examples/adapter-launchdarkly/flags';
 
 export async function GET(request: NextRequest) {
   const access = await verifyAccess(request.headers.get('Authorization'));
@@ -24,6 +25,7 @@ export async function GET(request: NextRequest) {
       ...basicEdgeMiddlewareFlags,
       ...basicIdentifyFlags,
       ...fullIdentifyFlags,
+      ...adapterLaunchDarklyFlags,
     }),
   );
 }

--- a/examples/snippets/app/examples/adapter-launchdarkly/flags.ts
+++ b/examples/snippets/app/examples/adapter-launchdarkly/flags.ts
@@ -1,0 +1,12 @@
+import { flag } from 'flags/next';
+import { launchDarkly } from '@flags-sdk/launchdarkly';
+
+export const exampleFlag = flag({
+  key: 'launchdarkly-adapter-example-flag',
+  defaultValue: false,
+  description: 'Whether the summer sale is active',
+  adapter: launchDarkly(),
+  async identify() {
+    return { key: 'uid1' };
+  },
+});

--- a/examples/snippets/app/examples/adapter-launchdarkly/page.tsx
+++ b/examples/snippets/app/examples/adapter-launchdarkly/page.tsx
@@ -1,0 +1,6 @@
+import { exampleFlag } from './flags';
+
+export default async function Page() {
+  const example = await exampleFlag();
+  return <div>Flag is on {example ? 'Yes' : 'No'}</div>;
+}

--- a/examples/snippets/app/examples/adapter-launchdarkly/page.tsx
+++ b/examples/snippets/app/examples/adapter-launchdarkly/page.tsx
@@ -1,6 +1,12 @@
+import { FlagValues } from 'flags/react';
 import { exampleFlag } from './flags';
 
 export default async function Page() {
   const example = await exampleFlag();
-  return <div>Flag is on {example ? 'Yes' : 'No'}</div>;
+  return (
+    <>
+      <div>Flag is on {example ? 'Yes' : 'No'}</div>
+      <FlagValues values={{ [exampleFlag.key]: example }} />
+    </>
+  );
 }

--- a/examples/snippets/package.json
+++ b/examples/snippets/package.json
@@ -9,6 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@flags-sdk/launchdarkly": "workspace:*",
     "@radix-ui/react-dialog": "1.1.2",
     "@radix-ui/react-separator": "1.1.0",
     "@radix-ui/react-slot": "1.1.0",

--- a/packages/adapter-launchdarkly/README.md
+++ b/packages/adapter-launchdarkly/README.md
@@ -1,0 +1,48 @@
+# `@flags-sdk/launchdarkly`
+
+## Installation
+
+```sh
+npm install @flags-sdk/launchdarkly @launchdarkly/vercel-server-sdk @vercel/edge-config
+```
+
+## Usage
+
+**NOTE:** [The LaunchDarkly Vercel integration must be installed on our account.](https://vercel.com/integrations/launchdarkly)
+
+The following environment variables are required in order to use the default adapter:
+
+```sh
+export EDGE_CONFIG="https://edge-config.vercel.com/ecfg_abdc1234?token=xxx-xxx-xxx" # Provided by Vercel when connecting an Edge Config to the project
+export LAUNCHDARKLY_CLIENT_SIDE_ID="612376f91b8f5713a58777a1"
+export LAUNCHDARKLY_PROJECT_SLUG="my-project"
+```
+
+```ts
+import { flag, dedupe } from 'flags/next';
+import { launchDarkly, type LDContext } from '@flags-sdk/launchdarkly';
+
+const identify = dedupe(async (): Promise<LDContext> => {
+  return {
+    key: 'user_123',
+  };
+});
+
+export const showBanner = flag<boolean, LDContext>({
+  key: 'show-banner',
+  identify,
+  adapter: launchDarkly(),
+});
+```
+
+It's possible to create an adapter by using the `createLaunchDarklyAdapter` function:
+
+```ts
+import { createLaunchDarklyAdapter } from '@flags-sdk/launchdarkly';
+
+const adapter = createLaunchDarklyAdapter({
+  projectSlug: 'my-project',
+  ldClientSideKey: '612376f91b8f5713a58777a1',
+  edgeConfigConnectionString: process.env.EDGE_CONFIG,
+});
+```

--- a/packages/adapter-launchdarkly/package.json
+++ b/packages/adapter-launchdarkly/package.json
@@ -35,7 +35,10 @@
     "test:watch": "vitest",
     "type-check": "tsc --noEmit"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@launchdarkly/vercel-server-sdk": "^1.3.23",
+    "@vercel/edge-config": "^1.3.0"
+  },
   "devDependencies": {
     "@types/node": "20.11.17",
     "eslint-config-custom": "workspace:*",

--- a/packages/adapter-launchdarkly/src/index.ts
+++ b/packages/adapter-launchdarkly/src/index.ts
@@ -1,1 +1,73 @@
+import type { Adapter } from 'flags';
+import { createClient } from '@vercel/edge-config';
+import { init, type LDContext } from '@launchdarkly/vercel-server-sdk';
+
 export { getProviderData } from './provider';
+export type { LDContext };
+
+interface AdapterOptions<ValueType> {
+  defaultValue?: ValueType;
+}
+
+let defaultLaunchDarklyAdapter:
+  | ReturnType<typeof createLaunchDarklyAdapter>
+  | undefined;
+
+function assertEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(
+      `@flags-sdk/launchdarkly: Missing ${name} environment variable`,
+    );
+  }
+  return value;
+}
+
+export function createLaunchDarklyAdapter({
+  projectSlug,
+  clientSideId,
+  edgeConfigConnectionString,
+}: {
+  projectSlug: string;
+  clientSideId: string;
+  edgeConfigConnectionString: string;
+}) {
+  const edgeConfigClient = createClient(edgeConfigConnectionString);
+  const ldClient = init(clientSideId, edgeConfigClient);
+
+  return function launchDarklyAdapter<ValueType>(
+    options: AdapterOptions<ValueType> = {},
+  ): Adapter<ValueType, LDContext> {
+    return {
+      origin(key) {
+        return `https://app.launchdarkly.com/projects/${projectSlug}/flags/${key}/`;
+      },
+      async decide({ key, entities }): Promise<ValueType> {
+        await ldClient.waitForInitialization();
+        return ldClient.variation(
+          key,
+          entities!,
+          options.defaultValue,
+        ) as ValueType;
+      },
+    };
+  };
+}
+
+export function launchDarkly<ValueType>(
+  options?: AdapterOptions<ValueType>,
+): Adapter<ValueType, LDContext> {
+  if (!defaultLaunchDarklyAdapter) {
+    const edgeConfigConnectionString = assertEnv('EDGE_CONFIG');
+    const clientSideId = assertEnv('LAUNCHDARKLY_CLIENT_SIDE_ID');
+    const projectSlug = assertEnv('LAUNCHDARKLY_PROJECT_SLUG');
+
+    defaultLaunchDarklyAdapter = createLaunchDarklyAdapter({
+      projectSlug,
+      clientSideId,
+      edgeConfigConnectionString,
+    });
+  }
+
+  return defaultLaunchDarklyAdapter(options);
+}

--- a/packages/flags/src/types.ts
+++ b/packages/flags/src/types.ts
@@ -150,6 +150,7 @@ export interface Adapter<ValueType, EntitiesType> {
     entities?: EntitiesType;
     headers: ReadonlyHeaders;
     cookies: ReadonlyRequestCookies;
+    defaultValue?: ValueType;
   }) => Promise<ValueType> | ValueType;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
 
   examples/snippets:
     dependencies:
+      '@flags-sdk/launchdarkly':
+        specifier: workspace:*
+        version: link:../../packages/adapter-launchdarkly
       '@radix-ui/react-dialog':
         specifier: 1.1.2
         version: 1.1.2(@types/react-dom@19.0.4)(@types/react@19.0.10)(react-dom@19.0.0-rc.1)(react@19.0.0-rc.1)
@@ -406,6 +409,13 @@ importers:
         version: 1.4.0(@types/node@20.11.17)
 
   packages/adapter-launchdarkly:
+    dependencies:
+      '@launchdarkly/vercel-server-sdk':
+        specifier: ^1.3.23
+        version: 1.3.23
+      '@vercel/edge-config':
+        specifier: ^1.3.0
+        version: 1.4.0
     devDependencies:
       '@types/node':
         specifier: 20.11.17
@@ -566,7 +576,7 @@ importers:
         version: 5.10.0
       react-dom:
         specifier: '*'
-        version: 18.3.1(react@19.1.0-canary-d55cc79b-20250228)
+        version: 18.3.1(react@19.1.0-canary-443b7ff2-20250303)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 0.17.3
@@ -588,10 +598,10 @@ importers:
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       next:
         specifier: 15.1.4
-        version: 15.1.4(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@18.3.1)(react@19.1.0-canary-d55cc79b-20250228)
+        version: 15.1.4(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@18.3.1)(react@19.1.0-canary-443b7ff2-20250303)
       react:
         specifier: canary
-        version: 19.1.0-canary-d55cc79b-20250228
+        version: 19.1.0-canary-443b7ff2-20250303
       tsconfig:
         specifier: workspace:*
         version: link:../../tooling/tsconfig
@@ -2278,6 +2288,34 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  /@launchdarkly/js-sdk-common@2.13.0:
+    resolution: {integrity: sha512-cRoOQWBEOOynY3YDHIF4am1ZxiGu6MFK4v8WyNR0zN+nVjdQiuuyfAbHB//1Q0nrc1aB0flOy6e8C51eHy+VeA==}
+    dev: false
+
+  /@launchdarkly/js-server-sdk-common-edge@2.5.4:
+    resolution: {integrity: sha512-L79FsZfAosYMHE/eg3p7KFLiWHJn3TCdEAL89frzMOLv0e43xTp4xQEDnTovWKQpAN7gH1iYDLwKUpoWgUAS2g==}
+    dependencies:
+      '@launchdarkly/js-server-sdk-common': 2.11.1
+      crypto-js: 4.2.0
+    dev: false
+
+  /@launchdarkly/js-server-sdk-common@2.11.1:
+    resolution: {integrity: sha512-mz5meN+tII/By8TjPRhuI5SSztFSIYXQpK1IlUX1uUlM8xDlS/HrzM4KcP7BRLpO0TQcZKl4roEkkoMBoukPsA==}
+    dependencies:
+      '@launchdarkly/js-sdk-common': 2.13.0
+      semver: 7.5.4
+    dev: false
+
+  /@launchdarkly/vercel-server-sdk@1.3.23:
+    resolution: {integrity: sha512-1QcUA+QD69bbPwDWCg5PpEvRmbi8FHv1D22OECHtChKnmSlw28orHnmfw7MqcgVVZu5z2x91q/Gs37VMNkh3Ig==}
+    dependencies:
+      '@launchdarkly/js-server-sdk-common-edge': 2.5.4
+      '@vercel/edge-config': 1.4.0
+      crypto-js: 4.2.0
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+    dev: false
 
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -4133,7 +4171,6 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.48.0)(typescript@5.6.3):
     resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
@@ -4162,6 +4199,7 @@ packages:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.56.0)(typescript@5.6.3):
     resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
@@ -4259,7 +4297,6 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/parser@6.21.0(eslint@8.48.0)(typescript@5.6.3):
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
@@ -4280,6 +4317,7 @@ packages:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.6.3):
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
@@ -4378,7 +4416,6 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/type-utils@6.21.0(eslint@8.48.0)(typescript@5.6.3):
     resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
@@ -4398,6 +4435,7 @@ packages:
       typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@typescript-eslint/type-utils@6.21.0(eslint@8.56.0)(typescript@5.6.3):
     resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
@@ -4485,7 +4523,6 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/typescript-estree@5.62.0(typescript@5.6.3):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
@@ -4527,7 +4564,6 @@ packages:
       typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@typescript-eslint/typescript-estree@6.21.0(typescript@5.6.3):
     resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
@@ -4606,7 +4642,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
 
   /@typescript-eslint/utils@5.62.0(eslint@8.48.0)(typescript@5.6.3):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
@@ -4626,6 +4661,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: false
 
   /@typescript-eslint/utils@5.62.0(eslint@8.56.0)(typescript@5.6.3):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
@@ -4664,7 +4700,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
 
   /@typescript-eslint/utils@6.21.0(eslint@8.48.0)(typescript@5.6.3):
     resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
@@ -4683,6 +4718,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: false
 
   /@typescript-eslint/utils@6.21.0(eslint@8.56.0)(typescript@5.6.3):
     resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
@@ -6611,7 +6647,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 6.21.0(eslint@8.48.0)(typescript@5.6.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.48.0)(typescript@5.3.3)
       debug: 3.2.7
       eslint: 8.48.0
       eslint-import-resolver-node: 0.3.9
@@ -6741,7 +6777,7 @@ packages:
         optional: true
     dependencies:
       '@rtsao/scc': 1.1.0
-      '@typescript-eslint/parser': 6.21.0(eslint@8.48.0)(typescript@5.6.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.48.0)(typescript@5.3.3)
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
       array.prototype.flat: 1.3.3
@@ -6897,7 +6933,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: true
 
   /eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.48.0)(jest@29.7.0)(typescript@5.6.3):
     resolution: {integrity: sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==}
@@ -6919,6 +6954,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
+    dev: false
 
   /eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.56.0)(jest@29.7.0)(typescript@5.6.3):
     resolution: {integrity: sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==}
@@ -7023,7 +7059,7 @@ packages:
         optional: true
     dependencies:
       eslint: 8.48.0
-      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.48.0)(jest@29.7.0)(typescript@5.6.3)
+      eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@6.21.0)(eslint@8.48.0)(jest@29.7.0)(typescript@5.3.3)
 
   /eslint-plugin-playwright@0.16.0(eslint-plugin-jest@27.9.0)(eslint@8.56.0):
     resolution: {integrity: sha512-DcHpF0SLbNeh9MT4pMzUGuUSnJ7q5MWbP8sSEFIMS6j7Ggnduq8ghNlfhURgty4c1YFny7Ge9xYTO1FSAoV2Vw==}
@@ -9276,6 +9312,13 @@ packages:
     dependencies:
       yallist: 3.1.1
 
+  /lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+    dependencies:
+      yallist: 4.0.0
+    dev: false
+
   /magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
     dependencies:
@@ -9705,7 +9748,7 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /next@15.1.4(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@18.3.1)(react@19.1.0-canary-d55cc79b-20250228):
+  /next@15.1.4(@babel/core@7.26.9)(@opentelemetry/api@1.9.0)(react-dom@18.3.1)(react@19.1.0-canary-443b7ff2-20250303):
     resolution: {integrity: sha512-mTaq9dwaSuwwOrcu3ebjDYObekkxRnXpuVL21zotM8qE2W0HBOdVIdg2Li9QjMEZrj73LN96LcWcz62V19FjAg==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
@@ -9733,9 +9776,9 @@ packages:
       busboy: 1.6.0
       caniuse-lite: 1.0.30001701
       postcss: 8.4.31
-      react: 19.1.0-canary-d55cc79b-20250228
-      react-dom: 18.3.1(react@19.1.0-canary-d55cc79b-20250228)
-      styled-jsx: 5.1.6(@babel/core@7.26.9)(react@19.1.0-canary-d55cc79b-20250228)
+      react: 19.1.0-canary-443b7ff2-20250303
+      react-dom: 18.3.1(react@19.1.0-canary-443b7ff2-20250303)
+      styled-jsx: 5.1.6(@babel/core@7.26.9)(react@19.1.0-canary-443b7ff2-20250303)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.1.4
       '@next/swc-darwin-x64': 15.1.4
@@ -10555,13 +10598,13 @@ packages:
       scheduler: 0.23.2
     dev: false
 
-  /react-dom@18.3.1(react@19.1.0-canary-d55cc79b-20250228):
+  /react-dom@18.3.1(react@19.1.0-canary-443b7ff2-20250303):
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
     dependencies:
       loose-envify: 1.4.0
-      react: 19.1.0-canary-d55cc79b-20250228
+      react: 19.1.0-canary-443b7ff2-20250303
       scheduler: 0.23.2
 
   /react-dom@19.0.0(react@19.0.0):
@@ -10675,8 +10718,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /react@19.1.0-canary-d55cc79b-20250228:
-    resolution: {integrity: sha512-H/z8xXo1/5UgzzDz9p2dnb2GpaRSLyr4G9S58XZFdSPfz5yRpafOJvgRXArB1eqXXX1+JZmGgEV4ZVg/afQ1qw==}
+  /react@19.1.0-canary-443b7ff2-20250303:
+    resolution: {integrity: sha512-vvP+6z/lNdJ6Th54WM16bpBKcPI12amOW/98USDg+1deXhSdFRyDvk2cMD1mwaZmK8jAtg2zjb4aDt3ipHH6WA==}
     engines: {node: '>=0.10.0'}
 
   /read-cache@1.0.0:
@@ -10985,6 +11028,14 @@ packages:
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
+
+  /semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: false
 
   /semver@7.7.1:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
@@ -11569,7 +11620,7 @@ packages:
       react: 19.0.0-rc.1
     dev: false
 
-  /styled-jsx@5.1.6(@babel/core@7.26.9)(react@19.1.0-canary-d55cc79b-20250228):
+  /styled-jsx@5.1.6(@babel/core@7.26.9)(react@19.1.0-canary-443b7ff2-20250303):
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -11584,7 +11635,7 @@ packages:
     dependencies:
       '@babel/core': 7.26.9
       client-only: 0.0.1
-      react: 19.1.0-canary-d55cc79b-20250228
+      react: 19.1.0-canary-443b7ff2-20250303
     dev: true
 
   /sucrase@3.35.0:
@@ -11900,7 +11951,6 @@ packages:
       typescript: '>=4.2.0'
     dependencies:
       typescript: 5.3.3
-    dev: true
 
   /ts-api-utils@1.4.3(typescript@5.6.3):
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
@@ -12026,7 +12076,6 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 5.3.3
-    dev: true
 
   /tsutils@3.21.0(typescript@5.6.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -12197,7 +12246,6 @@ packages:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /typescript@5.6.1-rc:
     resolution: {integrity: sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ==}
@@ -12730,6 +12778,10 @@ packages:
 
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  /yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+    dev: false
 
   /yaml@2.3.4:
     resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}

--- a/turbo.json
+++ b/turbo.json
@@ -13,8 +13,8 @@
         "EDGE_CONFIG",
         "FLAGS_SECRET",
         "FLAGS",
-        "LD_PROJECT_SLUG",
-        "LD_CLIENT_SIDE_KEY",
+        "LAUNCHDARKLY_CLIENT_SIDE_ID",
+        "LAUNCHDARKLY_PROJECT_SLUG",
         "BACKEND_URL"
       ],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]


### PR DESCRIPTION
This adds a basic LaunchDarkly adapter
- The adapter currently requires Edge Config, due to a limitation in the LaunchDarkly SDK
- The adapter only evaluates feature flags, but does not implement LaunchDarkly's experimentation features

Same code as originally written by @AndyBitz in #2, but with merge conflicts resolved.