### PR TITLE
allow clearing the dedupe cache

### DIFF
--- a/.changeset/twelve-feet-glow.md
+++ b/.changeset/twelve-feet-glow.md
@@ -1,0 +1,5 @@
+---
+'flags': patch
+---
+
+allow clearing the dedupe cache

--- a/.changeset/twelve-feet-glow.md
+++ b/.changeset/twelve-feet-glow.md
@@ -2,4 +2,4 @@
 'flags': patch
 ---
 
-- expose `clearCacheForCurrentRequest` to allow clearing the cache of a deduped function for the current request
+- expose `clearDedupeCacheForCurrentRequest` to allow clearing the cache of a deduped function for the current request

--- a/.changeset/twelve-feet-glow.md
+++ b/.changeset/twelve-feet-glow.md
@@ -2,4 +2,4 @@
 'flags': patch
 ---
 
-allow clearing the dedupe cache
+- expose `clearCacheForCurrentRequest` to allow clearing the cache of a deduped function for the current request

--- a/packages/flags/src/next/dedupe.test.ts
+++ b/packages/flags/src/next/dedupe.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, Mock, vitest, vi } from 'vitest';
-import { clearCacheForCurrentRequest, dedupe } from './dedupe';
+import { clearDedupeCacheForCurrentRequest, dedupe } from './dedupe';
 
 const mocks = vi.hoisted(() => {
   return {
@@ -200,7 +200,7 @@ describe('dedupe', () => {
 
       await deduped();
       await deduped();
-      await clearCacheForCurrentRequest(deduped);
+      await clearDedupeCacheForCurrentRequest(deduped);
       await deduped();
       await deduped();
 
@@ -232,7 +232,7 @@ describe('dedupe', () => {
 
       // now clear one cache but not the other, and call once for each request
       headersMock.mockReturnValue(same);
-      await clearCacheForCurrentRequest(deduped);
+      await clearDedupeCacheForCurrentRequest(deduped);
       await deduped();
 
       headersMock.mockReturnValue(other);

--- a/packages/flags/src/next/dedupe.test.ts
+++ b/packages/flags/src/next/dedupe.test.ts
@@ -190,6 +190,24 @@ describe('dedupe', () => {
     });
   });
 
+  describe('clearCurrent', () => {
+    it('should allow dedupe to be cleared within same request', async () => {
+      const fn = vitest.fn();
+      const deduped = dedupe(fn);
+      const same = new Headers();
+      const headersMock = await getHeadersMock();
+      headersMock.mockReturnValue(same);
+
+      await deduped();
+      await deduped();
+      await deduped.clearDedupeCacheForCurrentRequest();
+      await deduped();
+      await deduped();
+
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('promises', () => {
     it('should dedupe even when the promise has not resolved yet', async () => {
       let resolvePromise: (value: unknown) => void = () => {

--- a/packages/flags/src/next/index.test.ts
+++ b/packages/flags/src/next/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, it, describe, vi, beforeAll } from 'vitest';
-import { flag, precompute } from '.';
+import { flag, precompute, dedupe, clearDedupeCacheForCurrentRequest } from '.';
 import { IncomingMessage } from 'node:http';
 import { NextApiRequestCookies } from 'next/dist/server/api-utils';
 import { Readable } from 'node:stream';
@@ -41,6 +41,21 @@ function createRequest(cookies = {}): [
 
   return [request, socket];
 }
+
+describe('exports', () => {
+  it('should export flag', () => {
+    expect(typeof flag).toBe('function');
+  });
+  it('should export precompute', () => {
+    expect(typeof precompute).toBe('function');
+  });
+  it('should export dedupe', () => {
+    expect(typeof dedupe).toBe('function');
+  });
+  it('should export clearDedupeCacheForCurrentRequest', () => {
+    expect(typeof clearDedupeCacheForCurrentRequest).toBe('function');
+  });
+});
 
 describe('flag on app router', () => {
   beforeAll(() => {

--- a/packages/flags/src/next/index.ts
+++ b/packages/flags/src/next/index.ts
@@ -483,5 +483,5 @@ export function getProviderData(
   return { definitions, hints: [] };
 }
 
-export { dedupe } from './dedupe';
+export { dedupe, clearDedupeCacheForCurrentRequest } from './dedupe';
 export { createFlagsDiscoveryEndpoint } from './create-flags-discovery-endpoint';


### PR DESCRIPTION
Allows clearing the dedupe cache for the current request

```ts
import { dedupe, clearDedupeCacheForCurrentRequest } from 'flags/next';

export const getCartId = dedupe(async () => {
  return Math.random()
});

// later during request lifecycle
await getCartId() // 0.7663811701171378
await getCartId() // 0.7663811701171378
await clearDedupeCacheForCurrentRequest(getCartId);
await getCartId() // 0.42921389424642964
```

Fixes #135