### PR TITLE
Add BLOB_READ_WRITE_TOKEN to turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -25,7 +25,8 @@
         "KV_REST_API_READ_ONLY_TOKEN",
         "KV_REST_API_TOKEN",
         "KV_REST_API_URL",
-        "REDIS_URL"
+        "REDIS_URL",
+        "BLOB_READ_WRITE_TOKEN"
       ],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [


### PR DESCRIPTION
Make the Vercel Blob read/write token available to all Turborepo tasks by adding it to globalPassThroughEnv.