### PR TITLE
[adapter-launch-darkly] Bump `vercel-server-sdk` to `1.3.33`

### DIFF
--- a/.changeset/rotten-donkeys-bow.md
+++ b/.changeset/rotten-donkeys-bow.md
@@ -1,0 +1,5 @@
+---
+'@flags-sdk/launchdarkly': patch
+---
+
+Update `@launchdarkly/vercel-server-sdk` to `1.3.33` which removes serialization overhead for Edge Config

--- a/packages/adapter-launchdarkly/package.json
+++ b/packages/adapter-launchdarkly/package.json
@@ -51,7 +51,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@launchdarkly/vercel-server-sdk": "^1.3.23",
+    "@launchdarkly/vercel-server-sdk": "^1.3.33",
     "@vercel/edge-config": "^1.4.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -392,6 +392,38 @@ importers:
       flagsmith:
         specifier: ^9.0.5
         version: 9.0.5
+    devDependencies:
+      '@types/node':
+        specifier: 20.11.17
+        version: 20.11.17
+      eslint-config-custom:
+        specifier: workspace:*
+        version: link:../../tooling/eslint-config-custom
+      flags:
+        specifier: workspace:*
+        version: link:../flags
+      msw:
+        specifier: 2.6.4
+        version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
+      rimraf:
+        specifier: 6.0.1
+        version: 6.0.1
+      tsconfig:
+        specifier: workspace:*
+        version: link:../../tooling/tsconfig
+      tsup:
+        specifier: 8.0.1
+        version: 8.0.1(typescript@5.6.3)
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
+      vite:
+        specifier: 5.1.1
+        version: 5.1.1(@types/node@20.11.17)
+      vitest:
+        specifier: 1.4.0
+        version: 1.4.0(@types/node@20.11.17)
+
   packages/adapter-growthbook:
     dependencies:
       '@growthbook/growthbook':
@@ -518,8 +550,8 @@ importers:
   packages/adapter-launchdarkly:
     dependencies:
       '@launchdarkly/vercel-server-sdk':
-        specifier: ^1.3.23
-        version: 1.3.23
+        specifier: ^1.3.33
+        version: 1.3.33
       '@vercel/edge-config':
         specifier: ^1.4.0
         version: 1.4.0
@@ -759,7 +791,7 @@ importers:
         version: 5.10.0
       react-dom:
         specifier: '*'
-        version: 19.0.0(react@19.2.0-canary-526dd340-20250602)
+        version: 19.0.0(react@19.2.0-canary-bb6f0c8d-20250901)
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: 0.17.3
@@ -781,10 +813,10 @@ importers:
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       next:
         specifier: 15.1.4
-        version: 15.1.4(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.0.0)(react@19.2.0-canary-526dd340-20250602)
+        version: 15.1.4(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.0.0)(react@19.2.0-canary-bb6f0c8d-20250901)
       react:
         specifier: canary
-        version: 19.2.0-canary-526dd340-20250602
+        version: 19.2.0-canary-bb6f0c8d-20250901
       tsconfig:
         specifier: workspace:*
         version: link:../../tooling/tsconfig
@@ -3184,8 +3216,8 @@ packages:
     resolution: {integrity: sha512-HIDxvgo1vksC9hsYy3517sgW0Ql+iW3fgwlq/CEigeBNmaa9/J1Pxo7LrKPzezEA0kaGedmt/DCzVVxVBmxSsQ==}
     dev: false
 
-  /@launchdarkly/js-sdk-common@2.13.0:
-    resolution: {integrity: sha512-cRoOQWBEOOynY3YDHIF4am1ZxiGu6MFK4v8WyNR0zN+nVjdQiuuyfAbHB//1Q0nrc1aB0flOy6e8C51eHy+VeA==}
+  /@launchdarkly/js-sdk-common@2.19.0:
+    resolution: {integrity: sha512-p4MU3VxFSxj1T5yGm3OeJAS034nAiISGUF9Av3r9tClRCElcIdj159hADBYCE4VpiH6q+6KJ3cbvXF8v1200+g==}
     dev: false
 
   /@launchdarkly/js-server-sdk-common-edge@2.5.2:
@@ -3195,10 +3227,10 @@ packages:
       crypto-js: 4.2.0
     dev: false
 
-  /@launchdarkly/js-server-sdk-common-edge@2.5.4:
-    resolution: {integrity: sha512-L79FsZfAosYMHE/eg3p7KFLiWHJn3TCdEAL89frzMOLv0e43xTp4xQEDnTovWKQpAN7gH1iYDLwKUpoWgUAS2g==}
+  /@launchdarkly/js-server-sdk-common-edge@2.6.9:
+    resolution: {integrity: sha512-z8rUtlnz527WJRa6IBAJ6SZjJUdbAFz+Fqdc4zZpFgxyYctEcNrrCua96P9IQlM7K+yZp9zggb7oBChPjixZ6g==}
     dependencies:
-      '@launchdarkly/js-server-sdk-common': 2.11.1
+      '@launchdarkly/js-server-sdk-common': 2.16.2
       crypto-js: 4.2.0
     dev: false
 
@@ -3209,10 +3241,10 @@ packages:
       semver: 7.5.4
     dev: false
 
-  /@launchdarkly/js-server-sdk-common@2.11.1:
-    resolution: {integrity: sha512-mz5meN+tII/By8TjPRhuI5SSztFSIYXQpK1IlUX1uUlM8xDlS/HrzM4KcP7BRLpO0TQcZKl4roEkkoMBoukPsA==}
+  /@launchdarkly/js-server-sdk-common@2.16.2:
+    resolution: {integrity: sha512-xjJP1YHdSABgn4whBccaIFK5Mr0e3WVdu47NJoSzbkVEDrr2LaOaya+92vYkuByulObvuGAkhI+ceJhz3G0l2g==}
     dependencies:
-      '@launchdarkly/js-sdk-common': 2.13.0
+      '@launchdarkly/js-sdk-common': 2.19.0
       semver: 7.5.4
     dev: false
 
@@ -3226,10 +3258,10 @@ packages:
       - '@opentelemetry/api'
     dev: false
 
-  /@launchdarkly/vercel-server-sdk@1.3.23:
-    resolution: {integrity: sha512-1QcUA+QD69bbPwDWCg5PpEvRmbi8FHv1D22OECHtChKnmSlw28orHnmfw7MqcgVVZu5z2x91q/Gs37VMNkh3Ig==}
+  /@launchdarkly/vercel-server-sdk@1.3.33:
+    resolution: {integrity: sha512-RYE1q3E+3+xFOs0sbunCcKv2+8qxAH6hKH8EAddhkKT3ERVivsxe1OKoE0qLa87Jzop3nUXNPIPBdy3XLBOEiQ==}
     dependencies:
-      '@launchdarkly/js-server-sdk-common-edge': 2.5.4
+      '@launchdarkly/js-server-sdk-common-edge': 2.6.9
       '@vercel/edge-config': 1.4.0
       crypto-js: 4.2.0
     transitivePeerDependencies:
@@ -11329,7 +11361,7 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /next@15.1.4(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.0.0)(react@19.2.0-canary-526dd340-20250602):
+  /next@15.1.4(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.0.0)(react@19.2.0-canary-bb6f0c8d-20250901):
     resolution: {integrity: sha512-mTaq9dwaSuwwOrcu3ebjDYObekkxRnXpuVL21zotM8qE2W0HBOdVIdg2Li9QjMEZrj73LN96LcWcz62V19FjAg==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
@@ -11357,9 +11389,9 @@ packages:
       busboy: 1.6.0
       caniuse-lite: 1.0.30001704
       postcss: 8.4.31
-      react: 19.2.0-canary-526dd340-20250602
-      react-dom: 19.0.0(react@19.2.0-canary-526dd340-20250602)
-      styled-jsx: 5.1.6(@babel/core@7.26.10)(react@19.2.0-canary-526dd340-20250602)
+      react: 19.2.0-canary-bb6f0c8d-20250901
+      react-dom: 19.0.0(react@19.2.0-canary-bb6f0c8d-20250901)
+      styled-jsx: 5.1.6(@babel/core@7.26.10)(react@19.2.0-canary-bb6f0c8d-20250901)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.1.4
       '@next/swc-darwin-x64': 15.1.4
@@ -12214,12 +12246,12 @@ packages:
       scheduler: 0.25.0
     dev: false
 
-  /react-dom@19.0.0(react@19.2.0-canary-526dd340-20250602):
+  /react-dom@19.0.0(react@19.2.0-canary-bb6f0c8d-20250901):
     resolution: {integrity: sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==}
     peerDependencies:
       react: ^19.0.0
     dependencies:
-      react: 19.2.0-canary-526dd340-20250602
+      react: 19.2.0-canary-bb6f0c8d-20250901
       scheduler: 0.25.0
 
   /react-dom@19.0.0-rc-02c0e824-20241028(react@19.0.0-rc-02c0e824-20241028):
@@ -12324,8 +12356,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /react@19.2.0-canary-526dd340-20250602:
-    resolution: {integrity: sha512-Ebiwh5tDLCZx7z5KYQQ3IPezOKbgN2ZPGXLh/akSEd3ve6NhMj/Zy+x7lnMVweFil29iC16ujVeLCGU5wf+R5w==}
+  /react@19.2.0-canary-bb6f0c8d-20250901:
+    resolution: {integrity: sha512-CztnvJqmshfHfN/P0gJ0pNE9I/oLgdCoXP6Pm3sO6nMP9nFt7S6khW5TuD/CquIXDD62vRtxdGLeYIEfNifPMQ==}
     engines: {node: '>=0.10.0'}
 
   /read-cache@1.0.0:
@@ -12893,6 +12925,7 @@ packages:
   /source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
     dependencies:
       whatwg-url: 7.1.0
     dev: true
@@ -13215,7 +13248,7 @@ packages:
       react: 19.0.0-rc.1
     dev: false
 
-  /styled-jsx@5.1.6(@babel/core@7.26.10)(react@19.2.0-canary-526dd340-20250602):
+  /styled-jsx@5.1.6(@babel/core@7.26.10)(react@19.2.0-canary-bb6f0c8d-20250901):
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -13230,7 +13263,7 @@ packages:
     dependencies:
       '@babel/core': 7.26.10
       client-only: 0.0.1
-      react: 19.2.0-canary-526dd340-20250602
+      react: 19.2.0-canary-bb6f0c8d-20250901
     dev: true
 
   /sucrase@3.35.0:


### PR DESCRIPTION
Bumps the `@launchdarkly/vercel-server-sdk` package to `1.3.33`.
https://github.com/launchdarkly/js-core/releases/tag/vercel-server-sdk-v1.3.33

It includes a change to reduce the serialization overhead when reading from Edge Config, therefore reducing the time it takes to evaluate flags.
