### PR TITLE
Update cookie package version to 0.7.0

### DIFF
--- a/examples/sveltekit-example/package.json
+++ b/examples/sveltekit-example/package.json
@@ -16,7 +16,7 @@
     "@tailwindcss/vite": "4.0.15",
     "@vercel/edge": "^1.2.1",
     "@vercel/toolbar": "0.1.36",
-    "cookie": "^0.6.0",
+    "cookie": "^0.7.0",
     "flags": "workspace:*",
     "tailwindcss": "4.0.15"
   },


### PR DESCRIPTION
cookie is a basic HTTP cookie parser and serializer for HTTP servers. The cookie name could be used to set other fields of the cookie, resulting in an unexpected cookie value. A similar escape can be used for path and domain, which could be abused to alter other fields of the cookie. Upgrade to 0.7.0, which updates the validation for name, path, and domain.