### PR TITLE
[code quality] avoid shadowing "flag" function name

### DIFF
--- a/packages/flags/src/next/index.ts
+++ b/packages/flags/src/next/index.ts
@@ -378,7 +378,7 @@ export function flag<
   const run = getRun<ValueType, EntitiesType>(definition, decide);
   const origin = getOrigin(definition);
 
-  const flag = trace(
+  const api = trace(
     async (...args: any[]) => {
       // Default method, may be overwritten by `getPrecomputed` or `run`
       // which is why we must not trace them directly in here,
@@ -392,12 +392,7 @@ export function flag<
         >;
         if (precomputedCode && precomputedGroup) {
           setSpanAttribute('method', 'precomputed');
-          return getPrecomputed(
-            flag,
-            precomputedGroup,
-            precomputedCode,
-            secret,
-          );
+          return getPrecomputed(api, precomputedGroup, precomputedCode, secret);
         }
       }
 
@@ -424,30 +419,30 @@ export function flag<
     },
   ) as Flag<ValueType, EntitiesType>;
 
-  flag.key = definition.key;
-  flag.defaultValue = definition.defaultValue;
-  flag.origin = origin;
-  flag.options = normalizeOptions<ValueType>(definition.options);
-  flag.description = definition.description;
-  flag.identify = identify
+  api.key = definition.key;
+  api.defaultValue = definition.defaultValue;
+  api.origin = origin;
+  api.options = normalizeOptions<ValueType>(definition.options);
+  api.description = definition.description;
+  api.identify = identify
     ? trace(identify, {
         isVerboseTrace: false,
         name: 'identify',
         attributes: { key: definition.key },
       })
     : identify;
-  flag.decide = trace(decide, {
+  api.decide = trace(decide, {
     isVerboseTrace: false,
     name: 'decide',
     attributes: { key: definition.key },
   });
-  flag.run = trace(run, {
+  api.run = trace(run, {
     isVerboseTrace: false,
     name: 'run',
     attributes: { key: definition.key },
   });
 
-  return flag;
+  return api;
 }
 
 export type KeyedFlagDefinitionType = { key: string } & FlagDefinitionType;


### PR DESCRIPTION
We were essentially using the below, which shadows the `flag` name making the code harder to read

```ts
function flag() {
  const flag = () => {}
  return flag
}
```

This PR cleans it up so we have


```ts
function flag() {
  const api = () => {}
  return api
}
```
