### PR TITLE
Updated rimraf to 6.1.2

### DIFF
--- a/packages/adapter-edge-config/package.json
+++ b/packages/adapter-edge-config/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@types/node": "20.11.17",
     "flags": "workspace:*",
-    "rimraf": "6.0.1",
+    "rimraf": "6.1.2",
     "tsup": "8.5.1",
     "typescript": "5.6.3",
     "vite": "5.4.21",

--- a/packages/adapter-flagsmith/package.json
+++ b/packages/adapter-flagsmith/package.json
@@ -55,7 +55,7 @@
     "@types/node": "20.11.17",
     "flags": "workspace:*",
     "msw": "2.6.4",
-    "rimraf": "6.0.1",
+    "rimraf": "6.1.2",
     "tsup": "8.5.1",
     "typescript": "5.6.3",
     "vite": "5.4.21",

--- a/packages/adapter-growthbook/package.json
+++ b/packages/adapter-growthbook/package.json
@@ -60,7 +60,7 @@
     "@types/node": "20.11.17",
     "flags": "workspace:*",
     "msw": "2.6.4",
-    "rimraf": "6.0.1",
+    "rimraf": "6.1.2",
     "tsup": "8.5.1",
     "typescript": "5.6.3",
     "vite": "5.4.21",

--- a/packages/adapter-hypertune/package.json
+++ b/packages/adapter-hypertune/package.json
@@ -42,7 +42,7 @@
     "@types/node": "20.11.17",
     "flags": "workspace:*",
     "msw": "2.6.4",
-    "rimraf": "6.0.1",
+    "rimraf": "6.1.2",
     "tsup": "8.5.1",
     "typescript": "5.6.3",
     "vite": "5.4.21",

--- a/packages/adapter-launchdarkly/package.json
+++ b/packages/adapter-launchdarkly/package.json
@@ -57,7 +57,7 @@
     "@types/node": "20.11.17",
     "flags": "workspace:*",
     "msw": "2.6.4",
-    "rimraf": "6.0.1",
+    "rimraf": "6.1.2",
     "tsup": "8.5.1",
     "typescript": "5.6.3",
     "vite": "5.4.21",

--- a/packages/adapter-openfeature/package.json
+++ b/packages/adapter-openfeature/package.json
@@ -53,7 +53,7 @@
     "@types/node": "20.11.17",
     "flags": "workspace:*",
     "msw": "2.6.4",
-    "rimraf": "6.0.1",
+    "rimraf": "6.1.2",
     "tsup": "8.5.1",
     "typescript": "5.6.3",
     "vite": "5.4.21",

--- a/packages/adapter-optimizely/package.json
+++ b/packages/adapter-optimizely/package.json
@@ -39,7 +39,7 @@
     "@types/node": "20.11.17",
     "flags": "workspace:*",
     "msw": "2.6.4",
-    "rimraf": "6.0.1",
+    "rimraf": "6.1.2",
     "tsup": "8.5.1",
     "typescript": "5.6.3",
     "vite": "5.4.21",

--- a/packages/adapter-posthog/package.json
+++ b/packages/adapter-posthog/package.json
@@ -57,7 +57,7 @@
     "@types/node": "22.14.0",
     "flags": "workspace:*",
     "msw": "2.6.4",
-    "rimraf": "6.0.1",
+    "rimraf": "6.1.2",
     "tsup": "8.5.1",
     "typescript": "5.8.2",
     "vite": "6.4.1",

--- a/packages/adapter-reflag/package.json
+++ b/packages/adapter-reflag/package.json
@@ -54,7 +54,7 @@
     "@types/node": "20.11.17",
     "flags": "workspace:*",
     "msw": "2.6.4",
-    "rimraf": "6.0.1",
+    "rimraf": "6.1.2",
     "tsup": "8.5.1",
     "typescript": "5.6.3",
     "vite": "5.4.21",

--- a/packages/adapter-split/package.json
+++ b/packages/adapter-split/package.json
@@ -39,7 +39,7 @@
     "@types/node": "20.11.17",
     "flags": "workspace:*",
     "msw": "2.6.4",
-    "rimraf": "6.0.1",
+    "rimraf": "6.1.2",
     "tsup": "8.5.1",
     "typescript": "5.6.3",
     "vite": "5.4.21",

--- a/packages/adapter-statsig/package.json
+++ b/packages/adapter-statsig/package.json
@@ -71,7 +71,7 @@
     "@types/node": "20.11.17",
     "flags": "workspace:*",
     "msw": "2.6.4",
-    "rimraf": "6.0.1",
+    "rimraf": "6.1.2",
     "tsup": "8.5.1",
     "typescript": "5.6.3",
     "vite": "5.4.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,8 +287,8 @@ importers:
         specifier: workspace:*
         version: link:../flags
       rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.1.2
+        version: 6.1.2
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.6.3)(yaml@2.8.1)
@@ -318,8 +318,8 @@ importers:
         specifier: 2.6.4
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.1.2
+        version: 6.1.2
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.6.3)(yaml@2.8.1)
@@ -355,8 +355,8 @@ importers:
         specifier: 2.6.4
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.1.2
+        version: 6.1.2
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.6.3)(yaml@2.8.1)
@@ -389,8 +389,8 @@ importers:
         specifier: 2.6.4
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.1.2
+        version: 6.1.2
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.6.3)(yaml@2.8.1)
@@ -423,8 +423,8 @@ importers:
         specifier: 2.6.4
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.1.2
+        version: 6.1.2
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.6.3)(yaml@2.8.1)
@@ -453,8 +453,8 @@ importers:
         specifier: 2.6.4
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.1.2
+        version: 6.1.2
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.6.3)(yaml@2.8.1)
@@ -480,8 +480,8 @@ importers:
         specifier: 2.6.4
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.1.2
+        version: 6.1.2
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.6.3)(yaml@2.8.1)
@@ -514,8 +514,8 @@ importers:
         specifier: 2.6.4
         version: 2.6.4(@types/node@22.14.0)(typescript@5.8.2)
       rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.1.2
+        version: 6.1.2
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.8.2)(yaml@2.8.1)
@@ -545,8 +545,8 @@ importers:
         specifier: 2.6.4
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.1.2
+        version: 6.1.2
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.6.3)(yaml@2.8.1)
@@ -572,8 +572,8 @@ importers:
         specifier: 2.6.4
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.1.2
+        version: 6.1.2
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.6.3)(yaml@2.8.1)
@@ -612,8 +612,8 @@ importers:
         specifier: 2.6.4
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       rimraf:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 6.1.2
+        version: 6.1.2
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.6.3)(yaml@2.8.1)
@@ -1969,8 +1969,8 @@ packages:
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
 
-  '@isaacs/brace-expansion@5.0.0':
-    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
     engines: {node: 20 || >=22}
 
   '@isaacs/cliui@8.0.2':
@@ -4205,11 +4205,9 @@ packages:
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
-  glob@11.0.3:
-    resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
+  glob@13.0.1:
+    resolution: {integrity: sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w==}
     engines: {node: 20 || >=22}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -4506,10 +4504,6 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-
-  jackspeak@4.1.1:
-    resolution: {integrity: sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==}
-    engines: {node: 20 || >=22}
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
@@ -4914,8 +4908,8 @@ packages:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
 
-  minimatch@10.0.3:
-    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
+  minimatch@10.1.2:
+    resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
     engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
@@ -5598,8 +5592,8 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rimraf@6.0.1:
-    resolution: {integrity: sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==}
+  rimraf@6.1.2:
+    resolution: {integrity: sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==}
     engines: {node: 20 || >=22}
     hasBin: true
 
@@ -7448,7 +7442,7 @@ snapshots:
 
   '@isaacs/balanced-match@4.0.1': {}
 
-  '@isaacs/brace-expansion@5.0.0':
+  '@isaacs/brace-expansion@5.0.1':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
 
@@ -9992,13 +9986,10 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
-  glob@11.0.3:
+  glob@13.0.1:
     dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 4.1.1
-      minimatch: 10.0.3
+      minimatch: 10.1.2
       minipass: 7.1.2
-      package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
 
   globals@14.0.0: {}
@@ -10291,10 +10282,6 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
-
-  jackspeak@4.1.1:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
 
   jiti@1.21.7: {}
 
@@ -10651,9 +10638,9 @@ snapshots:
 
   mini-svg-data-uri@1.4.4: {}
 
-  minimatch@10.0.3:
+  minimatch@10.1.2:
     dependencies:
-      '@isaacs/brace-expansion': 5.0.0
+      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@3.1.2:
     dependencies:
@@ -11401,9 +11388,9 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rimraf@6.0.1:
+  rimraf@6.1.2:
     dependencies:
-      glob: 11.0.3
+      glob: 13.0.1
       package-json-from-dist: 1.0.1
 
   rollup@4.57.1:


### PR DESCRIPTION
Fixes: 
https://github.com/vercel/flags/security/dependabot/353
https://github.com/vercel/flags/security/dependabot/419
They are both vulnerabilities in rimrafs deps