### PR TITLE
Posthog provider: enable discovery of disabled flags.

### DIFF
--- a/packages/adapter-posthog/src/provider/index.ts
+++ b/packages/adapter-posthog/src/provider/index.ts
@@ -63,7 +63,7 @@ export async function getProviderData(options: {
   };
 
   const res = await fetch(
-    `${host}/api/projects/${options.projectId}/feature_flags?active=true`,
+    `${host}/api/projects/${options.projectId}/feature_flags`,
     {
       method: 'GET',
       headers,
@@ -91,7 +91,7 @@ export async function getProviderData(options: {
     // paginate in a parallel request
     for (let offset = 100; offset < data.count; offset += 100) {
       const paginatedRes = await fetch(
-        `${host}/api/projects/${options.projectId}/feature_flags?active=true&offset=${offset}&limit=100`,
+        `${host}/api/projects/${options.projectId}/feature_flags?offset=${offset}&limit=100`,
         {
           method: 'GET',
           headers,


### PR DESCRIPTION
Leaving out the `active=true` flag in the posthog request allows the provider to discover flags that are deactivated in Posthog. Previously these flags were not listed in Flags Explorer.
Deleted flags will not be fetched with this request.

Fixes some issues of #152 
