### PR TITLE
Fix snapshot release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,6 +117,8 @@ jobs:
 
       - name: Version Packages
         run: pnpm changeset version --snapshot ${SHORT_SHA}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: pnpm turbo build --filter='./packages/*'


### PR DESCRIPTION
This step needs a github token otherwise it fails: https://github.com/vercel/flags/actions/runs/25323771699/job/74239156452