### PR TITLE
[@flags-sdk/edge-config] support bulk and simple interface

### DIFF
--- a/.changeset/edge-config-bulk-decide.md
+++ b/.changeset/edge-config-bulk-decide.md
@@ -2,9 +2,11 @@
 '@flags-sdk/edge-config': minor
 ---
 
-Simplify usage of the Edge Config adapter
+Simplify usage and improve evaluation of the Edge Config adapter
 
-You can now pass the adapter by reference instead of calling it:
+When multiple flags share the same Edge Config adapter, the SDK now evaluates them in a single batched call instead of one by one.
+
+You can also now pass the adapter by reference instead of calling it:
 
 ```ts
 import { edgeConfigAdapter } from '@flags-sdk/edge-config';

--- a/.changeset/edge-config-bulk-decide.md
+++ b/.changeset/edge-config-bulk-decide.md
@@ -1,0 +1,17 @@
+---
+'@flags-sdk/edge-config': minor
+---
+
+Simplify usage of the Edge Config adapter
+
+You can now pass the adapter by reference instead of calling it:
+
+```ts
+import { edgeConfigAdapter } from '@flags-sdk/edge-config';
+
+// before (still supported)
+flag({ key: 'example', adapter: edgeConfigAdapter() });
+
+// now also works
+flag({ key: 'example', adapter: edgeConfigAdapter });
+```

--- a/packages/adapter-edge-config/src/index.test.ts
+++ b/packages/adapter-edge-config/src/index.test.ts
@@ -14,6 +14,96 @@ describe('createEdgeConfigAdapter', () => {
     expect(adapter).toBeDefined();
   });
 
+  it('returns the same adapter instance on every call', () => {
+    const fakeEdgeConfigClient = {} as EdgeConfigClient;
+    const adapter = createEdgeConfigAdapter(fakeEdgeConfigClient);
+    expect(adapter()).toBe(adapter());
+  });
+
+  describe('adapterId', () => {
+    it('shares one adapterId across all adapters from the same factory call', () => {
+      const fakeEdgeConfigClient = {} as EdgeConfigClient;
+      const adapter = createEdgeConfigAdapter(fakeEdgeConfigClient);
+      const a = adapter();
+      const b = adapter();
+      expect(a).toBe(b);
+      expect(a.adapterId).toBeDefined();
+      expect(a.adapterId).toBe(b.adapterId);
+    });
+
+    it('uses different adapterIds across separate factory calls', () => {
+      const fakeEdgeConfigClient = {} as EdgeConfigClient;
+      const adapterA = createEdgeConfigAdapter(fakeEdgeConfigClient);
+      const adapterB = createEdgeConfigAdapter(fakeEdgeConfigClient);
+      expect(adapterA().adapterId).not.toBe(adapterB().adapterId);
+    });
+  });
+
+  describe('bulkDecide', () => {
+    it('resolves all requested flag keys from Edge Config in one read', async () => {
+      const fakeEdgeConfigClient = {
+        get: vi.fn(async () => ({
+          'flag-a': true,
+          'flag-b': false,
+          'flag-c': true,
+        })),
+      } as unknown as EdgeConfigClient;
+      const adapter = createEdgeConfigAdapter(fakeEdgeConfigClient);
+      const headers = new Headers();
+
+      const result = await adapter().bulkDecide!({
+        flags: [{ key: 'flag-a' }, { key: 'flag-b' }],
+        entities: {},
+        headers,
+        cookies: {} as ReadonlyRequestCookies,
+      });
+
+      expect(result).toEqual({ 'flag-a': true, 'flag-b': false });
+      expect(fakeEdgeConfigClient.get).toHaveBeenCalledOnce();
+    });
+
+    it('omits keys missing from Edge Config so the SDK applies defaultValue', async () => {
+      const fakeEdgeConfigClient = {
+        get: vi.fn(async () => ({ 'flag-a': true })),
+      } as unknown as EdgeConfigClient;
+      const adapter = createEdgeConfigAdapter(fakeEdgeConfigClient);
+      const headers = new Headers();
+
+      const result = await adapter().bulkDecide!({
+        flags: [{ key: 'flag-a' }, { key: 'flag-missing' }],
+        entities: {},
+        headers,
+        cookies: {} as ReadonlyRequestCookies,
+      });
+
+      expect(result).toEqual({ 'flag-a': true });
+    });
+
+    it('shares the per-request cache with decide', async () => {
+      const fakeEdgeConfigClient = {
+        get: vi.fn(async () => ({ 'flag-a': true, 'flag-b': false })),
+      } as unknown as EdgeConfigClient;
+      const adapter = createEdgeConfigAdapter(fakeEdgeConfigClient);
+      const headers = new Headers();
+
+      await adapter().decide({
+        key: 'flag-a',
+        entities: {},
+        headers,
+        cookies: {} as ReadonlyRequestCookies,
+      });
+
+      await adapter().bulkDecide!({
+        flags: [{ key: 'flag-b' }],
+        entities: {},
+        headers,
+        cookies: {} as ReadonlyRequestCookies,
+      });
+
+      expect(fakeEdgeConfigClient.get).toHaveBeenCalledOnce();
+    });
+  });
+
   it('should allow creating an adapter with a connection string', () => {
     const adapter = createEdgeConfigAdapter(
       'https://edge-config.vercel.com/ecfg_xxx?token=yyy',

--- a/packages/adapter-edge-config/src/index.ts
+++ b/packages/adapter-edge-config/src/index.ts
@@ -67,43 +67,65 @@ export function createEdgeConfigAdapter(
     Promise<EdgeConfigItem | undefined>
   >();
 
+  const adapterId = Symbol('edgeConfigAdapter');
+
+  async function getDefinitions(
+    headers: ReadonlyHeaders,
+  ): Promise<EdgeConfigItem | undefined> {
+    const cached = edgeConfigItemCache.get(headers);
+    if (cached) return cached;
+    const valuePromise =
+      edgeConfigClient.get<EdgeConfigItem>(edgeConfigItemKey);
+    edgeConfigItemCache.set(headers, valuePromise);
+    return valuePromise;
+  }
+
+  const adapter: Adapter<unknown, unknown> = {
+    adapterId,
+    origin: options?.teamSlug
+      ? `https://vercel.com/${options.teamSlug}/~/stores/edge-config/${edgeConfigClient.connection.id}/items#item=${edgeConfigItemKey}`
+      : undefined,
+    async decide({ key, headers }): Promise<unknown> {
+      const definitions = await getDefinitions(headers);
+
+      // if a defaultValue was provided this error will be caught and the defaultValue will be used
+      if (!definitions) {
+        throw new Error(
+          `@flags-sdk/edge-config: Edge Config item "${edgeConfigItemKey}" not found`,
+        );
+      }
+
+      // if a defaultValue was provided this error will be caught and the defaultValue will be used
+      if (!(key in definitions)) {
+        throw new Error(
+          `@flags-sdk/edge-config: Flag "${key}" not found in Edge Config item "${edgeConfigItemKey}"`,
+        );
+      }
+      return definitions[key];
+    },
+    async bulkDecide({ flags, headers }): Promise<Record<string, unknown>> {
+      const definitions = await getDefinitions(headers);
+
+      if (!definitions) {
+        throw new Error(
+          `@flags-sdk/edge-config: Edge Config item "${edgeConfigItemKey}" not found`,
+        );
+      }
+
+      const out: Record<string, unknown> = {};
+      for (const { key } of flags) {
+        if (key in definitions) {
+          out[key] = definitions[key];
+        }
+      }
+      return out;
+    },
+  };
+
   return function edgeConfigAdapter<ValueType, EntitiesType>(): Adapter<
     ValueType,
     EntitiesType
   > {
-    return {
-      origin: options?.teamSlug
-        ? `https://vercel.com/${options.teamSlug}/~/stores/edge-config/${edgeConfigClient.connection.id}/items#item=${edgeConfigItemKey}`
-        : undefined,
-      async decide({ key, headers }): Promise<ValueType> {
-        const cached = edgeConfigItemCache.get(headers);
-        let valuePromise: Promise<EdgeConfigItem | undefined>;
-
-        if (!cached) {
-          valuePromise =
-            edgeConfigClient.get<EdgeConfigItem>(edgeConfigItemKey);
-          edgeConfigItemCache.set(headers, valuePromise);
-        } else {
-          valuePromise = cached;
-        }
-
-        const definitions = await valuePromise;
-
-        // if a defaultValue was provided this error will be caught and the defaultValue will be used
-        if (!definitions) {
-          throw new Error(
-            `@flags-sdk/edge-config: Edge Config item "${edgeConfigItemKey}" not found`,
-          );
-        }
-
-        // if a defaultValue was provided this error will be caught and the defaultValue will be used
-        if (!(key in definitions)) {
-          throw new Error(
-            `@flags-sdk/edge-config: Flag "${key}" not found in Edge Config item "${edgeConfigItemKey}"`,
-          );
-        }
-        return definitions[key] as ValueType;
-      },
-    };
+    return adapter as Adapter<ValueType, EntitiesType>;
   };
 }


### PR DESCRIPTION
Simplify usage and improve evaluation of the Edge Config adapter

When multiple flags share the same Edge Config adapter, the SDK now evaluates them in a single batched call instead of one by one.

You can also now pass the adapter by reference instead of calling it:

```ts
import { edgeConfigAdapter } from '@flags-sdk/edge-config';

// before (still supported)
flag({ key: 'example', adapter: edgeConfigAdapter() });

// now also works
flag({ key: 'example', adapter: edgeConfigAdapter });
```
