### PR TITLE
perf(flags): use single dynamic import of `next/headers`

### DIFF
--- a/packages/flags/src/next/dedupe.ts
+++ b/packages/flags/src/next/dedupe.ts
@@ -53,10 +53,12 @@ export function dedupe<A extends Array<unknown>, T>(
 ): (...args: A) => Promise<T> {
   const requestStore: RequestStore<T> = new WeakMap<Headers, CacheNode<T>>();
 
+  // async import required as turbopack errors in Pages Router
+  // when next/headers is imported at the top-level
+  const headersPromise = import('next/headers').then((mod) => mod.headers);
+
   const dedupedFn = async function (this: unknown, ...args: A): Promise<T> {
-    // async import required as turbopack errors in Pages Router
-    // when next/headers is imported at the top-level
-    const { headers } = await import('next/headers');
+    const headers = await headersPromise;
 
     const h = await headers();
     let cacheNode = requestStore.get(h);


### PR DESCRIPTION
I think this should be slightly more performant than re-importing every time we call the deduped function.

(though in honesty I'm raising it as otherwise the mocks for `next/headers` in vitest v3+ fail, which I think is a vitest bug)