### PR TITLE
fill out metadata

### DIFF
--- a/.changeset/ninety-bottles-relax.md
+++ b/.changeset/ninety-bottles-relax.md
@@ -1,0 +1,5 @@
+---
+'@flags-sdk/launchdarkly': patch
+---
+
+add metadata to package.json

--- a/packages/adapter-launchdarkly/package.json
+++ b/packages/adapter-launchdarkly/package.json
@@ -1,8 +1,23 @@
 {
   "name": "@flags-sdk/launchdarkly",
   "version": "0.2.1",
-  "description": "",
-  "keywords": [],
+  "description": "LaunchDarkly provider for the Flags SDK",
+  "keywords": [
+    "flags-sdk",
+    "launchdarkly",
+    "vercel",
+    "edge config",
+    "feature flags",
+    "flags"
+  ],
+  "homepage": "https://flags-sdk.dev",
+  "bugs": {
+    "url": "https://github.com/vercel/flags/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vercel/flags.git"
+  },
   "license": "MIT",
   "author": "",
   "sideEffects": false,

--- a/packages/adapter-statsig/package.json
+++ b/packages/adapter-statsig/package.json
@@ -12,7 +12,7 @@
     "experimentation",
     "ab testing"
   ],
-  "homepage": "https://flags-sdk.dev/docs",
+  "homepage": "https://flags-sdk.dev",
   "bugs": {
     "url": "https://github.com/vercel/flags/issues"
   },


### PR DESCRIPTION
Adds more metadata to `@flags-sdk/launchdarkly`'s `package.json`