### PR TITLE
Flags-sdk.dev dark mode

### DIFF
--- a/apps/docs/components/custom/iframe-browser.tsx
+++ b/apps/docs/components/custom/iframe-browser.tsx
@@ -31,12 +31,12 @@ export function IframeBrowser({
 
   return (
     <div className="mx-auto flex w-full max-w-4xl flex-col overflow-hidden rounded-lg border shadow-lg">
-      <div className="flex items-center gap-1.5 bg-gray-100 dark:bg-gray-800 p-2">
+      <div className="flex items-center gap-1.5 bg-gray-100 dark:bg-card p-2">
         <div className="flex-grow">
           <Input
             defaultValue={resolvedSrc}
             placeholder="Enter URL"
-            className="w-full cursor-default bg-white dark:bg-gray-900"
+            className="w-full cursor-default bg-white dark:bg-card"
             readOnly
             aria-labelledby="input-label"
           />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes dark mode for the `IframeBrowser` component by adding dark mode specific Tailwind classes.

**Before**

<img width="883" height="83" alt="image" src="https://github.com/user-attachments/assets/e224318b-b3a9-454b-a222-04aa78e667b5" />

<img width="861" height="85" alt="image" src="https://github.com/user-attachments/assets/6ca3eb72-1242-40b6-a590-b25c620afd8f" />




**After**


<img width="869" height="85" alt="image" src="https://github.com/user-attachments/assets/4a92848d-fa61-4cd3-b24c-9e4062ec43d1" />

<img width="857" height="77" alt="image" src="https://github.com/user-attachments/assets/dcb8ac45-d175-4ffc-88ec-d39d8963b794" />


---
Linear Issue: [FLA-2542](https://linear.app/vercel/issue/FLA-2542/flags-sdkdev-dark-mode-broken)

<p><a href="https://cursor.com/agents/bc-01c66e2b-8dbc-4d93-af4e-2d3ef32a1ca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01c66e2b-8dbc-4d93-af4e-2d3ef32a1ca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->