### PR TITLE
fix (OTEL): Rethrow React postpone errors

### DIFF
--- a/.changeset/itchy-drinks-repair.md
+++ b/.changeset/itchy-drinks-repair.md
@@ -1,0 +1,5 @@
+---
+'flags': patch
+---
+
+Rethrow React postpone errors in OTEL tracing


### PR DESCRIPTION
I've observed OTEL spans reporting a React error:

> [route] needs to bail out of prerendering at this point because it used headers. React throws this special object to indicate where. It should not be caught by your own try/catch. Learn more: https://nextjs.org/docs/messages/ppr-caught-error

It indicates to me that we must throw the error within a catch statement in the tracing function