### PR TITLE
Add sitemap.md route

### DIFF
--- a/apps/docs/app/[lang]/sitemap.md/route.ts
+++ b/apps/docs/app/[lang]/sitemap.md/route.ts
@@ -1,7 +1,14 @@
 import type { NextRequest } from 'next/server';
+import { translations } from '@/geistdocs';
 import { source } from '@/lib/geistdocs/source';
 
 export const revalidate = false;
+export const dynamic = 'error';
+
+export const generateStaticParams = async () => {
+  const langs = Object.keys(translations);
+  return langs.map((lang) => ({ lang }));
+};
 
 const DOCS_PREFIX_PATTERN = /^\/docs\/?/;
 const WHITESPACE_PATTERN = /\s+/;


### PR DESCRIPTION
## Summary

- Adds `sitemap.md` route for LLM-friendly documentation indexing
- Generates a hierarchical markdown sitemap at `/[lang]/sitemap.md`
- Self-contained — no other file changes needed

## Test plan

- [ ] Verify the site builds successfully
- [ ] Check `/sitemap.md` returns a valid markdown sitemap

🤖 Generated with [Claude Code](https://claude.com/claude-code)