### PR TITLE
align snapshot git sha release length

### DIFF
--- a/.github/workflows/release-snapshot.yaml
+++ b/.github/workflows/release-snapshot.yaml
@@ -68,7 +68,7 @@ jobs:
         run: pnpm install
 
       - name: Add SHORT_SHA env property with commit short sha
-        run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-8`" >> $GITHUB_ENV
+        run: echo "SHORT_SHA=`echo ${{ github.sha }} | cut -c1-7`" >> $GITHUB_ENV
 
       - name: Version Packages
         run: pnpm changeset version --snapshot ${SHORT_SHA}


### PR DESCRIPTION
Aligns the length of the sha we make part of snapshot releases with the short-sha length used by GitHub such that we can correlate them more easily.