### PR TITLE
perf: avoid initialized() call

### DIFF
--- a/.changeset/slow-ears-sin.md
+++ b/.changeset/slow-ears-sin.md
@@ -1,0 +1,5 @@
+---
+'@flags-sdk/launchdarkly': patch
+---
+
+Improve performance by avoiding the `ldClient.initialized()` call

--- a/package.json
+++ b/package.json
@@ -60,5 +60,11 @@
   "packageManager": "pnpm@8.7.1",
   "engines": {
     "node": ">=18"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@launchdarkly/js-server-sdk-common@2.11.1": "patches/@launchdarkly__js-server-sdk-common@2.11.1.patch",
+      "@launchdarkly/vercel-server-sdk@1.3.23": "patches/@launchdarkly__vercel-server-sdk@1.3.23.patch"
+    }
   }
 }

--- a/packages/adapter-launchdarkly/src/index.ts
+++ b/packages/adapter-launchdarkly/src/index.ts
@@ -76,15 +76,18 @@ export function createLaunchDarklyAdapter({
     return `https://app.launchdarkly.com/projects/${projectSlug}/flags/${key}/`;
   }
 
+  let initialized = false;
+
   function variation<ValueType>(
     options: AdapterOptions<ValueType> = {},
   ): Adapter<ValueType, LDContext> {
     return {
       origin,
       async decide({ key, entities, headers }): Promise<ValueType> {
-        if (!ldClient.initialized()) {
+        if (!initialized) {
           if (!initPromise) initPromise = ldClient.waitForInitialization();
           await initPromise;
+          initialized = true;
         }
 
         return store.run(

--- a/patches/@launchdarkly__js-server-sdk-common@2.11.1.patch
+++ b/patches/@launchdarkly__js-server-sdk-common@2.11.1.patch
@@ -1,0 +1,16 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index f38bcc612ee241e19598cf83aa24f555fb219cc8..0000000000000000000000000000000000000000
+diff --git a/dist/store/serialization.js b/dist/store/serialization.js
+index 21a7a5415c077d272cc4c6f50a03c232351eb17a..60ed113c58884be3b3e7b7287c1b7120a9e34dc3 100644
+--- a/dist/store/serialization.js
++++ b/dist/store/serialization.js
+@@ -225,7 +225,7 @@ exports.deserializeAll = deserializeAll;
+  * @returns The parsed and processed data.
+  */
+ function deserializePoll(data) {
+-    const parsed = tryParse(data);
++    const parsed = data && typeof data !== 'string' ? data : tryParse(data);
+     if (!parsed) {
+         return undefined;
+     }

--- a/patches/@launchdarkly__vercel-server-sdk@1.3.23.patch
+++ b/patches/@launchdarkly__vercel-server-sdk@1.3.23.patch
@@ -1,0 +1,29 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index a099f5d92067f10db29adc9e24162702a53a441b..0000000000000000000000000000000000000000
+diff --git a/dist/cjs/src/index.js b/dist/cjs/src/index.js
+index d7aed6a778023742931dc5ddc127d9598ef2de84..b284cf3fb51fa6b0d7d2756b6a1284a67612de06 100644
+--- a/dist/cjs/src/index.js
++++ b/dist/cjs/src/index.js
+@@ -46,7 +46,7 @@ const init = (sdkKey, edgeConfig, options = {}) => {
+     const edgeProvider = {
+         get: async (rootKey) => {
+             const json = await edgeConfig.get(rootKey);
+-            return json ? JSON.stringify(json) : null;
++            return json || null;
+         },
+     };
+     return (0, js_server_sdk_common_edge_1.init)(sdkKey, (0, createPlatformInfo_1.default)(), Object.assign({ featureStore: new js_server_sdk_common_edge_1.EdgeFeatureStore(edgeProvider, sdkKey, 'Vercel', logger), logger }, options));
+diff --git a/dist/esm/src/index.js b/dist/esm/src/index.js
+index a98507e9798d97deb4f9453f0d7dba186d499a99..5e816df08c725ce6a8c8e01211563434f1843405 100644
+--- a/dist/esm/src/index.js
++++ b/dist/esm/src/index.js
+@@ -29,7 +29,7 @@ export const init = (sdkKey, edgeConfig, options = {}) => {
+     const edgeProvider = {
+         get: async (rootKey) => {
+             const json = await edgeConfig.get(rootKey);
+-            return json ? JSON.stringify(json) : null;
++            return json || null;
+         },
+     };
+     return initEdge(sdkKey, createPlatformInfo(), Object.assign({ featureStore: new EdgeFeatureStore(edgeProvider, sdkKey, 'Vercel', logger), logger }, options));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,14 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@launchdarkly/js-server-sdk-common@2.11.1':
+    hash: 2htdmklwzagmyzjqexyrwmj7le
+    path: patches/@launchdarkly__js-server-sdk-common@2.11.1.patch
+  '@launchdarkly/vercel-server-sdk@1.3.23':
+    hash: rbsl6fiv2mx36b47kohmf4s73a
+    path: patches/@launchdarkly__vercel-server-sdk@1.3.23.patch
+
 importers:
 
   .:
@@ -514,7 +522,7 @@ importers:
     dependencies:
       '@launchdarkly/vercel-server-sdk':
         specifier: ^1.3.23
-        version: 1.3.23
+        version: 1.3.23(patch_hash=rbsl6fiv2mx36b47kohmf4s73a)
       '@vercel/edge-config':
         specifier: ^1.4.0
         version: 1.4.0
@@ -754,7 +762,7 @@ importers:
         version: 5.10.0
       react-dom:
         specifier: '*'
-        version: 19.0.0(react@19.2.0-canary-526dd340-20250602)
+        version: 19.0.0(react@19.2.0-canary-3958d5d8-20250807)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 0.17.3
@@ -776,10 +784,10 @@ importers:
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       next:
         specifier: 15.1.4
-        version: 15.1.4(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.0.0)(react@19.2.0-canary-526dd340-20250602)
+        version: 15.1.4(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.0.0)(react@19.2.0-canary-3958d5d8-20250807)
       react:
         specifier: canary
-        version: 19.2.0-canary-526dd340-20250602
+        version: 19.2.0-canary-3958d5d8-20250807
       tsconfig:
         specifier: workspace:*
         version: link:../../tooling/tsconfig
@@ -3193,7 +3201,7 @@ packages:
   /@launchdarkly/js-server-sdk-common-edge@2.5.4:
     resolution: {integrity: sha512-L79FsZfAosYMHE/eg3p7KFLiWHJn3TCdEAL89frzMOLv0e43xTp4xQEDnTovWKQpAN7gH1iYDLwKUpoWgUAS2g==}
     dependencies:
-      '@launchdarkly/js-server-sdk-common': 2.11.1
+      '@launchdarkly/js-server-sdk-common': 2.11.1(patch_hash=2htdmklwzagmyzjqexyrwmj7le)
       crypto-js: 4.2.0
     dev: false
 
@@ -3204,12 +3212,13 @@ packages:
       semver: 7.5.4
     dev: false
 
-  /@launchdarkly/js-server-sdk-common@2.11.1:
+  /@launchdarkly/js-server-sdk-common@2.11.1(patch_hash=2htdmklwzagmyzjqexyrwmj7le):
     resolution: {integrity: sha512-mz5meN+tII/By8TjPRhuI5SSztFSIYXQpK1IlUX1uUlM8xDlS/HrzM4KcP7BRLpO0TQcZKl4roEkkoMBoukPsA==}
     dependencies:
       '@launchdarkly/js-sdk-common': 2.13.0
       semver: 7.5.4
     dev: false
+    patched: true
 
   /@launchdarkly/vercel-server-sdk@1.3.21:
     resolution: {integrity: sha512-ELt4fYXXpHzixLvZOWG+T82RVGmI1iKwOlpV8YfxW8FISmlTfF7xmSlH6mTUSRMA3Q5xIzYnXuk9XaTc/F8tag==}
@@ -3221,7 +3230,7 @@ packages:
       - '@opentelemetry/api'
     dev: false
 
-  /@launchdarkly/vercel-server-sdk@1.3.23:
+  /@launchdarkly/vercel-server-sdk@1.3.23(patch_hash=rbsl6fiv2mx36b47kohmf4s73a):
     resolution: {integrity: sha512-1QcUA+QD69bbPwDWCg5PpEvRmbi8FHv1D22OECHtChKnmSlw28orHnmfw7MqcgVVZu5z2x91q/Gs37VMNkh3Ig==}
     dependencies:
       '@launchdarkly/js-server-sdk-common-edge': 2.5.4
@@ -3230,6 +3239,7 @@ packages:
     transitivePeerDependencies:
       - '@opentelemetry/api'
     dev: false
+    patched: true
 
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -11320,7 +11330,7 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /next@15.1.4(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.0.0)(react@19.2.0-canary-526dd340-20250602):
+  /next@15.1.4(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.0.0)(react@19.2.0-canary-3958d5d8-20250807):
     resolution: {integrity: sha512-mTaq9dwaSuwwOrcu3ebjDYObekkxRnXpuVL21zotM8qE2W0HBOdVIdg2Li9QjMEZrj73LN96LcWcz62V19FjAg==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
@@ -11348,9 +11358,9 @@ packages:
       busboy: 1.6.0
       caniuse-lite: 1.0.30001704
       postcss: 8.4.31
-      react: 19.2.0-canary-526dd340-20250602
-      react-dom: 19.0.0(react@19.2.0-canary-526dd340-20250602)
-      styled-jsx: 5.1.6(@babel/core@7.26.10)(react@19.2.0-canary-526dd340-20250602)
+      react: 19.2.0-canary-3958d5d8-20250807
+      react-dom: 19.0.0(react@19.2.0-canary-3958d5d8-20250807)
+      styled-jsx: 5.1.6(@babel/core@7.26.10)(react@19.2.0-canary-3958d5d8-20250807)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.1.4
       '@next/swc-darwin-x64': 15.1.4
@@ -12205,12 +12215,12 @@ packages:
       scheduler: 0.25.0
     dev: false
 
-  /react-dom@19.0.0(react@19.2.0-canary-526dd340-20250602):
+  /react-dom@19.0.0(react@19.2.0-canary-3958d5d8-20250807):
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
       react: ^19.0.0
     dependencies:
-      react: 19.2.0-canary-526dd340-20250602
+      react: 19.2.0-canary-3958d5d8-20250807
       scheduler: 0.25.0
 
   /react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028):
@@ -12315,8 +12325,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /react@19.2.0-canary-526dd340-20250602:
-    resolution: {integrity: sha512-Ebiwh5tDLCZx7z5KYQQ3IPezOKbgN2ZPGXLh/akSEd3ve6NhMj/Zy+x7lnMVweFil29iC16ujVeLCGU5wf+R5w==}
+  /react@19.2.0-canary-3958d5d8-20250807:
+    resolution: {integrity: sha512-CSMwokRgyNr6O1eXKtPOqoD0vpOT4KFQIVALpw0iSjOYmCp7ecx2MgUyvI33jGE9dm76TIwORV+N7gQdODPo1g==}
     engines: {node: '>=0.10.0'}
 
   /read-cache@1.0.0:
@@ -13206,7 +13216,7 @@ packages:
       react: 19.0.0-rc.1
     dev: false
 
-  /styled-jsx@5.1.6(@babel/core@7.26.10)(react@19.2.0-canary-526dd340-20250602):
+  /styled-jsx@5.1.6(@babel/core@7.26.10)(react@19.2.0-canary-3958d5d8-20250807):
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -13221,7 +13231,7 @@ packages:
     dependencies:
       '@babel/core': 7.26.10
       client-only: 0.0.1
-      react: 19.2.0-canary-526dd340-20250602
+      react: 19.2.0-canary-3958d5d8-20250807
     dev: true
 
   /sucrase@3.35.0:


### PR DESCRIPTION
- Avoid calling `initialized()` as it may do more work than necessary (v0.3.2-ef90ab28-20250809114336)
- Patches LaunchDarkly's SDKs to avoid what results in essentially an unnecessary JSON.parse(JSON.stringify(item)) (v0.3.2-bcda87d5-20250809122704)