### PR TITLE
chore: add test `.env` files

### DIFF
--- a/examples/shirt-shop/.env
+++ b/examples/shirt-shop/.env
@@ -1,0 +1,2 @@
+# this is a random secret that can be used for testing
+FLAGS_SECRET=testing-secret-2pMFwxPkTiHKcrwRfFllrhT1KAc8

--- a/examples/snippets/.env
+++ b/examples/snippets/.env
@@ -1,0 +1,2 @@
+# this is a random secret that can be used for testing
+FLAGS_SECRET=testing-secret-2pMFwxPkTiHKcrwRfFllrhT1KAc8

--- a/examples/sveltekit-example/.env
+++ b/examples/sveltekit-example/.env
@@ -1,0 +1,2 @@
+# this is a random secret that can be used for testing
+FLAGS_SECRET=testing-secret-2pMFwxPkTiHKcrwRfFllrhT1KAc8

--- a/tests/sveltekit-e2e/.env
+++ b/tests/sveltekit-e2e/.env
@@ -1,0 +1,2 @@
+# this is a random secret that can be used for testing
+FLAGS_SECRET=testing-secret-2pMFwxPkTiHKcrwRfFllrhT1KAc8


### PR DESCRIPTION
this adds some more stub `.env` files, like we already have for `tests/next-*`, for example:

https://github.com/vercel/flags/blob/db89f0dfb1803fa9d64cfd49020fd0d61f18e2fa/tests/next-13/.env#L1-L2

the aim here is for `pnpm build` to _succeed_ with a fresh clone of this repo as an outside contributor...

we still do have one issue, which we might be able to fix with a read-only connection string (cc: @dferber90):

- [ ] `snippets:build`: `Error: Edge Config Adapter: Missing connection string`