### PR TITLE
Mention CLI in skill

### DIFF
--- a/skills/flags-sdk/references/providers.md
+++ b/skills/flags-sdk/references/providers.md
@@ -90,6 +90,26 @@ export const exampleFlag = flag({
 });
 ```
 
+### CLI
+
+Manage Vercel Flags from the terminal with `vercel flags`. Requires the [Vercel CLI](https://vercel.com/docs/cli) (`pnpm i -g vercel`) and a linked project.
+
+Available subcommands: `list`, `add`, `inspect`, `enable`, `disable`, `archive`, `rm`, `sdk-keys`.
+
+```bash
+vercel flags add my-feature --kind boolean --description "New onboarding flow"
+vercel flags enable my-feature --environment production
+vercel flags list
+vercel flags sdk-keys ls
+```
+
+`enable` / `disable` only work with boolean flags. A flag must be archived before it can be deleted.
+
+Full CLI reference: https://vercel.com/docs/cli/flags
+
+> For broader Vercel CLI usage, install the `vercel-cli` skill:
+> `npx skills add https://github.com/vercel/vercel --skill vercel-cli`
+
 ---
 
 ## Edge Config


### PR DESCRIPTION
Adds a reference to the Vercel CLI in our flags sdk skill when using Vercel Flags