### PR TITLE
launchDarkly » ldAdapter

### DIFF
--- a/.changeset/modern-boxes-fail.md
+++ b/.changeset/modern-boxes-fail.md
@@ -1,0 +1,5 @@
+---
+'@flags-sdk/launchdarkly': patch
+---
+
+expose ldAdapter.ldClient

--- a/.changeset/twelve-shirts-pay.md
+++ b/.changeset/twelve-shirts-pay.md
@@ -1,0 +1,5 @@
+---
+'@flags-sdk/launchdarkly': patch
+---
+
+expose as ldAdapter

--- a/packages/adapter-launchdarkly/README.md
+++ b/packages/adapter-launchdarkly/README.md
@@ -14,10 +14,10 @@ npm i @flags-sdk/launchdarkly
 
 **NOTE:** The [LaunchDarkly Vercel integration](https://vercel.com/integrations/launchdarkly) must be installed on your account, as this adapter loads LaunchDarkly from Edge Config. The adapter can not be used without Edge Config.
 
-Import the default adapter instance `launchDarkly` from `@flags-sdk/launchdarkly`:
+Import the default adapter instance `ldAdapter` from `@flags-sdk/launchdarkly`:
 
 ```ts
-import { launchDarkly } from '@flags-sdk/launchdarkly';
+import { ldAdapter } from '@flags-sdk/launchdarkly';
 ```
 
 The default adapter uses the following environment variables to configure itself:
@@ -33,7 +33,7 @@ export EDGE_CONFIG="https://edge-config.vercel.com/ecfg_abdc1234?token=xxx-xxx-x
 
 ```ts
 import { flag, dedupe } from 'flags/next';
-import { launchDarkly, type LDContext } from '@flags-sdk/launchdarkly';
+import { ldAdapter, type LDContext } from '@flags-sdk/launchdarkly';
 
 const identify = dedupe(async (): Promise<LDContext> => {
   return {
@@ -44,7 +44,7 @@ const identify = dedupe(async (): Promise<LDContext> => {
 export const showBanner = flag<boolean, LDContext>({
   key: 'show-banner',
   identify,
-  adapter: launchDarkly(),
+  adapter: ldAdapter(),
 });
 ```
 

--- a/packages/adapter-launchdarkly/src/index.ts
+++ b/packages/adapter-launchdarkly/src/index.ts
@@ -60,7 +60,7 @@ export function createLaunchDarklyAdapter({
   };
 }
 
-export function launchDarkly<ValueType>(
+export function ldAdapter<ValueType>(
   options?: AdapterOptions<ValueType>,
 ): Adapter<ValueType, LDContext> {
   if (!defaultLaunchDarklyAdapter) {
@@ -77,3 +77,10 @@ export function launchDarkly<ValueType>(
 
   return defaultLaunchDarklyAdapter(options);
 }
+
+/**
+ * This is the previous name for the LaunchDarkly adapter.
+ *
+ * @deprecated Use `ldAdapter` instead.
+ */
+export const launchDarkly = ldAdapter;

--- a/packages/adapter-launchdarkly/src/index.ts
+++ b/packages/adapter-launchdarkly/src/index.ts
@@ -35,16 +35,20 @@ export function createLaunchDarklyAdapter({
   projectSlug: string;
   clientSideId: string;
   edgeConfigConnectionString: string;
-}) {
+}): {
+  <ValueType>(
+    options?: AdapterOptions<ValueType>,
+  ): Adapter<ValueType, LDContext>;
+  /** The LaunchDarkly client instance used by the adapter. */
+  ldClient: LDClient;
+} {
   const edgeConfigClient = createClient(edgeConfigConnectionString);
   const ldClient = init(clientSideId, edgeConfigClient);
 
-  return function launchDarklyAdapter<ValueType>(
+  const launchDarklyAdapter = function launchDarklyAdapter<ValueType>(
     options: AdapterOptions<ValueType> = {},
-  ): Adapter<ValueType, LDContext> & { ldClient: LDClient } {
+  ): Adapter<ValueType, LDContext> {
     return {
-      /** The LaunchDarkly client instance used by the adapter. */
-      ldClient,
       origin(key) {
         return `https://app.launchdarkly.com/projects/${projectSlug}/flags/${key}/`;
       },
@@ -58,6 +62,10 @@ export function createLaunchDarklyAdapter({
       },
     };
   };
+
+  launchDarklyAdapter.ldClient = ldClient;
+
+  return launchDarklyAdapter;
 }
 
 export function ldAdapter<ValueType>(


### PR DESCRIPTION
Rename the adapter, while still exposing the original name.