### PR TITLE
Updated precompute instructions in skill

### DIFF
--- a/skills/flags-sdk/references/nextjs.md
+++ b/skills/flags-sdk/references/nextjs.md
@@ -197,27 +197,19 @@ export default async function Page({ params }: { params: Params }) {
 }
 ```
 
-### Enable ISR
+### Step 4: Enable ISR & build time prerendering
 
 ```tsx
 // app/[code]/layout.tsx
-export async function generateStaticParams() {
-  return []; // empty array enables ISR
-}
-
-export default async function Layout({ children }) {
-  return children;
-}
-```
-
-### Build-time rendering
-
-```tsx
 import { generatePermutations } from 'flags/next';
 
 export async function generateStaticParams() {
   const codes = await generatePermutations(marketingFlags);
   return codes.map((code) => ({ code }));
+}
+
+export default async function Layout({ children }) {
+  return children;
 }
 ```
 


### PR DESCRIPTION
The agent skips the ISR and generatePermutations commands because they are not part of the numbered list. This fixes that so those steps are not optional.