### PR TITLE
Add CLI reference to quickstart guide

### DIFF
--- a/skills/flags-sdk/SKILL.md
+++ b/skills/flags-sdk/SKILL.md
@@ -71,9 +71,10 @@ Install the adapter:
 pnpm i flags @flags-sdk/vercel
 ```
 
-Create a flag in the Vercel dashboard, then pull environment variables:
+Create a flag via the CLI or in the Vercel dashboard, then pull environment variables:
 
 ```bash
+vercel flags add example-flag
 vercel env pull
 ```
 


### PR DESCRIPTION
The agent ignored the CLI usage when setting up flags in an empty project without explicit instructions to use the CLI. This should improve that.