### PR TITLE
Allow passing an adapter factory directly to flag()

### DIFF
--- a/.changeset/adapter-factory-shorthand.md
+++ b/.changeset/adapter-factory-shorthand.md
@@ -1,0 +1,21 @@
+---
+'flags': minor
+---
+
+Allow passing an adapter factory directly to `flag()`
+
+You can now pass an adapter factory by reference instead of calling it:
+
+```ts
+import { vercelAdapter } from '@flags-sdk/vercel';
+
+// before (still supported)
+flag({ key: 'example', adapter: vercelAdapter() });
+
+// now also works
+flag({ key: 'example', adapter: vercelAdapter });
+```
+
+`flag()` resolves the factory once per declaration. Passing an already-constructed
+adapter instance continues to work unchanged. Applies to both the Next.js and
+SvelteKit entrypoints.

--- a/.changeset/stale-papayas-flash.md
+++ b/.changeset/stale-papayas-flash.md
@@ -1,0 +1,5 @@
+---
+"@flags-sdk/vercel": minor
+---
+
+reuse adapter instance on subsequent calls

--- a/.changeset/stale-papayas-flash.md
+++ b/.changeset/stale-papayas-flash.md
@@ -1,5 +1,5 @@
 ---
-"@flags-sdk/vercel": minor
+"@flags-sdk/vercel": patch
 ---
 
-reuse adapter instance on subsequent calls
+Calling `vercelAdapter()` multiple times now returns the same adapter instance instead of creating a new one each time, which improves performance and memory usage.

--- a/packages/adapter-vercel/src/index.test.ts
+++ b/packages/adapter-vercel/src/index.test.ts
@@ -123,7 +123,7 @@ describe('createVercelAdapter', () => {
       const adapter = createVercelAdapter(flagsClient);
       const a = adapter();
       const b = adapter();
-      expect(a).not.toBe(b);
+      expect(a).toBe(b);
       expect(a.adapterId).toBeDefined();
       expect(a.adapterId).toBe(b.adapterId);
     });

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -36,53 +36,56 @@ export function createVercelAdapter(
   // into a single `bulkDecide` invocation.
   const adapterId = Symbol('vercelAdapter');
 
+  const adapter: Adapter<unknown, unknown> = {
+    adapterId,
+    origin: flagsClient.origin,
+    config: { reportValue: false },
+    async decide({ key, entities }) {
+      const evaluationResult = await flagsClient.evaluate<unknown, unknown>(
+        key,
+        undefined,
+        entities,
+      );
+
+      if (evaluationResult.value === undefined) {
+        // if there was no defaultValue we need to throw
+        throw new Error(
+          evaluationResult.reason === Reason.ERROR &&
+            evaluationResult.errorMessage
+            ? `flags: Could not evaluate flag "${key}". ${evaluationResult.errorMessage}`
+            : `flags: Could not evaluate flag "${key}"`,
+        );
+      }
+
+      // runs when the flag evaluates successfully or
+      // when there was an error but the defaultValue was set
+      return evaluationResult.value;
+    },
+    async bulkDecide({ flags, entities }) {
+      // `flags` is typed `{ key: string; defaultValue?: unknown }[]` on
+      // `Adapter.bulkDecide` (to keep `ValueType` covariant). The client
+      // here narrows it back to `ValueType`; `defaultValue` is shuttled
+      // through opaquely so the cast is safe.
+      const results = await flagsClient.bulkEvaluate<unknown, unknown>(
+        flags as { key: string; defaultValue?: unknown }[],
+        entities,
+      );
+      const out: Record<string, unknown> = {};
+      for (const key in results) {
+        const r = results[key]!;
+        // Omit undefined so the SDK applies the per-flag `defaultValue`
+        // fallback (matches single-decide semantics).
+        if (r.value !== undefined) out[key] = r.value;
+      }
+      return out;
+    },
+  };
+
   return function vercelAdapter<ValueType, EntitiesType>(): Adapter<
     ValueType,
     EntitiesType
   > {
-    return {
-      adapterId,
-      origin: flagsClient.origin,
-      config: { reportValue: false },
-      async decide({ key, entities }): Promise<ValueType> {
-        const evaluationResult = await flagsClient.evaluate<
-          ValueType,
-          EntitiesType
-        >(key, undefined, entities);
-
-        if (evaluationResult.value === undefined) {
-          // if there was no defaultValue we need to throw
-          throw new Error(
-            evaluationResult.reason === Reason.ERROR &&
-              evaluationResult.errorMessage
-              ? `flags: Could not evaluate flag "${key}". ${evaluationResult.errorMessage}`
-              : `flags: Could not evaluate flag "${key}"`,
-          );
-        }
-
-        // runs when the flag evaluates successfully or
-        // when there was an error but the defaultValue was set
-        return evaluationResult.value;
-      },
-      async bulkDecide({ flags, entities }) {
-        // `flags` is typed `{ key: string; defaultValue?: unknown }[]` on
-        // `Adapter.bulkDecide` (to keep `ValueType` covariant). The client
-        // here narrows it back to `ValueType`; `defaultValue` is shuttled
-        // through opaquely so the cast is safe.
-        const results = await flagsClient.bulkEvaluate<ValueType, EntitiesType>(
-          flags as { key: string; defaultValue?: ValueType }[],
-          entities,
-        );
-        const out: Record<string, ValueType> = {};
-        for (const key in results) {
-          const r = results[key]!;
-          // Omit undefined so the SDK applies the per-flag `defaultValue`
-          // fallback (matches single-decide semantics).
-          if (r.value !== undefined) out[key] = r.value;
-        }
-        return out;
-      },
-    };
+    return adapter as Adapter<ValueType, EntitiesType>;
   };
 }
 

--- a/packages/flags/src/next/evaluate.ts
+++ b/packages/flags/src/next/evaluate.ts
@@ -16,6 +16,7 @@ import type {
   Decide,
   FlagDeclaration,
   FlagParamsType,
+  ResolvedFlagDeclaration,
 } from '../types';
 import { isInternalNextError } from './is-internal-next-error';
 import { getOverrides } from './overrides';
@@ -328,7 +329,7 @@ type Run<ValueType, EntitiesType> = (options: {
  * App Router, and reuse of pre-read data when called from inside `evaluate()`.
  */
 export function getRun<ValueType, EntitiesType>(
-  definition: FlagDeclaration<ValueType, EntitiesType>,
+  definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
   decide: Decide<ValueType, EntitiesType>,
 ): Run<ValueType, EntitiesType> {
   // use cache to guarantee flags only decide once per request

--- a/packages/flags/src/next/index.test.ts
+++ b/packages/flags/src/next/index.test.ts
@@ -121,7 +121,7 @@ describe('flag on app router', () => {
 
   it('throws when passing invalid adapter', () => {
     expect(() => flag({ key: 'my-key', adapter: {} as any })).toThrowError(
-      'flags: You passed an adapter that does not have a "decide" method for flag "my-key". Did you pass "adapter: exampleAdapter" instead of "adapter: exampleAdapter()"?',
+      'flags: The adapter passed to flag "my-key" does not have a "decide" method.',
     );
   });
 
@@ -803,6 +803,60 @@ describe('adapters', () => {
 
     expect(await exampleFlag()).toBe(outerValue);
   });
+
+  it('accepts an adapter factory passed by reference', async () => {
+    // A zero-arg factory, like `vercelAdapter`, can be passed directly
+    // (`adapter: vercelAdapter`) instead of being called (`adapter: vercelAdapter()`).
+    const vercelAdapter = <ValueType, EntitiesType>(): Adapter<
+      ValueType,
+      EntitiesType
+    > => ({
+      decide: () => 5 as ValueType,
+      origin: (key) => `fake-origin#${key}`,
+    });
+
+    mocks.headers.mockReturnValueOnce(new Headers());
+
+    const f = flag<number>({
+      key: 'factory-flag',
+      adapter: vercelAdapter,
+    });
+
+    expect(f).toHaveProperty('key', 'factory-flag');
+    await expect(f()).resolves.toEqual(5);
+    // origin/identify still resolve from the factory-produced adapter
+    expect(f).toHaveProperty('origin', 'fake-origin#factory-flag');
+  });
+
+  it('resolves config.reportValue from a factory-passed adapter', async () => {
+    const makeAdapter = (): Adapter<boolean, any> => ({
+      decide: () => true,
+      config: { reportValue: false },
+    });
+
+    const requestContext = createRequestContext();
+    Reflect.set(globalThis, requestContextSymbol, {
+      get() {
+        return requestContext;
+      },
+    });
+
+    try {
+      mocks.headers.mockReturnValueOnce(new Headers());
+
+      const f = flag<boolean>({ key: 'no-report', adapter: makeAdapter });
+      await expect(f()).resolves.toEqual(true);
+
+      // adapter's `reportValue: false` is honored, so nothing is reported
+      expect(requestContext.flags.calls).toHaveLength(0);
+    } finally {
+      if (previousRequestContext === undefined) {
+        Reflect.deleteProperty(globalThis, requestContextSymbol);
+      } else {
+        Reflect.set(globalThis, requestContextSymbol, previousRequestContext);
+      }
+    }
+  });
 });
 
 describe('evaluate', () => {
@@ -867,6 +921,21 @@ describe('evaluate', () => {
       }),
     );
     expect(decideMock).not.toHaveBeenCalled();
+  });
+
+  it('batches flags that pass the same adapter factory by reference', async () => {
+    const bulkDecideMock = vi.fn().mockResolvedValue({ a: 'A', b: 'B' });
+    const adapter = makeBulkAdapter<string>({ bulkDecide: bulkDecideMock });
+
+    // Pass the factory by reference rather than calling it. Both flags share the
+    // factory's closure-captured adapterId, so they still batch into one call.
+    const a = flag<string>({ key: 'a', adapter });
+    const b = flag<string>({ key: 'b', adapter });
+
+    mocks.headers.mockReturnValueOnce(new Headers());
+    await expect(evaluate({ a, b })).resolves.toEqual({ a: 'A', b: 'B' });
+
+    expect(bulkDecideMock).toHaveBeenCalledTimes(1);
   });
 
   it('splits into separate bulkDecide calls when identify sources differ', async () => {

--- a/packages/flags/src/next/index.ts
+++ b/packages/flags/src/next/index.ts
@@ -9,6 +9,7 @@ import type {
   JsonValue,
   Origin,
   ProviderData,
+  ResolvedFlagDeclaration,
 } from '../types';
 import { BULK_IDENTIFY_REF, BULKABLE, getRun } from './evaluate';
 import { getPrecomputed } from './precompute';
@@ -26,11 +27,11 @@ export {
 export type { Flag } from './types';
 
 function getDecide<ValueType, EntitiesType>(
-  definition: FlagDeclaration<ValueType, EntitiesType>,
+  definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
 ): Decide<ValueType, EntitiesType> {
   if (definition.adapter && typeof definition.adapter.decide !== 'function') {
     throw new Error(
-      `flags: You passed an adapter that does not have a "decide" method for flag "${definition.key}". Did you pass "adapter: exampleAdapter" instead of "adapter: exampleAdapter()"?`,
+      `flags: The adapter passed to flag "${definition.key}" does not have a "decide" method.`,
     );
   }
 
@@ -55,7 +56,7 @@ function getDecide<ValueType, EntitiesType>(
 }
 
 function getIdentify<ValueType, EntitiesType>(
-  definition: FlagDeclaration<ValueType, EntitiesType>,
+  definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
 ): Identify<EntitiesType> {
   return function identify(params) {
     if (typeof definition.identify === 'function') {
@@ -69,7 +70,7 @@ function getIdentify<ValueType, EntitiesType>(
 }
 
 function getOrigin<ValueType, EntitiesType>(
-  definition: FlagDeclaration<ValueType, EntitiesType>,
+  definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
 ): string | Origin | undefined {
   if (definition.origin) return definition.origin;
   if (typeof definition.adapter?.origin === 'function')
@@ -96,10 +97,25 @@ export function flag<
 >(
   definition: FlagDeclaration<ValueType, EntitiesType>,
 ): Flag<ValueType, EntitiesType> {
-  const decide = getDecide<ValueType, EntitiesType>(definition);
-  const identify = getIdentify<ValueType, EntitiesType>(definition);
-  const run = getRun<ValueType, EntitiesType>(definition, decide);
-  const origin = getOrigin(definition);
+  // Allow passing the adapter factory directly (`adapter: vercelAdapter`) as a
+  // shorthand for calling it (`adapter: vercelAdapter()`). Resolve it once here
+  // so every consumer below works with a concrete Adapter instance.
+  const adapter =
+    typeof definition.adapter === 'function'
+      ? definition.adapter()
+      : definition.adapter;
+  // Cast: spreading the discriminated union widens `decide`/`adapter` so TS no
+  // longer sees the "decide or adapter is present" guarantee, but the original
+  // `definition` upheld it and we only narrowed `adapter` to an instance.
+  const resolvedDefinition = {
+    ...definition,
+    adapter,
+  } as ResolvedFlagDeclaration<ValueType, EntitiesType>;
+
+  const decide = getDecide<ValueType, EntitiesType>(resolvedDefinition);
+  const identify = getIdentify<ValueType, EntitiesType>(resolvedDefinition);
+  const run = getRun<ValueType, EntitiesType>(resolvedDefinition, decide);
+  const origin = getOrigin(resolvedDefinition);
 
   const api = trace(
     async (...args: any[]) => {
@@ -171,17 +187,17 @@ export function flag<
     name: 'run',
     attributes: { key: definition.key },
   });
-  api.adapter = definition.adapter;
+  api.adapter = adapter;
   api.config = definition.config;
 
   // Internal markers used by `evaluate()` to partition flags into adapter
   // groups. See `./evaluate.ts` for the symbol definitions.
   (api as any)[BULK_IDENTIFY_REF] =
-    definition.identify ?? definition.adapter?.identify ?? null;
+    definition.identify ?? adapter?.identify ?? null;
   (api as any)[BULKABLE] =
     !definition.decide &&
-    !!definition.adapter?.bulkDecide &&
-    definition.adapter.adapterId !== undefined;
+    !!adapter?.bulkDecide &&
+    adapter.adapterId !== undefined;
 
   return api;
 }

--- a/packages/flags/src/next/types.ts
+++ b/packages/flags/src/next/types.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage } from 'node:http';
 import type { JsonValue } from '..';
-import type { FlagDeclaration, FlagOption } from '../types';
+import type { Adapter, FlagDeclaration, FlagOption } from '../types';
 
 type NextApiRequestCookies = Partial<{
   [key: string]: string;
@@ -57,8 +57,11 @@ type FlagMeta<ValueType, EntitiesType> = {
    * The adapter used to evaluate this flag, if any. Exposed so `evaluate()`
    * can group flags that share an `adapterId` and call `adapter.bulkDecide`
    * once per group.
+   *
+   * Always a resolved adapter instance — if a factory was passed to `flag()`
+   * it has already been called.
    */
-  adapter?: FlagDeclaration<ValueType, EntitiesType>['adapter'];
+  adapter?: Adapter<ValueType, EntitiesType>;
   /**
    * Flag-level configuration (e.g. `reportValue`).
    */

--- a/packages/flags/src/sveltekit/index.ts
+++ b/packages/flags/src/sveltekit/index.ts
@@ -37,6 +37,7 @@ import type {
   FlagOverridesType,
   FlagValuesType,
   Identify,
+  ResolvedFlagDeclaration,
 } from '../types';
 import { tryGetSecret } from './env';
 import {
@@ -96,7 +97,7 @@ async function resolveObjectPromises<T>(obj: PromisesMap<T>): Promise<T> {
 }
 
 function getDecide<ValueType, EntitiesType>(
-  definition: FlagDeclaration<ValueType, EntitiesType>,
+  definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
 ): Decide<ValueType, EntitiesType> {
   return function decide(params) {
     if (typeof definition.decide === 'function') {
@@ -110,7 +111,7 @@ function getDecide<ValueType, EntitiesType>(
 }
 
 function getIdentify<ValueType, EntitiesType>(
-  definition: FlagDeclaration<ValueType, EntitiesType>,
+  definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
 ): Identify<EntitiesType> | undefined {
   if (typeof definition.identify === 'function') {
     return definition.identify;
@@ -133,8 +134,19 @@ export function flag<
   ValueType extends JsonValue = boolean | string | number,
   EntitiesType = any,
 >(definition: FlagDeclaration<ValueType, EntitiesType>): Flag<ValueType> {
-  const decide = getDecide<ValueType, EntitiesType>(definition);
-  const identify = getIdentify(definition);
+  // Allow passing the adapter factory directly (`adapter: vercelAdapter`) as a
+  // shorthand for calling it (`adapter: vercelAdapter()`). Resolve it once here.
+  const adapter =
+    typeof definition.adapter === 'function'
+      ? definition.adapter()
+      : definition.adapter;
+  const resolvedDefinition = {
+    ...definition,
+    adapter,
+  } as ResolvedFlagDeclaration<ValueType, EntitiesType>;
+
+  const decide = getDecide<ValueType, EntitiesType>(resolvedDefinition);
+  const identify = getIdentify(resolvedDefinition);
 
   const flagImpl = async function flagImpl(
     requestOrCode?: string | Request,

--- a/packages/flags/src/types.ts
+++ b/packages/flags/src/types.ts
@@ -190,6 +190,29 @@ export interface Adapter<ValueType, EntitiesType> {
 }
 
 /**
+ * An adapter instance, or a zero-arg factory that returns one.
+ *
+ * Passing the factory directly (e.g. `adapter: vercelAdapter`) is shorthand for
+ * calling it (`adapter: vercelAdapter()`). The Flags SDK resolves the factory
+ * once per flag declaration.
+ */
+export type AdapterOrFactory<ValueType, EntitiesType> =
+  | Adapter<ValueType, EntitiesType>
+  | (() => Adapter<ValueType, EntitiesType>);
+
+/**
+ * A {@link FlagDeclaration} whose `adapter` factory (if any) has been resolved
+ * to an {@link Adapter} instance. This is the internal shape the Flags SDK works
+ * with after `flag()` resolves a passed-in factory.
+ */
+export type ResolvedFlagDeclaration<ValueType, EntitiesType> = FlagDeclaration<
+  ValueType,
+  EntitiesType
+> & {
+  adapter?: Adapter<ValueType, EntitiesType>;
+};
+
+/**
  * Definition when declaring a feature flag, as provided to `flag(declaration)`
  */
 export type FlagDeclaration<ValueType, EntitiesType> = {
@@ -231,8 +254,11 @@ export type FlagDeclaration<ValueType, EntitiesType> = {
    * Adapters can implement default behavior for flags.
    *
    * Explicitly provided values always override adapters.
+   *
+   * Accepts either an adapter instance (`adapter: vercelAdapter()`) or a
+   * zero-arg factory that returns one (`adapter: vercelAdapter`).
    */
-  // adapter?: Adapter<ValueType, EntitiesType>;
+  // adapter?: AdapterOrFactory<ValueType, EntitiesType>;
   /**
    * This function is called when the feature flag is used (and no override is present) to return a value.
    */
@@ -243,11 +269,11 @@ export type FlagDeclaration<ValueType, EntitiesType> = {
   identify?: Identify<EntitiesType>;
 } & (
   | {
-      adapter: Adapter<ValueType, EntitiesType>;
+      adapter: AdapterOrFactory<ValueType, EntitiesType>;
       decide?: Decide<ValueType, EntitiesType>;
     }
   | {
-      adapter?: Adapter<ValueType, EntitiesType>;
+      adapter?: AdapterOrFactory<ValueType, EntitiesType>;
       decide: Decide<ValueType, EntitiesType>;
     }
 );


### PR DESCRIPTION
## Summary

Simplifies the adapter API so a flag can be declared by passing the adapter factory **by reference** instead of calling it:

```ts
import { vercelAdapter } from '@flags-sdk/vercel';

// before (still supported)
flag({ key: 'example', adapter: vercelAdapter() });

// now also works
flag({ key: 'example', adapter: vercelAdapter });
```

`flag()` resolves the factory once per declaration. Passing an already-constructed adapter instance keeps working unchanged. Applies to both the Next.js and SvelteKit entrypoints.

## Approach

`FlagDeclaration.adapter` now accepts `Adapter | (() => Adapter)` (new `AdapterOrFactory` type). `flag()` resolves it once — `typeof adapter === 'function' ? adapter() : adapter` — and threads the resolved instance through `getDecide`/`getIdentify`/`getOrigin`/`getRun` and the `evaluate()` batching markers. An internal `ResolvedFlagDeclaration` type captures the post-resolution shape.

### Backwards compatibility
An `Adapter` is always an object and a factory is a function, so `typeof === 'function'` cleanly distinguishes them and `Adapter` stays assignable to `AdapterOrFactory`. Batching is preserved because a factory's `adapterId` lives in its outer closure and is shared across the instances each `flag()` mints.

## Changes
- `types.ts` — add `AdapterOrFactory` + `ResolvedFlagDeclaration`; widen `FlagDeclaration.adapter`
- `next/index.ts` — resolve adapter once in `flag()`; reword the stale "did you forget `()`?" error
- `next/types.ts` — `Flag.adapter` is the resolved `Adapter` instance
- `next/evaluate.ts`, `sveltekit/index.ts` — thread the resolved declaration
- tests + changeset (`minor`)

## Verification
- `pnpm type-check` ✅
- `pnpm test` → 112/112 pass (added factory tests: decide/origin resolution, `config.reportValue`, and `evaluate()` batching two flags sharing the same factory) ✅
- `pnpm build` → clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)