### PR TITLE
[vercel-flags-core] Forward `configUpdatedAt` timestamp correctly

### DIFF
--- a/packages/vercel-flags-core/src/data-source/flag-network-data-source.ts
+++ b/packages/vercel-flags-core/src/data-source/flag-network-data-source.ts
@@ -886,6 +886,10 @@ export class FlagNetworkDataSource implements DataSource {
       cacheIsBlocking: !cacheHadDefinitions,
       duration: Date.now() - startTime,
     };
+    const configUpdatedAt = this.data?.configUpdatedAt;
+    if (typeof configUpdatedAt === 'number') {
+      trackOptions.configUpdatedAt = configUpdatedAt;
+    }
     if (isFirstRead) {
       trackOptions.cacheIsFirstRead = true;
     }


### PR DESCRIPTION
The timestamp was not passed to the `trackOptions`.