### PR TITLE
throw on declaration if flag is missing decide function

### DIFF
--- a/.changeset/full-cougars-sing.md
+++ b/.changeset/full-cougars-sing.md
@@ -1,0 +1,7 @@
+---
+"flags": patch
+---
+
+Throw on declaration if flag is missing decide function.
+
+When a feature flag is declared without a decide function, or with an adapter that is missing a decide function we will now throw an error at declaration time.

--- a/packages/flags/src/next/index.test.ts
+++ b/packages/flags/src/next/index.test.ts
@@ -77,6 +77,18 @@ describe('flag on app router', () => {
     await expect(f()).resolves.toEqual(false);
   });
 
+  it('throws when passing invalid adapter', () => {
+    expect(() => flag({ key: 'my-key', adapter: {} as any })).toThrowError(
+      'flags: You passed an adapter that does not have a "decide" method for flag "my-key". Did you pass "adapter: exampleAdapter" instead of "adapter: exampleAdapter()"?',
+    );
+  });
+
+  it('throws when passing no decide function', () => {
+    expect(() => flag({ key: 'my-key' } as any)).toThrowError(
+      'flags: You passed a flag declaration that does not have a "decide" method for flag "my-key"',
+    );
+  });
+
   it('caches for the duration of a request', async () => {
     let i = 0;
     const decide = vi.fn(() => i++);

--- a/packages/flags/src/next/index.ts
+++ b/packages/flags/src/next/index.ts
@@ -169,6 +169,21 @@ async function getEntities<ValueType, EntitiesType>(
 function getDecide<ValueType, EntitiesType>(
   definition: FlagDeclaration<ValueType, EntitiesType>,
 ): Decide<ValueType, EntitiesType> {
+  if (definition.adapter && typeof definition.adapter.decide !== 'function') {
+    throw new Error(
+      `flags: You passed an adapter that does not have a "decide" method for flag "${definition.key}". Did you pass "adapter: exampleAdapter" instead of "adapter: exampleAdapter()"?`,
+    );
+  }
+
+  if (
+    typeof definition.decide !== 'function' &&
+    typeof definition.adapter?.decide !== 'function'
+  ) {
+    throw new Error(
+      `flags: You passed a flag declaration that does not have a "decide" method for flag "${definition.key}"`,
+    );
+  }
+
   return function decide(params) {
     if (typeof definition.decide === 'function') {
       return definition.decide(params);


### PR DESCRIPTION
Throw on declaration if flag is missing decide function.

When a feature flag is declared without a decide function, or with an adapter that is missing a decide function we will now throw an error at declaration time.
