### PR TITLE
Reapply OIDC

### DIFF
--- a/.changeset/twelve-shoes-behave.md
+++ b/.changeset/twelve-shoes-behave.md
@@ -1,0 +1,13 @@
+---
+"@flags-sdk/vercel": minor
+"@vercel/prepare-flags-definitions": minor
+"@vercel/flags-core": minor
+---
+
+Add OIDC authentication support for Vercel Flags clients and generated flag definitions.
+
+`@vercel/flags-core` can now create clients without an SDK key and authenticate with a Vercel OIDC token, while still supporting SDK keys and connection strings. Bundled definitions can be looked up by SDK key hash or OIDC project ID.
+
+`@vercel/prepare-flags-definitions` now collects both SDK keys and `VERCEL_OIDC_TOKEN`, fetches definitions for each auth entry, deduplicates identical definitions across SDK keys and OIDC project IDs, and writes generated maps keyed by SDK key hash or project ID.
+
+`@flags-sdk/vercel` now supports provider data lookup for Vercel flag origins that do not include an SDK key, allowing OIDC-backed clients to resolve project metadata.

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -23,10 +23,10 @@ export type VercelAdapterDeclaration<ValueType, EntitiesType> = Omit<
  */
 export function createVercelAdapter(
   // usually a connection string, but can also be a pre-configured FlagsClient
-  sdkKeyOrFlagsClient: string | FlagsClient,
+  sdkKeyOrFlagsClient?: string | FlagsClient,
 ) {
   const flagsClient =
-    typeof sdkKeyOrFlagsClient === 'string'
+    typeof sdkKeyOrFlagsClient === 'string' || sdkKeyOrFlagsClient === undefined
       ? createClient(sdkKeyOrFlagsClient)
       : sdkKeyOrFlagsClient;
 
@@ -86,9 +86,13 @@ export function vercelAdapter<ValueType, EntitiesType>(): Adapter<
   return defaultVercelAdapter<ValueType, EntitiesType>();
 }
 
-const flagsClients = new Map<string, FlagsClient>();
+const flagsClients = new Map<string | undefined, FlagsClient>();
 
-function getOrCreateClient(sdkKey: string): FlagsClient {
+/**
+ * Ensures we only ever create a single client per SDK Key
+ * When undefined is passed, due to OIDC being used, then we return a single client too.
+ **/
+function getOrCreateClient(sdkKey?: string): FlagsClient {
   let client = flagsClients.get(sdkKey);
   if (!client) {
     client = createClient(sdkKey);
@@ -99,14 +103,12 @@ function getOrCreateClient(sdkKey: string): FlagsClient {
 
 function isVercelOrigin(
   origin: unknown,
-): origin is { provider: 'vercel'; sdkKey: string } {
+): origin is { provider: 'vercel'; sdkKey?: string } {
   return (
     typeof origin === 'object' &&
     origin !== null &&
     'provider' in origin &&
-    (origin as Record<string, unknown>).provider === 'vercel' &&
-    'sdkKey' in origin &&
-    typeof (origin as Record<string, unknown>).sdkKey === 'string'
+    (origin as Record<string, unknown>).provider === 'vercel'
   );
 }
 
@@ -122,14 +124,14 @@ export async function getProviderData(
     .filter((i): i is KeyedFlagDefinitionType => !Array.isArray(i));
 
   // Collect unique sdkKeys and resolve their projectIds
-  const sdkKeys = new Set<string>();
+  const sdkKeys = new Set<string | undefined>();
   for (const d of flagDefs) {
     if (isVercelOrigin(d.origin)) {
       sdkKeys.add(d.origin.sdkKey);
     }
   }
 
-  const projectIdBySdkKey = new Map<string, string>();
+  const projectIdBySdkKey = new Map<string | undefined, string>();
   await Promise.all(
     Array.from(sdkKeys).map(async (sdkKey) => {
       const client = getOrCreateClient(sdkKey);

--- a/packages/prepare-flags-definitions/README.md
+++ b/packages/prepare-flags-definitions/README.md
@@ -22,7 +22,7 @@ const result = await prepareFlagsDefinitions({
 });
 
 if (result.created) {
-  console.log(`Bundled definitions for ${result.sdkKeysCount} SDK keys`);
+  console.log(`Bundled definitions for ${result.entryCount} SDK keys`);
 } else {
   console.log(`No definitions created: ${result.reason}`);
 }

--- a/packages/prepare-flags-definitions/README.md
+++ b/packages/prepare-flags-definitions/README.md
@@ -22,7 +22,7 @@ const result = await prepareFlagsDefinitions({
 });
 
 if (result.created) {
-  console.log(`Bundled definitions for ${result.entryCount} SDK keys`);
+  console.log(`Bundled definitions for ${result.entryCount} entries`);
 } else {
   console.log(`No definitions created: ${result.reason}`);
 }

--- a/packages/prepare-flags-definitions/src/index.test.ts
+++ b/packages/prepare-flags-definitions/src/index.test.ts
@@ -1,10 +1,22 @@
+import { readFile } from 'node:fs/promises';
 import { describe, expect, it, vi } from 'vitest';
 import { version as pkgVersion } from '../package.json';
 import {
   generateDefinitionsModule,
+  getProjectIdFromOidcToken,
   hashSdkKey,
   prepareFlagsDefinitions,
 } from './index';
+
+function createOidcToken(projectId: string): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString(
+    'base64url',
+  );
+  const payload = Buffer.from(
+    JSON.stringify({ project_id: projectId, exp: 4_102_444_800 }),
+  ).toString('base64url');
+  return `${header}.${payload}.signature`;
+}
 
 describe('hashSdkKey', () => {
   it('returns a SHA-256 hex digest', () => {
@@ -21,80 +33,133 @@ describe('hashSdkKey', () => {
   });
 });
 
+describe('getProjectIdFromOidcToken', () => {
+  it('reads the project_id claim', () => {
+    expect(getProjectIdFromOidcToken(createOidcToken('prj_test'))).toBe(
+      'prj_test',
+    );
+  });
+});
+
 describe('generateDefinitionsModule', () => {
   it('generates a valid JS module', () => {
-    const sdkKeys = ['vf_server_key1'];
-    const values = [{ flag_a: { value: true } }];
-    const result = generateDefinitionsModule(sdkKeys, values);
+    const result = generateDefinitionsModule(
+      [{ key: 'vf_server_key1', definitions: { flag_a: { value: true } } }],
+      undefined,
+    );
 
     expect(result).toContain('const memo');
-    expect(result).toContain('export function get(hashedSdkKey)');
+    expect(result).toContain('export function get(key)');
     expect(result).toContain('export const version');
-    expect(result).toContain(hashSdkKey('vf_server_key1'));
+    expect(result).toContain('vf_server_key1');
   });
 
   it('deduplicates identical definitions', () => {
-    const sdkKeys = ['vf_server_key1', 'vf_client_key2'];
     const sharedDef = { flag_a: { value: true } };
-    const values = [sharedDef, sharedDef];
-    const result = generateDefinitionsModule(sdkKeys, values);
+    const result = generateDefinitionsModule(
+      [
+        { key: 'vf_server_key1', definitions: sharedDef },
+        { key: 'vf_client_key2', definitions: sharedDef },
+      ],
+      undefined,
+    );
 
     const memoMatches = result.match(/const _d\d+ = memo/g);
     expect(memoMatches).toHaveLength(1);
   });
 
   it('keeps separate definitions when values differ', () => {
-    const sdkKeys = ['vf_server_key1', 'vf_client_key2'];
-    const values = [{ flag_a: { value: true } }, { flag_b: { value: false } }];
-    const result = generateDefinitionsModule(sdkKeys, values);
+    const result = generateDefinitionsModule(
+      [
+        { key: 'vf_server_key1', definitions: { flag_a: { value: true } } },
+        { key: 'vf_client_key2', definitions: { flag_b: { value: false } } },
+      ],
+      undefined,
+    );
 
     const memoMatches = result.match(/const _d\d+ = memo/g);
     expect(memoMatches).toHaveLength(2);
   });
 
   it('maps each SDK key hash to the correct definition index', () => {
-    const sdkKeys = ['vf_server_key1', 'vf_client_key2'];
-    const values = [{ flag_a: true }, { flag_b: false }];
-    const result = generateDefinitionsModule(sdkKeys, values);
+    const result = generateDefinitionsModule(
+      [
+        { key: 'vf_server_key1', definitions: { flag_a: true } },
+        { key: 'vf_client_key2', definitions: { flag_b: false } },
+      ],
+      undefined,
+    );
 
-    expect(result).toContain(
-      `${JSON.stringify(hashSdkKey('vf_server_key1'))}: _d0`,
-    );
-    expect(result).toContain(
-      `${JSON.stringify(hashSdkKey('vf_client_key2'))}: _d1`,
-    );
+    expect(result).toContain(`${JSON.stringify('vf_server_key1')}: _d0`);
+    expect(result).toContain(`${JSON.stringify('vf_client_key2')}: _d1`);
   });
 
   it('handles empty input', () => {
-    const result = generateDefinitionsModule([], []);
+    const result = generateDefinitionsModule([], undefined);
     expect(result).toContain('const map = {');
-    expect(result).toContain('export function get(hashedSdkKey)');
+    expect(result).toContain('export function get(key)');
+  });
+
+  it('deduplicates definitions across SDK keys and OIDC project IDs', () => {
+    const sharedDef = { flag_a: { value: true } };
+    const result = generateDefinitionsModule(
+      [
+        { key: 'vf_server_key1', definitions: sharedDef },
+        { key: 'prj_test', definitions: sharedDef },
+      ],
+      undefined,
+    );
+
+    const memoMatches = result.match(/const _d\d+ = memo/g);
+    expect(memoMatches).toHaveLength(1);
+    expect(result).toContain(`${JSON.stringify('vf_server_key1')}: _d0`);
+    expect(result).toContain(`${JSON.stringify('prj_test')}: _d0`);
   });
 });
 
 describe('prepareFlagsDefinitions', () => {
-  it('returns { created: false, reason: "no-sdk-keys" } when no SDK keys in env', async () => {
+  it('returns { created: false, reason: "no-flags-entries" } when no flags auth is in env', async () => {
     const result = await prepareFlagsDefinitions({
       cwd: '/tmp/test',
       env: { SOME_VAR: 'hello' },
     });
 
-    expect(result).toEqual({ created: false, reason: 'no-sdk-keys' });
+    expect(result).toEqual({ created: false, reason: 'no-flags-entries' });
   });
 
-  it('returns { created: true, sdkKeysCount: N } when definitions are created', async () => {
+  it('returns { created: true, entryCount: N } when definitions are created', async () => {
     const mockFetch = async () =>
       new Response(JSON.stringify({ flag_a: { value: true } }), {
         status: 200,
       });
 
+    const cwd = '/tmp/test-definitions';
     const result = await prepareFlagsDefinitions({
-      cwd: '/tmp/test-definitions',
+      cwd,
       env: { FLAGS_SECRET: 'vf_server_test_key_123' },
       fetch: mockFetch,
     });
 
-    expect(result).toEqual({ created: true, sdkKeysCount: 1 });
+    expect(result).toEqual({ created: true, entryCount: 1 });
+    const definitionsJs = await readFile(
+      `${cwd}/node_modules/@vercel/flags-definitions/index.js`,
+      'utf8',
+    );
+    expect(definitionsJs).toMatchInlineSnapshot(`
+      "const memo = (fn) => { let cached; return () => (cached ??= fn()); };
+
+      const _d0 = memo(() => JSON.parse("{\\"flag_a\\":{\\"value\\":true}}"));
+
+      const map = {
+        "faab116281fa4201059a73f3ca8b7cad7fce9e1132988008784883fa2c78d64a": _d0,
+      };
+
+      export function get(key) {
+        return map[key]?.() ?? null;
+      }
+
+      export const version = "1.0.1";"
+    `);
   });
 
   it('sends default user-agent with package version', async () => {
@@ -147,7 +212,7 @@ describe('prepareFlagsDefinitions', () => {
       fetch: mockFetch,
     });
 
-    expect(result).toEqual({ created: false, reason: 'no-sdk-keys' });
+    expect(result).toEqual({ created: false, reason: 'no-flags-entries' });
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -157,18 +222,38 @@ describe('prepareFlagsDefinitions', () => {
       json: () => Promise.resolve({ flag_a: { value: true } }),
     });
 
+    const cwd = '/tmp/test-flags-format';
     const result = await prepareFlagsDefinitions({
-      cwd: '/tmp/test-flags-format',
+      cwd,
       env: {
         FLAGS_CONNECTION: 'flags:sdkKey=vf_server_my_key&other=value',
       },
       fetch: mockFetch,
     });
 
-    expect(result).toEqual({ created: true, sdkKeysCount: 1 });
+    expect(result).toEqual({ created: true, entryCount: 1 });
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const headers = mockFetch.mock.calls[0]?.[1]?.headers;
     expect(headers.authorization).toBe('Bearer vf_server_my_key');
+    const definitionsJs = await readFile(
+      `${cwd}/node_modules/@vercel/flags-definitions/index.js`,
+      'utf8',
+    );
+    expect(definitionsJs).toMatchInlineSnapshot(`
+      "const memo = (fn) => { let cached; return () => (cached ??= fn()); };
+
+      const _d0 = memo(() => JSON.parse("{\\"flag_a\\":{\\"value\\":true}}"));
+
+      const map = {
+        "3790790d2dc9b23c4539a9f3c49eb5820e4216daebdd7eeee9136f3ceccc31a3": _d0,
+      };
+
+      export function get(key) {
+        return map[key]?.() ?? null;
+      }
+
+      export const version = "1.0.1";"
+    `);
   });
 
   it('ignores invalid SDK keys in flags: connection string', async () => {
@@ -182,7 +267,137 @@ describe('prepareFlagsDefinitions', () => {
       fetch: mockFetch,
     });
 
-    expect(result).toEqual({ created: false, reason: 'no-sdk-keys' });
+    expect(result).toEqual({ created: false, reason: 'no-flags-entries' });
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('stores OIDC definitions under the token project_id', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ flag_a: { value: true } }),
+    });
+
+    const cwd = '/tmp/test-oidc-definitions';
+    const result = await prepareFlagsDefinitions({
+      cwd,
+      env: { VERCEL_OIDC_TOKEN: createOidcToken('prj_oidc_test') },
+      fetch: mockFetch,
+    });
+
+    expect(result).toEqual({ created: true, entryCount: 1 });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const headers = mockFetch.mock.calls[0]?.[1]?.headers;
+    expect(headers.authorization).toBe(
+      `Bearer ${createOidcToken('prj_oidc_test')}`,
+    );
+
+    const definitionsJs = await readFile(
+      `${cwd}/node_modules/@vercel/flags-definitions/index.js`,
+      'utf8',
+    );
+    expect(definitionsJs).toMatchInlineSnapshot(`
+      "const memo = (fn) => { let cached; return () => (cached ??= fn()); };
+
+      const _d0 = memo(() => JSON.parse("{\\"flag_a\\":{\\"value\\":true}}"));
+
+      const map = {
+        "prj_oidc_test": _d0,
+      };
+
+      export function get(key) {
+        return map[key]?.() ?? null;
+      }
+
+      export const version = "1.0.1";"
+    `);
+  });
+
+  it('stores OIDC definitions alongside SDK Keys', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ flag_a: { value: true } }),
+    });
+
+    const cwd = '/tmp/test-oidc-sdk-key-mix';
+    const result = await prepareFlagsDefinitions({
+      cwd,
+      env: {
+        VERCEL_OIDC_TOKEN: createOidcToken('prj_oidc_test'),
+        FLAGS: 'vf_server_test_key_123',
+      },
+      fetch: mockFetch,
+    });
+
+    expect(result).toEqual({ created: true, entryCount: 2 });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    const definitionsJs = await readFile(
+      `${cwd}/node_modules/@vercel/flags-definitions/index.js`,
+      'utf8',
+    );
+    expect(definitionsJs).toMatchInlineSnapshot(`
+      "const memo = (fn) => { let cached; return () => (cached ??= fn()); };
+
+      const _d0 = memo(() => JSON.parse("{\\"flag_a\\":{\\"value\\":true}}"));
+
+      const map = {
+        "faab116281fa4201059a73f3ca8b7cad7fce9e1132988008784883fa2c78d64a": _d0,
+        "prj_oidc_test": _d0,
+      };
+
+      export function get(key) {
+        return map[key]?.() ?? null;
+      }
+
+      export const version = "1.0.1";"
+    `);
+  });
+
+  it('stores OIDC definitions alongside SDK Keys with different datafiles', async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ flag_a: { value: true } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ flag_b: { value: true } }),
+      });
+
+    const cwd = '/tmp/test-oidc-sdk-key-mix';
+    const result = await prepareFlagsDefinitions({
+      cwd,
+      env: {
+        VERCEL_OIDC_TOKEN: createOidcToken('prj_oidc_test'),
+        FLAGS: 'vf_server_test_key_123',
+      },
+      fetch: mockFetch,
+    });
+
+    expect(result).toEqual({ created: true, entryCount: 2 });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    const definitionsJs = await readFile(
+      `${cwd}/node_modules/@vercel/flags-definitions/index.js`,
+      'utf8',
+    );
+    expect(definitionsJs).toMatchInlineSnapshot(`
+      "const memo = (fn) => { let cached; return () => (cached ??= fn()); };
+
+      const _d0 = memo(() => JSON.parse("{\\"flag_a\\":{\\"value\\":true}}"));
+      const _d1 = memo(() => JSON.parse("{\\"flag_b\\":{\\"value\\":true}}"));
+
+      const map = {
+        "faab116281fa4201059a73f3ca8b7cad7fce9e1132988008784883fa2c78d64a": _d0,
+        "prj_oidc_test": _d1,
+      };
+
+      export function get(key) {
+        return map[key]?.() ?? null;
+      }
+
+      export const version = "1.0.1";"
+    `);
   });
 });

--- a/packages/prepare-flags-definitions/src/index.ts
+++ b/packages/prepare-flags-definitions/src/index.ts
@@ -14,8 +14,8 @@ export interface Output {
 }
 
 export type PrepareFlagsDefinitionsResult =
-  | { created: false; reason: 'no-sdk-keys' }
-  | { created: true; sdkKeysCount: number };
+  | { created: false; reason: 'no-flags-entries' }
+  | { created: true; entryCount: number };
 
 /**
  * Obfuscates SDK key for logging (shows first 18 chars)
@@ -34,13 +34,128 @@ export function hashSdkKey(sdkKey: string): string {
   return createHash('sha256').update(sdkKey).digest('hex');
 }
 
+export function getProjectIdFromOidcToken(oidcToken: string) {
+  const tokenParts = oidcToken.split('.');
+  if (tokenParts.length !== 3 || !tokenParts[1]) {
+    return;
+  }
+
+  const payload = JSON.parse(
+    Buffer.from(tokenParts[1], 'base64url').toString('utf8'),
+  ) as { project_id?: unknown };
+
+  if (typeof payload.project_id !== 'string' || !payload.project_id) {
+    return;
+  }
+
+  return payload.project_id;
+}
+
+type DefinitionsEntry = {
+  key: string;
+  definitions: BundledDefinitions;
+};
+
+type MapEntry = {
+  key: string;
+  value: string;
+};
+
 /**
- * Regex to match valid Vercel Flags SDK keys.
- * SDK keys must follow the format: vf_server_* or vf_client_*
- * This avoids false positives with third-party identifiers that happen
- * to start with 'vf_' (e.g., Stripe identity flow IDs like 'vf_1PyH...').
+ * Creates js constants pointing to memoized deduplicated flag definitions.
+ * Output format:
+ * ```js
+ * const _d0 = memo(() => JSON.parse('...'));
+ * const _d1 = memo(() => JSON.parse('...'));
+ * ````
  */
-const SDK_KEY_REGEX = /^vf_(?:server|client)_/;
+function generateDefinitionConstants(
+  lines: string[],
+  entries: DefinitionsEntry[],
+): MapEntry[] {
+  const stringToConst = new Map<string, string>();
+
+  return entries.map((entry) => {
+    const stringified = JSON.stringify(entry.definitions);
+    let definitionConst = stringToConst.get(stringified);
+
+    if (!definitionConst) {
+      definitionConst = `_d${stringToConst.size}`;
+      stringToConst.set(stringified, definitionConst);
+      lines.push(
+        `const ${definitionConst} = memo(() => JSON.parse(${JSON.stringify(stringified)}));`,
+      );
+    }
+
+    return { key: entry.key, value: definitionConst };
+  });
+}
+
+/**
+ * Creates a js map and getter function for exposing key value pairs.
+ * Output format:
+ * ```js
+ * const map = { "<sha256_hash_or_project_id>": _d0 };
+ * export function get(key) { return map[key]?.() ?? null; }
+ * ````
+ */
+function generateMap(lines: string[], entries: MapEntry[]): void {
+  lines.push('');
+  lines.push('const map = {');
+  for (const entry of entries) {
+    lines.push(`  ${JSON.stringify(entry.key)}: ${entry.value},`);
+  }
+  lines.push('};');
+  lines.push('');
+  lines.push('export function get(key) {');
+  lines.push('  return map[key]?.() ?? null;');
+  lines.push('}');
+}
+
+async function fetchDatafile(
+  token: string,
+  env: Record<string, string | undefined>,
+  fetchFn: typeof globalThis.fetch,
+  userAgentSuffix?: string,
+): Promise<BundledDefinitions | undefined> {
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${token}`,
+    'user-agent': [
+      `@vercel/prepare-flags-definitions/${PACKAGE_VERSION}`,
+      userAgentSuffix,
+    ]
+      .filter(Boolean)
+      .join(' '),
+  };
+
+  // Add Vercel metadata headers if available
+  if (env.VERCEL_PROJECT_ID) {
+    headers['x-vercel-project-id'] = env.VERCEL_PROJECT_ID;
+  }
+  if (env.VERCEL_ENV) {
+    headers['x-vercel-env'] = env.VERCEL_ENV;
+  }
+  if (env.VERCEL_DEPLOYMENT_ID) {
+    headers['x-vercel-deployment-id'] = env.VERCEL_DEPLOYMENT_ID;
+  }
+  if (env.VERCEL_REGION) {
+    headers['x-vercel-region'] = env.VERCEL_REGION;
+  }
+
+  const res = await fetchFn(`${FLAGS_HOST}/v1/datafile`, { headers });
+
+  if (!res.ok) {
+    if (res.status === 404) {
+      return undefined;
+    }
+
+    throw new Error(
+      `Failed to fetch flag definitions for ${obfuscate(token)}: ${res.status} ${res.statusText}`,
+    );
+  }
+
+  return res.json() as Promise<BundledDefinitions>;
+}
 
 /**
  * Generates a JS module with deduplicated, lazily-parsed definitions.
@@ -57,59 +172,90 @@ const SDK_KEY_REGEX = /^vf_(?:server|client)_/;
  * ```
  */
 export function generateDefinitionsModule(
-  sdkKeys: string[],
-  values: BundledDefinitions[],
+  entries: DefinitionsEntry[],
+  output: Output | undefined,
 ): string {
-  // Stringify each definition
-  const stringified = sdkKeys.map((_, i) => JSON.stringify(values[i]));
-
-  // Deduplicate: map unique strings to indices
-  const uniqueStrings: string[] = [];
-  const stringToIndex = new Map<string, number>();
-  for (const s of stringified) {
-    if (!stringToIndex.has(s)) {
-      stringToIndex.set(s, uniqueStrings.length);
-      uniqueStrings.push(s);
-    }
-  }
-
-  // Map SDK keys to their definition index
-  const keyToIndex = sdkKeys.map(
-    (_, i) => stringToIndex.get(stringified[i]!) ?? 0,
+  output?.debug(
+    `vercel-flags: writing flag definitions for "${entries.map(({ key }) => obfuscate(key)).join(', ')}"`,
   );
 
-  // Hash each SDK key
-  const hashedKeys = sdkKeys.map(hashSdkKey);
-
-  // Generate JS
+  // generate shared js
   const lines: string[] = [
     'const memo = (fn) => { let cached; return () => (cached ??= fn()); };',
     '',
   ];
 
-  // Add definition constants
-  for (let i = 0; i < uniqueStrings.length; i++) {
-    lines.push(
-      `const _d${i} = memo(() => JSON.parse(${JSON.stringify(uniqueStrings[i])}));`,
-    );
-  }
+  // generate js const and capture the const names
+  const generatedDefinitions = generateDefinitionConstants(lines, entries);
 
-  lines.push('');
-  lines.push('const map = {');
-  for (let i = 0; i < sdkKeys.length; i++) {
-    lines.push(`  ${JSON.stringify(hashedKeys[i])}: _d${keyToIndex[i]},`);
-  }
-  lines.push('};');
-  lines.push('');
-  lines.push('export function get(hashedSdkKey) {');
-  lines.push('  return map[hashedSdkKey]?.() ?? null;');
-  lines.push('}');
-  lines.push('');
+  // generate a map wiring keys to const names
+  generateMap(lines, generatedDefinitions);
+
   lines.push(
+    '',
     `export const version = ${JSON.stringify(FLAGS_DEFINITIONS_VERSION)};`,
   );
 
   return lines.join('\n');
+}
+
+type FlagEntry = {
+  type: 'oidcToken' | 'sdkKey';
+  key: string;
+};
+
+/**
+ * Regex to match valid Vercel Flags SDK keys.
+ * SDK keys must follow the format: vf_server_* or vf_client_*
+ * This avoids false positives with third-party identifiers that happen
+ * to start with 'vf_' (e.g., Stripe identity flow IDs like 'vf_1PyH...').
+ */
+const SDK_KEY_REGEX = /^vf_(?:server|client)_/;
+
+/**
+ * Collect all possible flag entries the need embedding from the environment
+ */
+function collectFlagEntries(
+  env: Record<string, string | undefined>,
+  output: Output | undefined,
+): FlagEntry[] {
+  const entries: FlagEntry[] = [];
+
+  // Collect unique SDK keys from environment variables
+  // Supports both direct SDK keys (vf_server_*/vf_client_*) and flags: format
+  const sdkKeys = Array.from(
+    Object.values(env).reduce<Set<string>>((acc, value) => {
+      if (typeof value === 'string') {
+        if (SDK_KEY_REGEX.test(value)) {
+          acc.add(value);
+        } else if (value.startsWith('flags:')) {
+          const params = new URLSearchParams(value.slice('flags:'.length));
+          const sdkKey = params.get('sdkKey');
+          if (sdkKey && SDK_KEY_REGEX.test(sdkKey)) {
+            acc.add(sdkKey);
+          }
+        }
+      }
+      return acc;
+    }, new Set<string>()),
+  );
+
+  if (sdkKeys.length > 0) {
+    output?.debug(`vercel-flags: found ${sdkKeys.length} SDK keys`);
+
+    for (const key of sdkKeys) {
+      entries.push({ type: 'sdkKey', key });
+    }
+  }
+
+  const oidcToken = env.VERCEL_OIDC_TOKEN;
+  if (oidcToken && oidcToken?.length > 0) {
+    output?.debug(`vercel-flags: found OIDC token`);
+
+    entries.push({ type: 'oidcToken', key: oidcToken });
+  }
+
+  return entries;
 }
 
 /**
@@ -136,78 +282,49 @@ export async function prepareFlagsDefinitions(options: {
     output,
   } = options;
 
-  output?.debug('vercel-flags: checking env vars for SDK Keys');
+  output?.debug('vercel-flags: checking env vars for SDK Keys and OIDC Token');
 
-  // Collect unique SDK keys from environment variables
-  // Supports both direct SDK keys (vf_server_*/vf_client_*) and flags: format
-  const sdkKeys = Array.from(
-    Object.values(env).reduce<Set<string>>((acc, value) => {
-      if (typeof value === 'string') {
-        if (SDK_KEY_REGEX.test(value)) {
-          acc.add(value);
-        } else if (value.startsWith('flags:')) {
-          const params = new URLSearchParams(value.slice('flags:'.length));
-          const sdkKey = params.get('sdkKey');
-          if (sdkKey && SDK_KEY_REGEX.test(sdkKey)) {
-            acc.add(sdkKey);
-          }
-        }
-      }
-      return acc;
-    }, new Set<string>()),
-  );
-
-  output?.debug(`vercel-flags: found ${sdkKeys.length} SDK keys`);
-
-  if (sdkKeys.length === 0) {
-    return { created: false, reason: 'no-sdk-keys' };
+  const entries = collectFlagEntries(env, output);
+  if (entries.length === 0) {
+    return { created: false, reason: 'no-flags-entries' };
   }
 
-  // Fetch definitions for each SDK key
-  const fetchPromise = Promise.all(
-    sdkKeys.map(async (sdkKey) => {
-      const headers: Record<string, string> = {
-        authorization: `Bearer ${sdkKey}`,
-        'user-agent': [
-          `@vercel/prepare-flags-definitions/${PACKAGE_VERSION}`,
-          userAgentSuffix,
-        ]
-          .filter(Boolean)
-          .join(' '),
-      };
-
-      // Add Vercel metadata headers if available
-      if (env.VERCEL_PROJECT_ID) {
-        headers['x-vercel-project-id'] = env.VERCEL_PROJECT_ID;
-      }
-      if (env.VERCEL_ENV) {
-        headers['x-vercel-env'] = env.VERCEL_ENV;
-      }
-      if (env.VERCEL_DEPLOYMENT_ID) {
-        headers['x-vercel-deployment-id'] = env.VERCEL_DEPLOYMENT_ID;
-      }
-      if (env.VERCEL_REGION) {
-        headers['x-vercel-region'] = env.VERCEL_REGION;
+  // fetch all datafiles for sdk keys and oidc tokens
+  const resolvedEntries = await Promise.all(
+    entries.map(async ({ key, type }) => {
+      const definitions = await fetchDatafile(
+        key,
+        env,
+        fetchFn,
+        userAgentSuffix,
+      );
+      if (!definitions) {
+        return;
       }
 
-      const res = await fetchFn(`${FLAGS_HOST}/v1/datafile`, { headers });
+      if (type === 'oidcToken') {
+        const projectId = getProjectIdFromOidcToken(key);
 
-      if (!res.ok) {
-        throw new Error(
-          `Failed to fetch flag definitions for ${obfuscate(sdkKey)}: ${res.status} ${res.statusText}`,
-        );
+        if (projectId) {
+          return {
+            key: projectId,
+            definitions,
+          };
+        }
       }
 
-      return res.json() as Promise<BundledDefinitions>;
+      if (type === 'sdkKey') {
+        return {
+          key: hashSdkKey(key),
+          definitions,
+        };
+      }
     }),
   );
 
-  const values = output
-    ? await output.time('vercel-flags: load datafiles', fetchPromise)
-    : await fetchPromise;
+  const validEntries = resolvedEntries.filter((entry) => !!entry);
 
-  // Generate the JS module
-  const definitionsJs = generateDefinitionsModule(sdkKeys, values);
+  const definitionsJs = generateDefinitionsModule(validEntries, output);
 
   // Write to node_modules/@vercel/flags-definitions/
   const storageDir = join(cwd, 'node_modules', '@vercel', 'flags-definitions');
@@ -216,7 +333,7 @@ export async function prepareFlagsDefinitions(options: {
   const packageJsonPath = join(storageDir, 'package.json');
 
   const dts = [
-    'export function get(hashedSdkKey: string): Record<string, unknown> | null;',
+    'export function get(key: string): Record<string, unknown> | null;',
     'export const version: string;',
     '',
   ].join('\n');
@@ -246,9 +363,6 @@ export async function prepareFlagsDefinitions(options: {
   output?.debug(`  → ${indexPath}`);
   output?.debug(`  → ${dtsPath}`);
   output?.debug(`  → ${packageJsonPath}`);
-  output?.debug(
-    `  → included definitions for keys "${sdkKeys.map((key) => obfuscate(key)).join(', ')}"`,
-  );
 
-  return { created: true, sdkKeysCount: sdkKeys.length };
+  return { created: true, entryCount: entries.length };
 }

--- a/packages/prepare-flags-definitions/src/index.ts
+++ b/packages/prepare-flags-definitions/src/index.ts
@@ -167,8 +167,9 @@ async function fetchDatafile(
  * ```js
  * const memo = (fn) => { let cached; return () => (cached ??= fn()); };
  * const _d0 = memo(() => JSON.parse('...'));
- * const map = { "<sha256_hash>": _d0 };
- * export function get(hashedSdkKey) { return map[hashedSdkKey]?.() ?? null; }
+ * const _d1 = memo(() => JSON.parse('...'));
+ * const map = { "<sha256_hash>": _d0, "project_id": _d1 };
+ * export function get(key) { return map[key]?.() ?? null; }
  * ```
  */
 export function generateDefinitionsModule(

--- a/packages/vercel-flags-core/CLAUDE.md
+++ b/packages/vercel-flags-core/CLAUDE.md
@@ -84,7 +84,7 @@ type FlagsClient = {
 
 ```typescript
 type ControllerOptions = {
-  sdkKey?: string;
+  auth: Auth;
   datafile?: Datafile;  // Initial datafile for immediate reads
   stream?: boolean | { initTimeoutMs: number };      // default: true (3000ms)
   polling?: boolean | { intervalMs: number; initTimeoutMs: number };  // default: true (30s interval, 3s timeout)

--- a/packages/vercel-flags-core/CLAUDE.md
+++ b/packages/vercel-flags-core/CLAUDE.md
@@ -84,7 +84,7 @@ type FlagsClient = {
 
 ```typescript
 type ControllerOptions = {
-  sdkKey: string;
+  sdkKey?: string;
   datafile?: Datafile;  // Initial datafile for immediate reads
   stream?: boolean | { initTimeoutMs: number };      // default: true (3000ms)
   polling?: boolean | { intervalMs: number; initTimeoutMs: number };  // default: true (30s interval, 3s timeout)

--- a/packages/vercel-flags-core/package.json
+++ b/packages/vercel-flags-core/package.json
@@ -74,6 +74,7 @@
   },
   "dependencies": {
     "@vercel/functions": "^3.4.3",
+    "@vercel/oidc": "3.4.0",
     "jose": "5.2.1",
     "js-xxhash": "4.0.0"
   },

--- a/packages/vercel-flags-core/package.json
+++ b/packages/vercel-flags-core/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@vercel/functions": "^3.4.3",
-    "@vercel/oidc": "3.4.0",
+    "@vercel/oidc": "3.5.0",
     "jose": "5.2.1",
     "js-xxhash": "4.0.0"
   },

--- a/packages/vercel-flags-core/src/controller/auth.ts
+++ b/packages/vercel-flags-core/src/controller/auth.ts
@@ -1,0 +1,90 @@
+import { getVercelOidcToken } from '@vercel/oidc';
+import { parseSdkKeyFromFlagsConnectionString } from '../utils/sdk-keys';
+
+export type BundledDefinitionsLookup =
+  | { type: 'sdk-key'; sdkKey: string }
+  | { type: 'project-id'; projectId: string };
+
+export interface Auth {
+  sdkKey?: string;
+  resolveToken(): Promise<string>;
+  resolveBundledDefinitionsLookup(): Promise<BundledDefinitionsLookup>;
+}
+
+async function getOidcToken(): Promise<string> {
+  try {
+    return await getVercelOidcToken();
+  } catch {
+    throw new Error(
+      [
+        '@vercel/flags-core: Failed to get OIDC token.',
+        'Are you running in a Vercel Environment where OIDC tokens are available?',
+        'Did you mean to use an SDK Key instead? Use the environment variable FLAGS or pass it directly to the client.',
+      ].join(' '),
+    );
+  }
+}
+
+function getProjectIdFromOidcToken(oidcToken: string): string {
+  const tokenParts = oidcToken.split('.');
+  if (tokenParts.length !== 3 || !tokenParts[1]) {
+    throw new Error('@vercel/flags-core: Invalid OIDC token');
+  }
+
+  const payload = JSON.parse(
+    Buffer.from(tokenParts[1], 'base64url').toString('utf8'),
+  ) as { project_id?: unknown };
+
+  if (typeof payload.project_id !== 'string' || !payload.project_id) {
+    throw new Error(
+      '@vercel/flags-core: Missing project_id claim in OIDC token',
+    );
+  }
+
+  return payload.project_id;
+}
+
+export class Authentication implements Auth {
+  public readonly sdkKey?: string;
+
+  constructor(sdkKeyOrConnectionString: string | undefined) {
+    // validate sdk key format
+    if (sdkKeyOrConnectionString !== undefined) {
+      if (typeof sdkKeyOrConnectionString !== 'string') {
+        throw new Error(
+          `@vercel/flags-core: Invalid sdkKey. Expected string, got ${typeof sdkKeyOrConnectionString}`,
+        );
+      }
+
+      // Parse connection string if needed (e.g., "flags:edgeConfigId=...&sdkKey=vf_xxx")
+      const parsed = parseSdkKeyFromFlagsConnectionString(
+        sdkKeyOrConnectionString,
+      );
+      if (!parsed) {
+        throw new Error('@vercel/flags-core: Missing sdkKey');
+      }
+
+      this.sdkKey = parsed;
+    }
+  }
+
+  public async resolveToken() {
+    if (this.sdkKey) {
+      return this.sdkKey;
+    }
+
+    return await getOidcToken();
+  }
+
+  public async resolveBundledDefinitionsLookup(): Promise<BundledDefinitionsLookup> {
+    if (this.sdkKey) {
+      return { type: 'sdk-key', sdkKey: this.sdkKey };
+    }
+
+    const oidcToken = await this.resolveToken();
+    return {
+      type: 'project-id',
+      projectId: getProjectIdFromOidcToken(oidcToken),
+    };
+  }
+}

--- a/packages/vercel-flags-core/src/controller/bundled-source.ts
+++ b/packages/vercel-flags-core/src/controller/bundled-source.ts
@@ -5,6 +5,7 @@ import type {
   DatafileInput,
 } from '../types';
 import type { readBundledDefinitions } from '../utils/read-bundled-definitions';
+import type { Auth } from './auth';
 
 /**
  * Manages loading of bundled flag definitions.
@@ -12,17 +13,13 @@ import type { readBundledDefinitions } from '../utils/read-bundled-definitions';
  */
 export class BundledSource {
   private promise: Promise<BundledDefinitionsResult> | undefined;
-  private options: {
-    sdkKey: string;
-    readBundledDefinitions: typeof readBundledDefinitions;
-  };
 
-  constructor(options: {
-    sdkKey: string;
-    readBundledDefinitions: typeof readBundledDefinitions;
-  }) {
-    this.options = options;
-  }
+  constructor(
+    private options: {
+      auth: Auth;
+      readBundledDefinitions: typeof readBundledDefinitions;
+    },
+  ) {}
 
   /**
    * Load bundled definitions.
@@ -76,7 +73,7 @@ export class BundledSource {
 
   private getResult(): Promise<BundledDefinitionsResult> {
     if (!this.promise) {
-      this.promise = this.options.readBundledDefinitions(this.options.sdkKey);
+      this.promise = this.options.readBundledDefinitions(this.options.auth);
     }
     return this.promise;
   }

--- a/packages/vercel-flags-core/src/controller/fetch-datafile.ts
+++ b/packages/vercel-flags-core/src/controller/fetch-datafile.ts
@@ -1,5 +1,6 @@
 import { version } from '../../package.json';
 import type { BundledDefinitions } from '../types';
+import type { Auth } from './auth';
 
 const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
 
@@ -8,10 +9,12 @@ const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
  */
 export async function fetchDatafile(options: {
   host: string;
-  sdkKey: string;
+  auth: Auth;
   fetch: typeof globalThis.fetch;
   signal?: AbortSignal;
 }): Promise<BundledDefinitions> {
+  const token = await options.auth.resolveToken();
+
   const controller = new AbortController();
   const timeoutId = setTimeout(
     () => controller.abort(),
@@ -31,7 +34,7 @@ export async function fetchDatafile(options: {
   try {
     const res = await options.fetch(`${options.host}/v1/datafile`, {
       headers: {
-        Authorization: `Bearer ${options.sdkKey}`,
+        Authorization: `Bearer ${token}`,
         'User-Agent': `VercelFlagsCore/${version}`,
         ...(process.env.VERCEL_ENV
           ? { 'X-Vercel-Env': process.env.VERCEL_ENV }

--- a/packages/vercel-flags-core/src/controller/index.ts
+++ b/packages/vercel-flags-core/src/controller/index.ts
@@ -119,16 +119,6 @@ export class Controller implements ControllerInterface {
   private unauthorized = false;
 
   constructor(options: ControllerOptions) {
-    if (
-      !options.sdkKey ||
-      typeof options.sdkKey !== 'string' ||
-      !options.sdkKey.startsWith('vf_')
-    ) {
-      throw new Error(
-        '@vercel/flags-core: SDK key must be a string starting with "vf_"',
-      );
-    }
-
     this.options = normalizeOptions(options);
 
     // Create source modules
@@ -140,7 +130,7 @@ export class Controller implements ControllerInterface {
     this.pollingSource = new PollingSource(this.options);
 
     this.bundledSource = new BundledSource({
-      sdkKey: this.options.sdkKey,
+      auth: this.options.auth,
       readBundledDefinitions,
     });
 
@@ -388,7 +378,7 @@ export class Controller implements ControllerInterface {
         try {
           const fetched = await fetchDatafile({
             host: this.options.host,
-            sdkKey: this.options.sdkKey,
+            auth: this.options.auth,
             fetch: this.options.fetch,
           });
           this.data = tagData(fetched, 'fetched');
@@ -624,7 +614,7 @@ export class Controller implements ControllerInterface {
     try {
       const fetched = await fetchDatafile({
         host: this.options.host,
-        sdkKey: this.options.sdkKey,
+        auth: this.options.auth,
         fetch: this.options.fetch,
       });
       return tagData(fetched, 'fetched');
@@ -665,7 +655,7 @@ export class Controller implements ControllerInterface {
       try {
         const fetched = await fetchDatafile({
           host: this.options.host,
-          sdkKey: this.options.sdkKey,
+          auth: this.options.auth,
           fetch: this.options.fetch,
         });
         this.data = tagData(fetched, 'fetched');
@@ -730,7 +720,7 @@ export class Controller implements ControllerInterface {
       try {
         const fetched = await fetchDatafile({
           host: this.options.host,
-          sdkKey: this.options.sdkKey,
+          auth: this.options.auth,
           fetch: this.options.fetch,
         });
         this.data = tagData(fetched, 'fetched');

--- a/packages/vercel-flags-core/src/controller/normalized-options.ts
+++ b/packages/vercel-flags-core/src/controller/normalized-options.ts
@@ -1,4 +1,5 @@
 import type { DatafileInput, PollingOptions, StreamOptions } from '../types';
+import type { Auth } from './auth';
 
 const DEFAULT_STREAM_INIT_TIMEOUT_MS = 3000;
 const DEFAULT_POLLING_INTERVAL_MS = 30_000;
@@ -9,8 +10,8 @@ const DEFAULT_POLLING_INIT_TIMEOUT_MS = 3_000;
  * Configuration options for Controller
  */
 export type ControllerOptions = {
-  /** SDK key for authentication (must start with "vf_") */
-  sdkKey: string;
+  /** Authentication which resolves the token for requests */
+  auth: Auth;
 
   /**
    * Initial datafile to use immediately
@@ -54,7 +55,7 @@ export type ControllerOptions = {
 };
 
 export type NormalizedOptions = {
-  sdkKey: string;
+  auth: Auth;
   datafile: DatafileInput | undefined;
   stream: { enabled: boolean; initTimeoutMs: number };
   polling: { enabled: boolean; intervalMs: number; initTimeoutMs: number };
@@ -103,7 +104,7 @@ export function normalizeOptions(
   }
 
   return {
-    sdkKey: options.sdkKey,
+    auth: options.auth,
     datafile: options.datafile,
     stream,
     polling,

--- a/packages/vercel-flags-core/src/controller/polling-source.ts
+++ b/packages/vercel-flags-core/src/controller/polling-source.ts
@@ -1,10 +1,11 @@
 import type { DatafileInput } from '../types';
+import type { Auth } from './auth';
 import { fetchDatafile } from './fetch-datafile';
 import { TypedEmitter } from './typed-emitter';
 
 export type PollingSourceConfig = {
   host: string;
-  sdkKey: string;
+  auth: Auth;
   polling: {
     intervalMs: number;
   };

--- a/packages/vercel-flags-core/src/controller/stream-connection.test.ts
+++ b/packages/vercel-flags-core/src/controller/stream-connection.test.ts
@@ -63,7 +63,12 @@ describe('connectStream', () => {
       const onDatafile = vi.fn();
 
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile },
       );
 
@@ -85,7 +90,12 @@ describe('connectStream', () => {
       const onDatafile = vi.fn();
 
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile },
       );
 
@@ -109,7 +119,12 @@ describe('connectStream', () => {
       const onDatafile = vi.fn();
 
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile },
       );
 
@@ -144,7 +159,12 @@ describe('connectStream', () => {
       const onDatafile = vi.fn();
 
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile },
       );
 
@@ -177,7 +197,12 @@ describe('connectStream', () => {
       const onDatafile = vi.fn();
 
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile },
       );
 
@@ -194,7 +219,12 @@ describe('connectStream', () => {
     it('should include Authorization header with Bearer token', async () => {
       const abortController = new AbortController();
       await connectStream(
-        { host: HOST, token: 'vf_my_key', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_my_key'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile: vi.fn() },
       );
 
@@ -209,7 +239,12 @@ describe('connectStream', () => {
     it('should include User-Agent header with version', async () => {
       const abortController = new AbortController();
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile: vi.fn() },
       );
 
@@ -224,7 +259,12 @@ describe('connectStream', () => {
     it('should include X-Retry-Attempt header starting at 0', async () => {
       const abortController = new AbortController();
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile: vi.fn() },
       );
 
@@ -253,7 +293,12 @@ describe('connectStream', () => {
       const onDisconnect = vi.fn();
 
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile: vi.fn(), onDisconnect },
       );
 
@@ -271,6 +316,38 @@ describe('connectStream', () => {
       abortController.abort();
     });
 
+    it('should resolve a fresh token on reconnect', async () => {
+      let requestCount = 0;
+      const resolveToken = vi
+        .fn<() => Promise<string>>()
+        .mockResolvedValueOnce('token-1')
+        .mockResolvedValueOnce('token-2');
+
+      fetchMock.mockImplementation(() => {
+        requestCount++;
+        return ndjsonResponse([datafileMsg()], { keepOpen: requestCount >= 2 });
+      });
+
+      const abortController = new AbortController();
+
+      await connectStream(
+        { host: HOST, resolveToken, abortController, fetch: fetchMock },
+        { onDatafile: vi.fn() },
+      );
+
+      // Advance past the reconnection backoff delay
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(resolveToken).toHaveBeenCalledTimes(2);
+      const h0 = fetchMock.mock.calls[0]![1]!.headers as Record<string, string>;
+      const h1 = fetchMock.mock.calls[1]![1]!.headers as Record<string, string>;
+      expect(h0.Authorization).toBe('Bearer token-1');
+      expect(h1.Authorization).toBe('Bearer token-2');
+
+      abortController.abort();
+    });
+
     it('should reset retryCount to 0 after receiving datafile', async () => {
       let requestCount = 0;
 
@@ -282,7 +359,12 @@ describe('connectStream', () => {
       const abortController = new AbortController();
 
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile: vi.fn() },
       );
 
@@ -318,7 +400,12 @@ describe('connectStream', () => {
       const abortController = new AbortController();
 
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile: vi.fn() },
       );
 
@@ -356,7 +443,12 @@ describe('connectStream', () => {
       const onDisconnect = vi.fn();
 
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile: vi.fn(), onDisconnect },
       );
 
@@ -376,6 +468,24 @@ describe('connectStream', () => {
     // but the promise resolution is handled by the timeout mechanism in
     // Controller.
 
+    it('should reject if resolving the token fails before first datafile', async () => {
+      const authError = new Error('auth unavailable');
+      const resolveToken = vi
+        .fn<() => Promise<string>>()
+        .mockRejectedValue(authError);
+      const abortController = new AbortController();
+
+      const promise = connectStream(
+        { host: HOST, resolveToken, abortController, fetch: fetchMock },
+        { onDatafile: vi.fn() },
+      );
+
+      await expect(promise).rejects.toBe(authError);
+      expect(resolveToken).toHaveBeenCalledTimes(1);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(abortController.signal.aborted).toBe(true);
+    });
+
     it('should retry on error before first datafile and reject when aborted', async () => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -389,7 +499,12 @@ describe('connectStream', () => {
       const abortController = new AbortController();
 
       const promise = connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile: vi.fn() },
       );
 
@@ -431,7 +546,12 @@ describe('connectStream', () => {
       const abortController = new AbortController();
 
       const promise = connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile: vi.fn() },
       );
 
@@ -472,7 +592,12 @@ describe('connectStream', () => {
       const onDisconnect = vi.fn();
 
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile: vi.fn(), onDisconnect },
       );
 
@@ -519,7 +644,12 @@ describe('connectStream', () => {
       const onDatafile = vi.fn();
 
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile },
       );
 
@@ -561,7 +691,12 @@ describe('connectStream', () => {
       const onDisconnect = vi.fn();
 
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile: vi.fn(), onDisconnect },
       );
 
@@ -605,7 +740,12 @@ describe('connectStream', () => {
       const abortController = new AbortController();
 
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile: vi.fn() },
       );
 
@@ -644,7 +784,12 @@ describe('connectStream', () => {
       const abortController = new AbortController();
 
       const promise = connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile: vi.fn() },
       );
 
@@ -680,7 +825,12 @@ describe('connectStream', () => {
       const onDatafile = vi.fn();
 
       const promise = connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile },
       );
 
@@ -709,7 +859,7 @@ describe('connectStream', () => {
       await connectStream(
         {
           host: HOST,
-          token: 'vf_test',
+          resolveToken: () => Promise.resolve('vf_test'),
           abortController,
           fetch: fetchMock,
           revision: () => 42,
@@ -728,7 +878,12 @@ describe('connectStream', () => {
     it('should not include X-Revision header when revision is undefined', async () => {
       const abortController = new AbortController();
       await connectStream(
-        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
         { onDatafile: vi.fn() },
       );
 
@@ -768,7 +923,7 @@ describe('connectStream', () => {
       await connectStream(
         {
           host: HOST,
-          token: 'vf_test',
+          resolveToken: () => Promise.resolve('vf_test'),
           abortController,
           fetch: fetchMock,
           revision: () => currentRevision,
@@ -825,7 +980,7 @@ describe('connectStream', () => {
       await connectStream(
         {
           host: HOST,
-          token: 'vf_test',
+          resolveToken: () => Promise.resolve('vf_test'),
           abortController,
           fetch: fetchMock,
           revision: () => 33,
@@ -860,7 +1015,7 @@ describe('connectStream', () => {
       await connectStream(
         {
           host: HOST,
-          token: 'vf_test',
+          resolveToken: () => Promise.resolve('vf_test'),
           abortController,
           fetch: fetchMock,
           revision: () => 5,
@@ -910,7 +1065,7 @@ describe('connectStream', () => {
       await connectStream(
         {
           host: HOST,
-          token: 'vf_test',
+          resolveToken: () => Promise.resolve('vf_test'),
           abortController,
           fetch: fetchMock,
           revision: () => 1,

--- a/packages/vercel-flags-core/src/controller/stream-connection.test.ts
+++ b/packages/vercel-flags-core/src/controller/stream-connection.test.ts
@@ -63,7 +63,7 @@ describe('connectStream', () => {
       const onDatafile = vi.fn();
 
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile },
       );
 
@@ -85,7 +85,7 @@ describe('connectStream', () => {
       const onDatafile = vi.fn();
 
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile },
       );
 
@@ -109,7 +109,7 @@ describe('connectStream', () => {
       const onDatafile = vi.fn();
 
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile },
       );
 
@@ -144,7 +144,7 @@ describe('connectStream', () => {
       const onDatafile = vi.fn();
 
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile },
       );
 
@@ -177,7 +177,7 @@ describe('connectStream', () => {
       const onDatafile = vi.fn();
 
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile },
       );
 
@@ -194,7 +194,7 @@ describe('connectStream', () => {
     it('should include Authorization header with Bearer token', async () => {
       const abortController = new AbortController();
       await connectStream(
-        { host: HOST, sdkKey: 'vf_my_key', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_my_key', abortController, fetch: fetchMock },
         { onDatafile: vi.fn() },
       );
 
@@ -209,7 +209,7 @@ describe('connectStream', () => {
     it('should include User-Agent header with version', async () => {
       const abortController = new AbortController();
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile: vi.fn() },
       );
 
@@ -224,7 +224,7 @@ describe('connectStream', () => {
     it('should include X-Retry-Attempt header starting at 0', async () => {
       const abortController = new AbortController();
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile: vi.fn() },
       );
 
@@ -253,7 +253,7 @@ describe('connectStream', () => {
       const onDisconnect = vi.fn();
 
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile: vi.fn(), onDisconnect },
       );
 
@@ -282,7 +282,7 @@ describe('connectStream', () => {
       const abortController = new AbortController();
 
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile: vi.fn() },
       );
 
@@ -318,7 +318,7 @@ describe('connectStream', () => {
       const abortController = new AbortController();
 
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile: vi.fn() },
       );
 
@@ -356,7 +356,7 @@ describe('connectStream', () => {
       const onDisconnect = vi.fn();
 
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile: vi.fn(), onDisconnect },
       );
 
@@ -389,7 +389,7 @@ describe('connectStream', () => {
       const abortController = new AbortController();
 
       const promise = connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile: vi.fn() },
       );
 
@@ -431,7 +431,7 @@ describe('connectStream', () => {
       const abortController = new AbortController();
 
       const promise = connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile: vi.fn() },
       );
 
@@ -472,7 +472,7 @@ describe('connectStream', () => {
       const onDisconnect = vi.fn();
 
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile: vi.fn(), onDisconnect },
       );
 
@@ -519,7 +519,7 @@ describe('connectStream', () => {
       const onDatafile = vi.fn();
 
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile },
       );
 
@@ -561,7 +561,7 @@ describe('connectStream', () => {
       const onDisconnect = vi.fn();
 
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile: vi.fn(), onDisconnect },
       );
 
@@ -605,7 +605,7 @@ describe('connectStream', () => {
       const abortController = new AbortController();
 
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile: vi.fn() },
       );
 
@@ -644,7 +644,7 @@ describe('connectStream', () => {
       const abortController = new AbortController();
 
       const promise = connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile: vi.fn() },
       );
 
@@ -680,7 +680,7 @@ describe('connectStream', () => {
       const onDatafile = vi.fn();
 
       const promise = connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile },
       );
 
@@ -709,7 +709,7 @@ describe('connectStream', () => {
       await connectStream(
         {
           host: HOST,
-          sdkKey: 'vf_test',
+          token: 'vf_test',
           abortController,
           fetch: fetchMock,
           revision: () => 42,
@@ -728,7 +728,7 @@ describe('connectStream', () => {
     it('should not include X-Revision header when revision is undefined', async () => {
       const abortController = new AbortController();
       await connectStream(
-        { host: HOST, sdkKey: 'vf_test', abortController, fetch: fetchMock },
+        { host: HOST, token: 'vf_test', abortController, fetch: fetchMock },
         { onDatafile: vi.fn() },
       );
 
@@ -768,7 +768,7 @@ describe('connectStream', () => {
       await connectStream(
         {
           host: HOST,
-          sdkKey: 'vf_test',
+          token: 'vf_test',
           abortController,
           fetch: fetchMock,
           revision: () => currentRevision,
@@ -825,7 +825,7 @@ describe('connectStream', () => {
       await connectStream(
         {
           host: HOST,
-          sdkKey: 'vf_test',
+          token: 'vf_test',
           abortController,
           fetch: fetchMock,
           revision: () => 33,
@@ -860,7 +860,7 @@ describe('connectStream', () => {
       await connectStream(
         {
           host: HOST,
-          sdkKey: 'vf_test',
+          token: 'vf_test',
           abortController,
           fetch: fetchMock,
           revision: () => 5,
@@ -910,7 +910,7 @@ describe('connectStream', () => {
       await connectStream(
         {
           host: HOST,
-          sdkKey: 'vf_test',
+          token: 'vf_test',
           abortController,
           fetch: fetchMock,
           revision: () => 1,

--- a/packages/vercel-flags-core/src/controller/stream-connection.ts
+++ b/packages/vercel-flags-core/src/controller/stream-connection.ts
@@ -35,6 +35,13 @@ export class UnauthorizedError extends Error {
   }
 }
 
+class TokenResolutionError extends Error {
+  constructor(error: unknown) {
+    super('stream: token resolution failed', { cause: error });
+    this.name = 'TokenResolutionError';
+  }
+}
+
 export type StreamCallbacks = {
   onDatafile: (data: BundledDefinitions) => void;
   onPrimed?: (message: PrimedMessage) => void;
@@ -43,11 +50,11 @@ export type StreamCallbacks = {
 
 export type StreamConfig = {
   host: string;
-  token: string;
   abortController: AbortController;
   fetch?: typeof globalThis.fetch;
   /** Returns the current revision number to send as X-Revision header */
   revision?: () => number | undefined;
+  resolveToken: () => Promise<string>;
 };
 
 /**
@@ -109,8 +116,11 @@ export async function connectStream(
 
       try {
         lastAttemptTime = Date.now();
+        const token = await config.resolveToken().catch((error) => {
+          throw new TokenResolutionError(error);
+        });
         const headers: Record<string, string> = {
-          Authorization: `Bearer ${config.token}`,
+          Authorization: `Bearer ${token}`,
           'User-Agent': `VercelFlagsCore/${version}`,
           'X-Retry-Attempt': String(retryCount),
         };
@@ -234,6 +244,11 @@ export async function connectStream(
         clearTimeout(pingTimeoutId);
         abortController.signal.removeEventListener('abort', onMainAbort);
         if (abortController.signal.aborted) {
+          break;
+        }
+        if (error instanceof TokenResolutionError && !initialDataReceived) {
+          rejectInit!(error.cause);
+          abortController.abort();
           break;
         }
         // Ping timeout aborts only the per-connection controller; this is

--- a/packages/vercel-flags-core/src/controller/stream-connection.ts
+++ b/packages/vercel-flags-core/src/controller/stream-connection.ts
@@ -43,8 +43,7 @@ export type StreamCallbacks = {
 
 export type StreamConfig = {
   host: string;
-  token?: string;
-  sdkKey?: string;
+  token: string;
   abortController: AbortController;
   fetch?: typeof globalThis.fetch;
   /** Returns the current revision number to send as X-Revision header */
@@ -61,10 +60,6 @@ export async function connectStream(
   callbacks: StreamCallbacks,
 ): Promise<void> {
   const { host, abortController, fetch: fetchFn = globalThis.fetch } = config;
-  const token = config.token ?? config.sdkKey;
-  if (!token) {
-    throw new Error('stream: missing auth token');
-  }
   const { onDatafile, onPrimed, onDisconnect } = callbacks;
   let retryCount = 0;
   let lastAttemptTime = 0;
@@ -115,7 +110,7 @@ export async function connectStream(
       try {
         lastAttemptTime = Date.now();
         const headers: Record<string, string> = {
-          Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${config.token}`,
           'User-Agent': `VercelFlagsCore/${version}`,
           'X-Retry-Attempt': String(retryCount),
         };

--- a/packages/vercel-flags-core/src/controller/stream-connection.ts
+++ b/packages/vercel-flags-core/src/controller/stream-connection.ts
@@ -43,7 +43,8 @@ export type StreamCallbacks = {
 
 export type StreamConfig = {
   host: string;
-  sdkKey: string;
+  token?: string;
+  sdkKey?: string;
   abortController: AbortController;
   fetch?: typeof globalThis.fetch;
   /** Returns the current revision number to send as X-Revision header */
@@ -59,12 +60,11 @@ export async function connectStream(
   config: StreamConfig,
   callbacks: StreamCallbacks,
 ): Promise<void> {
-  const {
-    host,
-    sdkKey,
-    abortController,
-    fetch: fetchFn = globalThis.fetch,
-  } = config;
+  const { host, abortController, fetch: fetchFn = globalThis.fetch } = config;
+  const token = config.token ?? config.sdkKey;
+  if (!token) {
+    throw new Error('stream: missing auth token');
+  }
   const { onDatafile, onPrimed, onDisconnect } = callbacks;
   let retryCount = 0;
   let lastAttemptTime = 0;
@@ -115,7 +115,7 @@ export async function connectStream(
       try {
         lastAttemptTime = Date.now();
         const headers: Record<string, string> = {
-          Authorization: `Bearer ${sdkKey}`,
+          Authorization: `Bearer ${token}`,
           'User-Agent': `VercelFlagsCore/${version}`,
           'X-Retry-Attempt': String(retryCount),
         };

--- a/packages/vercel-flags-core/src/controller/stream-source.ts
+++ b/packages/vercel-flags-core/src/controller/stream-source.ts
@@ -52,27 +52,29 @@ export class StreamSource extends TypedEmitter<StreamSourceEvents> {
     );
 
     try {
-      const promise = connectStream(
-        {
-          host: this.options.host,
-          sdkKey: this.options.sdkKey,
-          abortController,
-          fetch: this.options.fetch,
-          revision: this.revision,
-        },
-        {
-          onDatafile: (newData) => {
-            this.emit('data', newData);
-            this.emit('connected');
+      const promise = this.options.auth.resolveToken().then((token) =>
+        connectStream(
+          {
+            host: this.options.host,
+            token,
+            abortController,
+            fetch: this.options.fetch,
+            revision: this.revision,
           },
-          onPrimed: (message) => {
-            this.emit('primed', message);
-            this.emit('connected');
+          {
+            onDatafile: (newData) => {
+              this.emit('data', newData);
+              this.emit('connected');
+            },
+            onPrimed: (message) => {
+              this.emit('primed', message);
+              this.emit('connected');
+            },
+            onDisconnect: () => {
+              this.emit('disconnected');
+            },
           },
-          onDisconnect: () => {
-            this.emit('disconnected');
-          },
-        },
+        ),
       );
 
       this.promise = promise;

--- a/packages/vercel-flags-core/src/controller/stream-source.ts
+++ b/packages/vercel-flags-core/src/controller/stream-source.ts
@@ -52,29 +52,27 @@ export class StreamSource extends TypedEmitter<StreamSourceEvents> {
     );
 
     try {
-      const promise = this.options.auth.resolveToken().then((token) =>
-        connectStream(
-          {
-            host: this.options.host,
-            token,
-            abortController,
-            fetch: this.options.fetch,
-            revision: this.revision,
+      const promise = connectStream(
+        {
+          host: this.options.host,
+          resolveToken: () => this.options.auth.resolveToken(),
+          abortController,
+          fetch: this.options.fetch,
+          revision: this.revision,
+        },
+        {
+          onDatafile: (newData) => {
+            this.emit('data', newData);
+            this.emit('connected');
           },
-          {
-            onDatafile: (newData) => {
-              this.emit('data', newData);
-              this.emit('connected');
-            },
-            onPrimed: (message) => {
-              this.emit('primed', message);
-              this.emit('connected');
-            },
-            onDisconnect: () => {
-              this.emit('disconnected');
-            },
+          onPrimed: (message) => {
+            this.emit('primed', message);
+            this.emit('connected');
           },
-        ),
+          onDisconnect: () => {
+            this.emit('disconnected');
+          },
+        },
       );
 
       this.promise = promise;

--- a/packages/vercel-flags-core/src/create-raw-client.ts
+++ b/packages/vercel-flags-core/src/create-raw-client.ts
@@ -45,7 +45,7 @@ export function createCreateRawClient(fns: {
     origin,
   }: {
     controller: ControllerInterface;
-    origin?: { provider: string; sdkKey: string };
+    origin?: { provider: string; sdkKey?: string };
   }): FlagsClient<Entities> {
     const id = idCount++;
     controllerInstanceMap.set(id, {

--- a/packages/vercel-flags-core/src/index.make.test.ts
+++ b/packages/vercel-flags-core/src/index.make.test.ts
@@ -4,8 +4,8 @@ import { make } from './index.make';
 
 // Mock the Controller to avoid real network calls
 vi.mock('./controller', () => ({
-  Controller: vi.fn().mockImplementation(({ sdkKey }) => ({
-    sdkKey,
+  Controller: vi.fn().mockImplementation(({ auth }) => ({
+    auth,
     read: vi.fn().mockResolvedValue({
       projectId: 'test',
       definitions: {},
@@ -20,7 +20,7 @@ vi.mock('./controller', () => ({
 import { Controller } from './controller';
 
 function createMockCreateRawClient(): ReturnType<typeof createCreateRawClient> {
-  return vi.fn().mockImplementation(({ dataSource }) => ({
+  return vi.fn().mockImplementation(({ controller }) => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     shutdown: vi.fn().mockResolvedValue(undefined),
     getDatafile: vi.fn().mockResolvedValue({
@@ -38,7 +38,7 @@ function createMockCreateRawClient(): ReturnType<typeof createCreateRawClient> {
       revision: 1,
     }),
     evaluate: vi.fn().mockResolvedValue({ value: true, reason: 'static' }),
-    _dataSource: dataSource, // For testing inspection
+    _dataSource: controller, // For testing inspection
   }));
 }
 
@@ -63,7 +63,7 @@ describe('make', () => {
       const client = createClient('vf_server_test_key');
 
       expect(Controller).toHaveBeenCalledWith({
-        sdkKey: 'vf_server_test_key',
+        auth: expect.objectContaining({ sdkKey: 'vf_server_test_key' }),
       });
       expect(createRawClient).toHaveBeenCalled();
       expect(client).toBeDefined();
@@ -78,7 +78,7 @@ describe('make', () => {
       const client = createClient(connectionString);
 
       expect(Controller).toHaveBeenCalledWith({
-        sdkKey: 'vf_client_conn_key',
+        auth: expect.objectContaining({ sdkKey: 'vf_client_conn_key' }),
       });
       expect(client).toBeDefined();
     });
@@ -127,15 +127,16 @@ describe('make', () => {
       expect(createRawClient).toHaveBeenCalledTimes(1);
     });
 
-    it('should throw if FLAGS env var is missing when accessed', () => {
+    it('should create an OIDC-authenticated default client if FLAGS env var is missing', () => {
       const createRawClient = createMockCreateRawClient();
       delete process.env.FLAGS;
 
       const { flagsClient } = make(createRawClient);
+      const _ = flagsClient.evaluate;
 
-      expect(() => flagsClient.evaluate).toThrow(
-        'flags: Missing environment variable FLAGS',
-      );
+      expect(Controller).toHaveBeenCalledWith({
+        auth: expect.objectContaining({ sdkKey: undefined }),
+      });
     });
 
     it('should throw if FLAGS env var has invalid value', () => {
@@ -172,7 +173,7 @@ describe('make', () => {
       const _ = flagsClient.evaluate;
 
       expect(Controller).toHaveBeenCalledWith({
-        sdkKey: 'vf_server_env_key',
+        auth: expect.objectContaining({ sdkKey: 'vf_server_env_key' }),
       });
     });
 
@@ -185,7 +186,7 @@ describe('make', () => {
       const _ = flagsClient.evaluate;
 
       expect(Controller).toHaveBeenCalledWith({
-        sdkKey: 'vf_client_flags_key',
+        auth: expect.objectContaining({ sdkKey: 'vf_client_flags_key' }),
       });
     });
   });
@@ -218,7 +219,7 @@ describe('make', () => {
       // Access with first key
       const _ = flagsClient.evaluate;
       expect(Controller).toHaveBeenCalledWith({
-        sdkKey: 'vf_server_first_key',
+        auth: expect.objectContaining({ sdkKey: 'vf_server_first_key' }),
       });
 
       // Reset and change env
@@ -228,7 +229,7 @@ describe('make', () => {
       // Access again with new key
       const __ = flagsClient.initialize;
       expect(Controller).toHaveBeenCalledWith({
-        sdkKey: 'vf_client_second_key',
+        auth: expect.objectContaining({ sdkKey: 'vf_client_second_key' }),
       });
     });
   });

--- a/packages/vercel-flags-core/src/index.make.ts
+++ b/packages/vercel-flags-core/src/index.make.ts
@@ -3,14 +3,14 @@
  */
 
 import { Controller, type ControllerOptions } from './controller';
+import { Authentication } from './controller/auth';
 import type { createCreateRawClient } from './create-raw-client';
 import type { FlagsClient } from './types';
-import { parseSdkKeyFromFlagsConnectionString } from './utils/sdk-keys';
 
 /**
  * Options for createClient
  */
-export type CreateClientOptions = Omit<ControllerOptions, 'sdkKey'>;
+export type CreateClientOptions = Omit<ControllerOptions, 'auth'>;
 
 export function make(
   createRawClient: ReturnType<typeof createCreateRawClient>,
@@ -18,7 +18,7 @@ export function make(
   flagsClient: FlagsClient;
   resetDefaultFlagsClient: () => void;
   createClient: <Entities = Record<string, unknown>>(
-    sdkKeyOrConnectionString: string,
+    sdkKeyOrConnectionString?: string,
     options?: CreateClientOptions,
   ) => FlagsClient<Entities>;
 } {
@@ -28,32 +28,16 @@ export function make(
   // - data source must specify the environment & projectId as sdkKey has that info
   // - "reuse" functionality relies on the data source having the data for all envs
   function createClient<Entities = Record<string, unknown>>(
-    sdkKeyOrConnectionString: string,
+    sdkKeyOrConnectionString?: string,
     options?: CreateClientOptions,
   ): FlagsClient<Entities> {
-    if (!sdkKeyOrConnectionString)
-      throw new Error('@vercel/flags-core: Missing sdkKey');
-
-    if (typeof sdkKeyOrConnectionString !== 'string')
-      throw new Error(
-        `@vercel/flags-core: Invalid sdkKey. Expected string, got ${typeof sdkKeyOrConnectionString}`,
-      );
-
-    // Parse connection string if needed (e.g., "flags:edgeConfigId=...&sdkKey=vf_xxx")
-    const sdkKey = parseSdkKeyFromFlagsConnectionString(
-      sdkKeyOrConnectionString,
-    );
-    if (!sdkKey) {
-      throw new Error(
-        '@vercel/flags-core: Missing sdkKey in connection string',
-      );
-    }
+    const auth = new Authentication(sdkKeyOrConnectionString);
 
     // sdk key contains the environment
-    const controller = new Controller({ sdkKey, ...options });
+    const controller = new Controller({ auth, ...options });
     return createRawClient<Entities>({
       controller,
-      origin: { provider: 'vercel', sdkKey },
+      origin: { provider: 'vercel', sdkKey: auth.sdkKey },
     });
   }
 
@@ -64,15 +48,7 @@ export function make(
   const flagsClient: FlagsClient = new Proxy({} as FlagsClient, {
     get(_, prop) {
       if (!_defaultFlagsClient) {
-        if (!process.env.FLAGS) {
-          throw new Error('flags: Missing environment variable FLAGS');
-        }
-
-        const sdkKey = parseSdkKeyFromFlagsConnectionString(process.env.FLAGS);
-        if (!sdkKey) {
-          throw new Error('@vercel/flags-core: Missing sdkKey');
-        }
-        _defaultFlagsClient = createClient(sdkKey);
+        _defaultFlagsClient = createClient(process.env.FLAGS);
       }
       return _defaultFlagsClient[prop as keyof FlagsClient];
     },

--- a/packages/vercel-flags-core/src/types.ts
+++ b/packages/vercel-flags-core/src/types.ts
@@ -120,11 +120,12 @@ export type Source = {
  */
 export type FlagsClient<Entities = Record<string, unknown>> = {
   /**
-   * Origin information for this client (provider and sdkKey)
+   * Origin information for this client.
+   * sdkKey is only present when the client was explicitly created with one.
    */
   origin?: {
     provider: string;
-    sdkKey: string;
+    sdkKey?: string;
   };
   /**
    * Evaluate a feature flag

--- a/packages/vercel-flags-core/src/types/flags-definitions.d.ts
+++ b/packages/vercel-flags-core/src/types/flags-definitions.d.ts
@@ -1,4 +1,4 @@
 declare module '@vercel/flags-definitions' {
-  export function get(hashedSdkKey: string): Record<string, unknown> | null;
+  export function get(key: string): Record<string, unknown> | null;
   export const version: string;
 }

--- a/packages/vercel-flags-core/src/utils/read-bundled-definitions.test.ts
+++ b/packages/vercel-flags-core/src/utils/read-bundled-definitions.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Auth } from '../controller/auth';
 
 // The readBundledDefinitions function uses dynamic import which is hard to mock.
 // Instead, we test the behavior indirectly through the Controller
@@ -7,6 +8,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('readBundledDefinitions', () => {
   const originalEnv = process.env;
+  const auth: Auth = {
+    sdkKey: 'test-id',
+    resolveToken: () => Promise.resolve('test-id'),
+    resolveBundledDefinitionsLookup: () =>
+      Promise.resolve({ type: 'sdk-key', sdkKey: 'test-id' }),
+  };
 
   beforeEach(() => {
     vi.resetModules();
@@ -26,7 +33,7 @@ describe('readBundledDefinitions', () => {
     expect(typeof readBundledDefinitions).toBe('function');
 
     // Calling it should return a promise (will likely fail since the module doesn't exist)
-    const result = readBundledDefinitions('test-id');
+    const result = readBundledDefinitions(auth);
     expect(result).toBeInstanceOf(Promise);
 
     // The result should have the expected shape
@@ -40,7 +47,7 @@ describe('readBundledDefinitions', () => {
       './read-bundled-definitions'
     );
 
-    const result = await readBundledDefinitions('nonexistent-id');
+    const result = await readBundledDefinitions(auth);
 
     // Since @vercel/flags-definitions/definitions.json doesn't exist in test env,
     // it should return either missing-file or unexpected-error
@@ -55,12 +62,43 @@ describe('readBundledDefinitions', () => {
       './read-bundled-definitions'
     );
 
-    const result = await readBundledDefinitions('nonexistent-id');
+    const result = await readBundledDefinitions(auth);
 
     expect(result).toEqual({
       definitions: null,
       state: 'missing-file',
     });
+  });
+
+  it('should read OIDC bundled definitions by project id', async () => {
+    const definitions = {
+      projectId: 'prj_test',
+      environment: 'production',
+      definitions: {},
+      configUpdatedAt: 1,
+      digest: 'digest',
+      revision: 1,
+    };
+    const get = vi.fn((key: string) =>
+      key === 'prj_test' ? definitions : null,
+    );
+    vi.doMock('@vercel/flags-definitions', () => ({ get }));
+
+    const oidcAuth: Auth = {
+      resolveToken: () => Promise.resolve('token'),
+      resolveBundledDefinitionsLookup: () =>
+        Promise.resolve({ type: 'project-id', projectId: 'prj_test' }),
+    };
+
+    const { readBundledDefinitions } = await import(
+      './read-bundled-definitions'
+    );
+
+    await expect(readBundledDefinitions(oidcAuth)).resolves.toEqual({
+      definitions,
+      state: 'ok',
+    });
+    expect(get).toHaveBeenCalledWith('prj_test');
   });
 
   // The detailed behavior of readBundledDefinitions is tested indirectly

--- a/packages/vercel-flags-core/src/utils/read-bundled-definitions.ts
+++ b/packages/vercel-flags-core/src/utils/read-bundled-definitions.ts
@@ -4,6 +4,7 @@
 // is degraded or unavailable.
 //
 
+import type { Auth, BundledDefinitionsLookup } from '../controller/auth';
 import type { BundledDefinitions, BundledDefinitionsResult } from '../types';
 
 /** In-memory cache of SDK key to its hashed value, so we don't re-hash repeatedly. */
@@ -35,7 +36,7 @@ function hashSdkKey(sdkKey: string): Promise<string> {
  * Reads the local definitions that get bundled at build time.
  */
 export async function readBundledDefinitions(
-  sdkKey: string,
+  auth: Auth,
 ): Promise<BundledDefinitionsResult> {
   let get: (sdkKey: string) => BundledDefinitions | null;
   try {
@@ -62,13 +63,27 @@ export async function readBundledDefinitions(
     return { definitions: null, state: 'missing-file' };
   }
 
-  // try plain sdk key first
-  const entry = get(sdkKey);
+  let lookup: BundledDefinitionsLookup;
+  try {
+    lookup = await auth.resolveBundledDefinitionsLookup();
+  } catch (error) {
+    return { definitions: null, state: 'unexpected-error', error };
+  }
+
+  if (lookup.type === 'project-id') {
+    const entry = get(lookup.projectId);
+    return entry
+      ? { definitions: entry, state: 'ok' }
+      : { definitions: null, state: 'missing-entry' };
+  }
+
+  // Try plain sdk key first for bundles created by older CLI versions.
+  const entry = get(lookup.sdkKey);
   if (entry) return { definitions: entry, state: 'ok' };
 
   // try hashed key but catch any errors
   try {
-    const hashedKey = await hashSdkKey(sdkKey);
+    const hashedKey = await hashSdkKey(lookup.sdkKey);
     // try original key (older cli versions) and hashed key (newer cli versions)
     const hashedEntry = get(hashedKey);
     if (hashedEntry) return { definitions: hashedEntry, state: 'ok' };

--- a/packages/vercel-flags-core/src/utils/usage-tracker.test.ts
+++ b/packages/vercel-flags-core/src/utils/usage-tracker.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Auth } from '../controller/auth';
 import { setRequestContext } from '../test-utils';
 import { type FlagsConfigReadEvent, UsageTracker } from './usage-tracker';
 
@@ -39,9 +40,18 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
+function createAuth(sdkKey = 'test-key'): Auth {
+  return {
+    sdkKey,
+    resolveToken: () => Promise.resolve(sdkKey),
+    resolveBundledDefinitionsLookup: () =>
+      Promise.resolve({ type: 'sdk-key', sdkKey }),
+  };
+}
+
 function createTracker(sdkKey = 'test-key') {
   return new UsageTracker({
-    sdkKey,
+    auth: createAuth(sdkKey),
     host: 'https://example.com',
     fetch: fetchMock,
   });
@@ -137,7 +147,7 @@ describe('UsageTracker', () => {
       fetchMock.mockImplementation(() => jsonResponse({ ok: true }));
 
       const tracker = new UsageTracker({
-        sdkKey: 'my-secret-key',
+        auth: createAuth('my-secret-key'),
         host: 'https://example.com',
         fetch: fetchMock,
       });
@@ -229,7 +239,7 @@ describe('UsageTracker', () => {
       );
 
       const tracker = new FreshUsageTracker({
-        sdkKey: 'test-key',
+        auth: createAuth('test-key'),
         host: 'https://example.com',
         fetch: fetchMock,
       });
@@ -267,7 +277,7 @@ describe('UsageTracker', () => {
       fetchMock.mockImplementation(() => jsonResponse({ ok: true }));
 
       const tracker = new FreshUsageTracker({
-        sdkKey: 'test-key',
+        auth: createAuth('test-key'),
         host: 'https://example.com',
         fetch: fetchMock,
       });
@@ -367,13 +377,13 @@ describe('UsageTracker', () => {
       });
 
       const tracker1 = new UsageTracker({
-        sdkKey: 'key-1',
+        auth: createAuth('key-1'),
         host: 'https://example.com',
         fetch: fetchMock,
       });
 
       const tracker2 = new UsageTracker({
-        sdkKey: 'key-2',
+        auth: createAuth('key-2'),
         host: 'https://example.com',
         fetch: fetchMock,
       });

--- a/packages/vercel-flags-core/src/utils/usage-tracker.ts
+++ b/packages/vercel-flags-core/src/utils/usage-tracker.ts
@@ -260,10 +260,10 @@ export class UsageTracker {
 
     const flushId = ++this.flushCounter;
 
-    const token = await this.options.auth.resolveToken();
-
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
       try {
+        const token = await this.options.auth.resolveToken();
+
         const response = await this.options.fetch(
           `${this.options.host}/v1/ingest`,
           {

--- a/packages/vercel-flags-core/src/utils/usage-tracker.ts
+++ b/packages/vercel-flags-core/src/utils/usage-tracker.ts
@@ -1,5 +1,6 @@
 import { waitUntil } from '@vercel/functions';
 import { version } from '../../package.json';
+import type { Auth } from '../controller/auth';
 import { getJitteredWaitMs, getRetryDelayMs } from './backoff';
 
 const RESOLVED_VOID: Promise<void> = Promise.resolve();
@@ -81,7 +82,7 @@ function getRequestContext(): RequestContext {
 }
 
 export interface UsageTrackerOptions {
-  sdkKey: string;
+  auth: Auth;
   host: string;
   fetch: typeof fetch;
 }
@@ -259,6 +260,8 @@ export class UsageTracker {
 
     const flushId = ++this.flushCounter;
 
+    const token = await this.options.auth.resolveToken();
+
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
       try {
         const response = await this.options.fetch(
@@ -267,7 +270,7 @@ export class UsageTracker {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              Authorization: `Bearer ${this.options.sdkKey}`,
+              Authorization: `Bearer ${token}`,
               'User-Agent': `VercelFlagsCore/${version}`,
               ...(process.env.VERCEL_ENV
                 ? { 'X-Vercel-Env': process.env.VERCEL_ENV }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -946,8 +946,8 @@ importers:
         specifier: ^3.4.3
         version: 3.4.3
       '@vercel/oidc':
-        specifier: 3.4.0
-        version: 3.4.0
+        specifier: 3.5.0
+        version: 3.5.0
       jose:
         specifier: 5.2.1
         version: 5.2.1
@@ -963,7 +963,7 @@ importers:
         version: 20.11.17
       next:
         specifier: ^16.1.6
-        version: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429)
+        version: 16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429)
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.6.3)(yaml@2.8.1)
@@ -4969,8 +4969,8 @@ packages:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
-  '@vercel/oidc@3.4.0':
-    resolution: {integrity: sha512-p0sKfHkfRmMaqqDwNL4tjnX9TgRrLMlEtUjIxfrEns8pOxz1R9ztqOVI+ehqiq93/2/HnfPe/UBZkfAZwnx0UA==}
+  '@vercel/oidc@3.5.0':
+    resolution: {integrity: sha512-jo7GgeJx2YMkjg9A28pFM5p88n5SnSHvDeNlf9898bRWiG9jPxwedj/gn/2XTw4UOTyQ50uHlrTGSlf/XU5tgw==}
     engines: {node: '>= 20'}
 
   '@vercel/speed-insights@1.3.1':
@@ -13426,7 +13426,7 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vercel/oidc@3.4.0': {}
+  '@vercel/oidc@3.5.0': {}
 
   '@vercel/speed-insights@1.3.1(@sveltejs/kit@2.50.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.41.3)(vite@5.4.21(@types/node@24.10.13)(lightningcss@1.30.2)))(svelte@5.41.3)(typescript@5.8.2)(vite@5.4.21(@types/node@24.10.13)(lightningcss@1.30.2)))(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(svelte@5.41.3)':
     optionalDependencies:
@@ -17055,7 +17055,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
-    optional: true
 
   node-emoji@2.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,7 +40,7 @@ importers:
         version: 15.2.2
       next:
         specifier: ^16.1.6
-        version: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429)
       playwright:
         specifier: 1.56.1
         version: 1.56.1
@@ -49,7 +49,7 @@ importers:
         version: 0.3.14
       react:
         specifier: canary
-        version: 19.3.0-canary-561ed529-20260423
+        version: 19.3.0-canary-f4e0d4ed-20260429
       turbo:
         specifier: 2.8.15
         version: 2.8.15
@@ -484,7 +484,7 @@ importers:
     dependencies:
       '@vercel/edge-config':
         specifier: ^1.4.3
-        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423))
+        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429))
     devDependencies:
       '@types/node':
         specifier: 20.11.17
@@ -546,7 +546,7 @@ importers:
         version: 1.6.1
       '@vercel/edge-config':
         specifier: ^1.4.3
-        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423))
+        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429))
       '@vercel/functions':
         specifier: ^1.5.2
         version: 1.6.0
@@ -580,7 +580,7 @@ importers:
     dependencies:
       '@vercel/edge-config':
         specifier: ^1.4.3
-        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423))
+        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429))
       hypertune:
         specifier: 2.8.3
         version: 2.8.3
@@ -614,10 +614,10 @@ importers:
     dependencies:
       '@launchdarkly/vercel-server-sdk':
         specifier: ^1.3.34
-        version: 1.3.34(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423))
+        version: 1.3.34(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429))
       '@vercel/edge-config':
         specifier: ^1.4.3
-        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423))
+        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429))
     devDependencies:
       '@types/node':
         specifier: 20.11.17
@@ -705,7 +705,7 @@ importers:
     dependencies:
       '@vercel/edge-config':
         specifier: ^1.4.3
-        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423))
+        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429))
       posthog-node:
         specifier: 4.11.1
         version: 4.11.1
@@ -797,7 +797,7 @@ importers:
     dependencies:
       '@vercel/edge-config':
         specifier: ^1.4.3
-        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423))
+        version: 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429))
       '@vercel/functions':
         specifier: ^1.5.2
         version: 1.6.0
@@ -806,7 +806,7 @@ importers:
         version: 0.5.2
       statsig-node-vercel:
         specifier: ^0.7.0
-        version: 0.7.0(@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423)))
+        version: 0.7.0(@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429)))
     devDependencies:
       '@types/node':
         specifier: 20.11.17
@@ -850,7 +850,7 @@ importers:
         version: 2.6.4(@types/node@20.11.17)(typescript@5.6.3)
       next:
         specifier: 16.1.5
-        version: 16.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423)
+        version: 16.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429)
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.6.3)(yaml@2.8.1)
@@ -945,6 +945,9 @@ importers:
       '@vercel/functions':
         specifier: ^3.4.3
         version: 3.4.3
+      '@vercel/oidc':
+        specifier: 3.4.0
+        version: 3.4.0
       jose:
         specifier: 5.2.1
         version: 5.2.1
@@ -960,7 +963,7 @@ importers:
         version: 20.11.17
       next:
         specifier: ^16.1.6
-        version: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423)
+        version: 16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429)
       tsup:
         specifier: 8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.6.3)(yaml@2.8.1)
@@ -4966,6 +4969,10 @@ packages:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
+  '@vercel/oidc@3.4.0':
+    resolution: {integrity: sha512-p0sKfHkfRmMaqqDwNL4tjnX9TgRrLMlEtUjIxfrEns8pOxz1R9ztqOVI+ehqiq93/2/HnfPe/UBZkfAZwnx0UA==}
+    engines: {node: '>= 20'}
+
   '@vercel/speed-insights@1.3.1':
     resolution: {integrity: sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==}
     peerDependencies:
@@ -8276,8 +8283,8 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
-  react@19.3.0-canary-561ed529-20260423:
-    resolution: {integrity: sha512-tN5JiqCwYgG5kSzVIcM5Sx3NPT6+rfOCVKolHycLBZivIhfcPVQqAn5/UgSxy8QeVNrUlyniVIztNpAeKlUz5w==}
+  react@19.3.0-canary-f4e0d4ed-20260429:
+    resolution: {integrity: sha512-FNfU7Fsr/U/6t76mMAOucXovXS7536HmVK4nVWKxLAOY+P7dpZ/rJfR2If4uHjAwQoMsLxZ41gG2VOWJDkprOA==}
     engines: {node: '>=0.10.0'}
 
   read-cache@1.0.0:
@@ -9171,6 +9178,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-name@5.0.1:
@@ -10630,10 +10638,10 @@ snapshots:
       '@launchdarkly/js-sdk-common': 2.19.0
       semver: 7.5.4
 
-  '@launchdarkly/vercel-server-sdk@1.3.34(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423))':
+  '@launchdarkly/vercel-server-sdk@1.3.34(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429))':
     dependencies:
       '@launchdarkly/js-server-sdk-common-edge': 2.6.9
-      '@vercel/edge-config': 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423))
+      '@vercel/edge-config': 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429))
       crypto-js: 4.2.0
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -13296,12 +13304,12 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       next: 16.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423))':
+  '@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429))':
     dependencies:
       '@vercel/edge-config-fs': 0.1.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      next: 16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423)
+      next: 16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429)
 
   '@vercel/edge@1.2.1': {}
 
@@ -13417,6 +13425,8 @@ snapshots:
   '@vercel/oidc@3.1.0': {}
 
   '@vercel/oidc@3.2.0': {}
+
+  '@vercel/oidc@3.4.0': {}
 
   '@vercel/speed-insights@1.3.1(@sveltejs/kit@2.50.2(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.41.3)(vite@5.4.21(@types/node@24.10.13)(lightningcss@1.30.2)))(svelte@5.41.3)(typescript@5.8.2)(vite@5.4.21(@types/node@24.10.13)(lightningcss@1.30.2)))(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(svelte@5.41.3)':
     optionalDependencies:
@@ -16916,16 +16926,16 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423):
+  next@16.1.5(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429):
     dependencies:
       '@next/env': 16.1.5
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.0
       caniuse-lite: 1.0.30001777
       postcss: 8.4.31
-      react: 19.3.0-canary-561ed529-20260423
-      react-dom: 19.2.4(react@19.3.0-canary-561ed529-20260423)
-      styled-jsx: 5.1.6(react@19.3.0-canary-561ed529-20260423)
+      react: 19.3.0-canary-f4e0d4ed-20260429
+      react-dom: 19.2.4(react@19.3.0-canary-f4e0d4ed-20260429)
+      styled-jsx: 5.1.6(react@19.3.0-canary-f4e0d4ed-20260429)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.5
       '@next/swc-darwin-x64': 16.1.5
@@ -16968,16 +16978,16 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423):
+  next@16.1.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429):
     dependencies:
       '@next/env': 16.1.6
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.0
       caniuse-lite: 1.0.30001777
       postcss: 8.4.31
-      react: 19.3.0-canary-561ed529-20260423
-      react-dom: 19.2.4(react@19.3.0-canary-561ed529-20260423)
-      styled-jsx: 5.1.6(react@19.3.0-canary-561ed529-20260423)
+      react: 19.3.0-canary-f4e0d4ed-20260429
+      react-dom: 19.2.4(react@19.3.0-canary-f4e0d4ed-20260429)
+      styled-jsx: 5.1.6(react@19.3.0-canary-f4e0d4ed-20260429)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.1.6
       '@next/swc-darwin-x64': 16.1.6
@@ -17020,16 +17030,16 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423):
+  next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429):
     dependencies:
       '@next/env': 16.2.0
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.0
       caniuse-lite: 1.0.30001777
       postcss: 8.4.31
-      react: 19.3.0-canary-561ed529-20260423
-      react-dom: 19.2.4(react@19.3.0-canary-561ed529-20260423)
-      styled-jsx: 5.1.6(react@19.3.0-canary-561ed529-20260423)
+      react: 19.3.0-canary-f4e0d4ed-20260429
+      react-dom: 19.2.4(react@19.3.0-canary-f4e0d4ed-20260429)
+      styled-jsx: 5.1.6(react@19.3.0-canary-f4e0d4ed-20260429)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.0
       '@next/swc-darwin-x64': 16.2.0
@@ -17528,9 +17538,9 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
-  react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423):
+  react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429):
     dependencies:
-      react: 19.3.0-canary-561ed529-20260423
+      react: 19.3.0-canary-f4e0d4ed-20260429
       scheduler: 0.27.0
 
   react-is@16.13.1: {}
@@ -17638,7 +17648,7 @@ snapshots:
 
   react@19.2.4: {}
 
-  react@19.3.0-canary-561ed529-20260423: {}
+  react@19.3.0-canary-f4e0d4ed-20260429: {}
 
   read-cache@1.0.0:
     dependencies:
@@ -18149,9 +18159,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  statsig-node-vercel@0.7.0(@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423))):
+  statsig-node-vercel@0.7.0(@vercel/edge-config@1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429))):
     dependencies:
-      '@vercel/edge-config': 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-561ed529-20260423))(react@19.3.0-canary-561ed529-20260423))
+      '@vercel/edge-config': 1.4.3(@opentelemetry/api@1.9.0)(next@16.2.0(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.3.0-canary-f4e0d4ed-20260429))(react@19.3.0-canary-f4e0d4ed-20260429))
       statsig-node-lite: 0.4.4
     transitivePeerDependencies:
       - encoding
@@ -18315,10 +18325,10 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.0
 
-  styled-jsx@5.1.6(react@19.3.0-canary-561ed529-20260423):
+  styled-jsx@5.1.6(react@19.3.0-canary-f4e0d4ed-20260429):
     dependencies:
       client-only: 0.0.1
-      react: 19.3.0-canary-561ed529-20260423
+      react: 19.3.0-canary-f4e0d4ed-20260429
 
   stylis@4.3.6: {}
 


### PR DESCRIPTION
Adds OIDC support by making SDK keys not required for the client init. I had to refactor how we handle the authentication token in the sdk since the sdk keys are always available and oidc tokens are only available at request time. 