### PR TITLE
Recognize hanging promise rejection as internal

### DIFF
--- a/packages/flags/src/next/is-internal-next-error.ts
+++ b/packages/flags/src/next/is-internal-next-error.ts
@@ -46,6 +46,7 @@ export function isInternalNextError(error: unknown): boolean {
     errorCode === 'NEXT_REDIRECT' ||
     errorCode === 'DYNAMIC_SERVER_USAGE' ||
     errorCode === 'BAILOUT_TO_CLIENT_SIDE_RENDERING' ||
-    errorCode === 'NEXT_NOT_FOUND'
+    errorCode === 'NEXT_NOT_FOUND' ||
+    errorCode === 'HANGING_PROMISE_REJECTION'
   );
 }


### PR DESCRIPTION
These rejection reasons are simply the resource cleanup of an aborted prerender and are not actionable. They don't represent a true erroring span either so we might want to characterize these as non errors from that perspective also.