### PR TITLE
publish cjs bundles besides esm

### DIFF
--- a/.changeset/sweet-zoos-grin.md
+++ b/.changeset/sweet-zoos-grin.md
@@ -1,0 +1,6 @@
+---
+"@vercel/flags-core": patch
+"@flags-sdk/vercel": patch
+---
+
+publish cjs bundles besides esm

--- a/packages/adapter-vercel/package.json
+++ b/packages/adapter-vercel/package.json
@@ -8,13 +8,17 @@
   "sideEffects": false,
   "type": "module",
   "exports": {
-    ".": "./dist/index.js"
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
   },
   "main": "./dist/index.js",
   "typesVersions": {
     "*": {
       ".": [
-        "dist/*.d.ts"
+        "dist/*.d.ts",
+        "dist/*.d.cts"
       ]
     }
   },

--- a/packages/adapter-vercel/tsup.config.js
+++ b/packages/adapter-vercel/tsup.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: 'esm',
+  format: ['esm', 'cjs'],
   splitting: true,
   sourcemap: true,
   minify: false,

--- a/packages/vercel-flags-core/package.json
+++ b/packages/vercel-flags-core/package.json
@@ -8,17 +8,25 @@
   "sideEffects": false,
   "type": "module",
   "exports": {
-    ".": "./dist/index.js",
-    "./openfeature": "./dist/openfeature.js"
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./openfeature": {
+      "import": "./dist/openfeature.js",
+      "require": "./dist/openfeature.cjs"
+    }
   },
   "main": "./dist/index.js",
   "typesVersions": {
     "*": {
       ".": [
-        "dist/*.d.ts"
+        "dist/*.d.ts",
+        "dist/*.d.cts"
       ],
       "./openfeature": [
-        "dist/openfeature.d.ts"
+        "dist/openfeature.d.ts",
+        "dist/openfeature.d.cts"
       ]
     }
   },

--- a/packages/vercel-flags-core/tsup.config.js
+++ b/packages/vercel-flags-core/tsup.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: ['src/index.ts', 'src/openfeature.ts'],
-  format: 'esm',
+  format: ['esm', 'cjs'],
   splitting: true,
   sourcemap: true,
   minify: false,


### PR DESCRIPTION
Publish CJS bundles besides the ESM bundles to make it easier to use the packages in Jest, as Jest doesn't support ESM out of the box.

<img width="973" height="229" alt="image" src="https://github.com/user-attachments/assets/efcac0ec-4b7e-4c2a-8a2c-3003d55637b9" />
