### PR TITLE
[flags] Add `defaultValue` to `decide` call

### DIFF
--- a/.changeset/popular-eels-heal.md
+++ b/.changeset/popular-eels-heal.md
@@ -1,0 +1,5 @@
+---
+'flags': minor
+---
+
+Pass the `defaultValue` to the adapter's decide function

--- a/.changeset/popular-eels-heal.md
+++ b/.changeset/popular-eels-heal.md
@@ -1,5 +1,5 @@
 ---
-'flags': minor
+'flags': patch
 ---
 
 Pass the `defaultValue` to the adapter's decide function

--- a/packages/flags/src/next/index.test.ts
+++ b/packages/flags/src/next/index.test.ts
@@ -531,4 +531,19 @@ describe('adapters', () => {
     );
     expect(f).toHaveProperty('origin', 'fake-origin#adapter-flag');
   });
+
+  it("should pass the defaultValue to the adapter's decide function", async () => {
+    const outerValue = Math.random();
+
+    const exampleFlag = flag<number>({
+      key: 'example-flag',
+      defaultValue: outerValue,
+      adapter: {
+        decide: ({ defaultValue }) => defaultValue || -1,
+        origin: (key) => `fake-origin#${key}`,
+      },
+    });
+
+    expect(await exampleFlag()).toBe(outerValue);
+  });
 });

--- a/packages/flags/src/next/index.ts
+++ b/packages/flags/src/next/index.ts
@@ -283,6 +283,8 @@ function getRun<ValueType, EntitiesType>(
     // Also fall back to defaultValue when the decide function returns undefined or throws an error.
     const decisionPromise = (async () => {
       return decide({
+        // @ts-expect-error TypeScript will not be able to process `getPrecomputed` when added to `Decide`. It is, however, part of the `Adapter` type
+        defaultValue: definition.defaultValue,
         headers: readonlyHeaders,
         cookies: readonlyCookies,
         entities,


### PR DESCRIPTION
Was originally part of #2 but got removed before shipping.

We're adding it so the Adapter's decide function can make use of the `defaultValue` the client set.