### PR TITLE
Precompute install-audience flag for the hero switcher

### DIFF
--- a/apps/docs/app/[lang]/home/[code]/install-command.tsx
+++ b/apps/docs/app/[lang]/home/[code]/install-command.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import {
+  CommandPromptContent,
+  CommandPromptCopy,
+  CommandPromptList,
+  CommandPromptPrefix,
+  CommandPromptRoot,
+  CommandPromptSurface,
+  CommandPromptTrigger,
+  CommandPromptTriggerDivider,
+  CommandPromptViewport,
+} from '@/components/ui/command-prompt';
+
+const COMMAND_FOR_HUMANS = 'npm install flags';
+const COMMAND_FOR_AGENTS = 'npx skills add vercel/flags@flags-sdk';
+const oneYearInSeconds = 31_536_000;
+
+type Audience = 'humans' | 'agents';
+
+interface InstallCommandProps {
+  value: Audience;
+  flagKey: string;
+}
+
+export const InstallCommand = ({ value, flagKey }: InstallCommandProps) => {
+  const router = useRouter();
+  // Optimistic override so the tab updates instantly; the server render of the
+  // matching prebuilt `[code]` takes over on refresh.
+  const [override, setOverride] = useState<Audience | null>(null);
+  const current = override ?? value;
+
+  return (
+    <CommandPromptRoot
+      className="mt-6 items-start"
+      onValueChange={(next) => {
+        const nextValue = next as Audience;
+        if (nextValue === current) return;
+        document.cookie = `${flagKey}=${nextValue}; max-age=${oneYearInSeconds}; path=/`;
+        setOverride(nextValue);
+        router.refresh();
+      }}
+      value={current}
+    >
+      <CommandPromptList>
+        <CommandPromptTrigger className="min-w-[90px]" value="humans">
+          For humans
+        </CommandPromptTrigger>
+        <CommandPromptTriggerDivider />
+        <CommandPromptTrigger className="min-w-[84px]" value="agents">
+          For agents
+        </CommandPromptTrigger>
+      </CommandPromptList>
+      <CommandPromptSurface>
+        <CommandPromptPrefix>$</CommandPromptPrefix>
+        <CommandPromptViewport>
+          <CommandPromptContent copyValue={COMMAND_FOR_HUMANS} value="humans">
+            {COMMAND_FOR_HUMANS}
+          </CommandPromptContent>
+          <CommandPromptContent copyValue={COMMAND_FOR_AGENTS} value="agents">
+            {COMMAND_FOR_AGENTS}
+          </CommandPromptContent>
+        </CommandPromptViewport>
+        <CommandPromptCopy />
+      </CommandPromptSurface>
+    </CommandPromptRoot>
+  );
+};

--- a/apps/docs/app/[lang]/home/[code]/layout.tsx
+++ b/apps/docs/app/[lang]/home/[code]/layout.tsx
@@ -17,7 +17,7 @@ export default async function Layout({
         </div>
       ) : null}
       <HomeLayout tree={source.pageTree[lang]}>
-        <div className="bg-sidebar pt-0 pb-32">{children}</div>
+        <div className="bg-background-200 pt-0 pb-32">{children}</div>
       </HomeLayout>
     </>
   );

--- a/apps/docs/app/[lang]/home/[code]/page.tsx
+++ b/apps/docs/app/[lang]/home/[code]/page.tsx
@@ -5,20 +5,10 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import {
-  CommandPromptContent,
-  CommandPromptCopy,
-  CommandPromptList,
-  CommandPromptPrefix,
-  CommandPromptRoot,
-  CommandPromptSurface,
-  CommandPromptTrigger,
-  CommandPromptTriggerDivider,
-  CommandPromptViewport,
-} from '@/components/ui/command-prompt';
-import {
   enableBannerFlag,
   enableDitheredHeroFlag,
   enableHeroTextFlag,
+  installAudienceFlag,
   rootFlags,
 } from '@/flags';
 import HeroImage from './components/hero-image';
@@ -26,6 +16,7 @@ import { Adaptable, Effortless, Flexible } from './components/illustrations';
 import Testimonials from './components/testimonials';
 import { CopySnippet } from './copy-snippet';
 import { HighlightedCode } from './highlighted-code';
+import { InstallCommand } from './install-command';
 import { FlagSelect, FlagToggle } from './toggles';
 
 const FEATURES = [
@@ -48,9 +39,6 @@ const FEATURES = [
     illustration: <Adaptable />,
   },
 ];
-
-const COMMAND_FOR_HUMANS = 'npm install flags';
-const COMMAND_FOR_AGENTS = 'npx skills add vercel/flags@flags-sdk';
 
 const flagsSetupCodeblock = `import { flag } from 'flags/next';
 
@@ -85,11 +73,13 @@ export default async function HomePage({
   params: Promise<{ code: string }>;
 }) {
   const { code } = await params;
-  const [bannerFlag, ditheredHeroFlag, heroTextFlag] = await Promise.all([
-    enableBannerFlag(code, rootFlags),
-    enableDitheredHeroFlag(code, rootFlags),
-    enableHeroTextFlag(code, rootFlags),
-  ]);
+  const [bannerFlag, ditheredHeroFlag, heroTextFlag, installAudience] =
+    await Promise.all([
+      enableBannerFlag(code, rootFlags),
+      enableDitheredHeroFlag(code, rootFlags),
+      enableHeroTextFlag(code, rootFlags),
+      installAudienceFlag(code, rootFlags),
+    ]);
 
   return (
     <div className="container mx-auto max-w-5xl">
@@ -98,6 +88,7 @@ export default async function HomePage({
           [enableBannerFlag.key]: bannerFlag,
           [enableDitheredHeroFlag.key]: ditheredHeroFlag,
           [enableHeroTextFlag.key]: heroTextFlag,
+          [installAudienceFlag.key]: installAudience,
         }}
       />
 
@@ -111,35 +102,10 @@ export default async function HomePage({
             Flags SDK is a free, open-source library for using feature flags in
             Next.js and SvelteKit.
           </p>
-          <CommandPromptRoot className="mt-6 items-start" defaultValue="agents">
-            <CommandPromptList>
-              <CommandPromptTrigger className="min-w-[90px]" value="humans">
-                For humans
-              </CommandPromptTrigger>
-              <CommandPromptTriggerDivider />
-              <CommandPromptTrigger className="min-w-[84px]" value="agents">
-                For agents
-              </CommandPromptTrigger>
-            </CommandPromptList>
-            <CommandPromptSurface>
-              <CommandPromptPrefix>$</CommandPromptPrefix>
-              <CommandPromptViewport>
-                <CommandPromptContent
-                  copyValue={COMMAND_FOR_HUMANS}
-                  value="humans"
-                >
-                  {COMMAND_FOR_HUMANS}
-                </CommandPromptContent>
-                <CommandPromptContent
-                  copyValue={COMMAND_FOR_AGENTS}
-                  value="agents"
-                >
-                  {COMMAND_FOR_AGENTS}
-                </CommandPromptContent>
-              </CommandPromptViewport>
-              <CommandPromptCopy />
-            </CommandPromptSurface>
-          </CommandPromptRoot>
+          <InstallCommand
+            flagKey={installAudienceFlag.key}
+            value={installAudience}
+          />
         </div>
         <div className="relative p-4 sm:p-6">
           {ditheredHeroFlag ? <HeroImage /> : null}

--- a/apps/docs/flags.ts
+++ b/apps/docs/flags.ts
@@ -36,8 +36,21 @@ export const enableHeroTextFlag = flag<string>({
   },
 });
 
+export const installAudienceFlag = flag<'humans' | 'agents'>({
+  key: 'install-audience',
+  description: 'Default tab of the hero install-command switcher',
+  options: ['humans', 'agents'],
+  decide({ cookies }) {
+    const cookieValue = cookies.get(this.key)?.value;
+    return cookieValue === 'humans' || cookieValue === 'agents'
+      ? cookieValue
+      : 'agents';
+  },
+});
+
 export const rootFlags = [
   enableBannerFlag,
   enableHeroTextFlag,
   enableDitheredHeroFlag,
+  installAudienceFlag,
 ] as const;


### PR DESCRIPTION
## Summary

The home hero's "For humans / For agents" tab was held in `useState`, so every reload snapped back to the default tab. This PR models the tab as a precomputed flag like the other hero flags.

### Changes

- **`flags.ts`** — new \`installAudienceFlag\` (\`'humans' | 'agents'\`, cookie key \`install-audience\`, default \`'agents'\`), added to \`rootFlags\` so \`generatePermutations\` covers both variants (2× permutations, cheap).
- **\`page.tsx\`** — awaits the flag alongside the others, publishes it via \`FlagValues\`, and renders the new \`<InstallCommand value={...} flagKey={...} />\` in place of the inline client component. Removed the now-unused \`CommandPrompt*\` imports and \`COMMAND_FOR_*\` constants.
- **\`install-command.tsx\` (new)** — client wrapper around \`CommandPromptRoot\`. On click: writes the cookie, sets an optimistic override, calls \`router.refresh()\` — same pattern as \`FlagToggle\`.

