### PR TITLE
Update peer dependency for @sveltejs/kit

### DIFF
--- a/packages/flags/package.json
+++ b/packages/flags/package.json
@@ -96,7 +96,7 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.7.0",
-    "@sveltejs/kit": "*",
+    "@sveltejs/kit": "^2.49.5",
     "next": "*",
     "react": "*",
     "react-dom": "*"


### PR DESCRIPTION
SvelteKit is a framework for rapidly developing robust, performant web applications using Svelte. Prior to 2.49.5, SvelteKit is vulnerable to a server side request forgery (SSRF) and denial of service (DoS) under certain conditions. From 2.44.0 through 2.49.4, the vulnerability results in a DoS when your app has at least one prerendered route (export const prerender = true). From 2.19.0 through 2.49.4, the vulnerability results in a DoS when your app has at least one prerendered route and you are using adapter-node without a configured ORIGIN environment variable, and you are not using a reverse proxy that implements Host header validation. This vulnerability is fixed in 2.49.5.