### PR TITLE
(flags-sdk/statsig) Reduce sync delay when using Edge Config

### DIFF
--- a/.changeset/afraid-frogs-kiss.md
+++ b/.changeset/afraid-frogs-kiss.md
@@ -1,0 +1,5 @@
+---
+'@flags-sdk/statsig': minor
+---
+
+If using an Edge Config adapter, reduce minimum sync delay for config specs from 5000ms->20ms

--- a/.changeset/afraid-frogs-kiss.md
+++ b/.changeset/afraid-frogs-kiss.md
@@ -1,5 +1,0 @@
----
-'@flags-sdk/statsig': minor
----
-
-If using an Edge Config adapter, reduce minimum sync delay for config specs from 5000ms->20ms

--- a/.changeset/small-panthers-rule.md
+++ b/.changeset/small-panthers-rule.md
@@ -1,0 +1,5 @@
+---
+'@flags-sdk/statsig': patch
+---
+
+If using an Edge Config adapter, reduce minimum sync delay for config specs from 5000ms->1000ms

--- a/packages/adapter-statsig/src/index.ts
+++ b/packages/adapter-statsig/src/index.ts
@@ -100,7 +100,8 @@ export function createStatsigAdapter(options: {
     return user != null && typeof user === 'object';
   };
 
-  const syncHandler = createSyncingHandler();
+  const minSyncDelayMs = options.edgeConfig ? 20 : 5_000;
+  const syncHandler = createSyncingHandler(minSyncDelayMs);
 
   async function predecide(user?: StatsigUser): Promise<StatsigUser> {
     await initialize();

--- a/packages/adapter-statsig/src/index.ts
+++ b/packages/adapter-statsig/src/index.ts
@@ -100,7 +100,7 @@ export function createStatsigAdapter(options: {
     return user != null && typeof user === 'object';
   };
 
-  const minSyncDelayMs = options.edgeConfig ? 20 : 5_000;
+  const minSyncDelayMs = options.edgeConfig ? 1_000 : 5_000;
   const syncHandler = createSyncingHandler(minSyncDelayMs);
 
   async function predecide(user?: StatsigUser): Promise<StatsigUser> {


### PR DESCRIPTION
If using an Edge Config adapter, reduce minimum sync delay for config specs from 5000ms->20ms