### PR TITLE
Suppress stream abort error on intentional shutdown

### DIFF
--- a/packages/vercel-flags-core/src/data-source/stream-connection.ts
+++ b/packages/vercel-flags-core/src/data-source/stream-connection.ts
@@ -128,7 +128,6 @@ export async function connectStream(
         }
       } catch (error) {
         if (abortController.signal.aborted) {
-          console.error('@vercel/flags-core: Stream aborted', error);
           break;
         }
         console.error('@vercel/flags-core: Stream error', error);


### PR DESCRIPTION
When shutdown() is called on a client using FlagNetworkDataSource, the stream abort error is expected and should not be logged. The break statement still exits the loop properly. All 304 tests pass.