### PR TITLE
Support createClient options-first overload

### DIFF
--- a/packages/vercel-flags-core/src/index.default.ts
+++ b/packages/vercel-flags-core/src/index.default.ts
@@ -29,7 +29,7 @@ export const {
    */
   resetDefaultFlagsClient,
   /**
-   * Create a flags client based on an SDK Key
+   * Create a flags client using an SDK key, connection string, or Vercel OIDC.
    */
   createClient,
 } = make(createCreateRawClient(fns));

--- a/packages/vercel-flags-core/src/index.make.test.ts
+++ b/packages/vercel-flags-core/src/index.make.test.ts
@@ -83,6 +83,24 @@ describe('make', () => {
       expect(client).toBeDefined();
     });
 
+    it('should create an OIDC-authenticated client with options as the first argument', () => {
+      const createRawClient = createMockCreateRawClient();
+      const { createClient } = make(createRawClient);
+
+      const client = createClient({ stream: false, polling: false });
+
+      expect(Controller).toHaveBeenCalledWith({
+        auth: expect.objectContaining({ sdkKey: undefined }),
+        stream: false,
+        polling: false,
+      });
+      expect(createRawClient).toHaveBeenCalledWith({
+        controller: expect.any(Object),
+        origin: { provider: 'vercel', sdkKey: undefined },
+      });
+      expect(client).toBeDefined();
+    });
+
     it('should throw for empty SDK key', () => {
       const createRawClient = createMockCreateRawClient();
       const { createClient } = make(createRawClient);

--- a/packages/vercel-flags-core/src/index.make.ts
+++ b/packages/vercel-flags-core/src/index.make.ts
@@ -12,15 +12,22 @@ import type { FlagsClient } from './types';
  */
 export type CreateClientOptions = Omit<ControllerOptions, 'auth'>;
 
+type CreateClient = {
+  <Entities = Record<string, unknown>>(
+    options: CreateClientOptions,
+  ): FlagsClient<Entities>;
+  <Entities = Record<string, unknown>>(
+    sdkKeyOrConnectionString?: string,
+    options?: CreateClientOptions,
+  ): FlagsClient<Entities>;
+};
+
 export function make(
   createRawClient: ReturnType<typeof createCreateRawClient>,
 ): {
   flagsClient: FlagsClient;
   resetDefaultFlagsClient: () => void;
-  createClient: <Entities = Record<string, unknown>>(
-    sdkKeyOrConnectionString?: string,
-    options?: CreateClientOptions,
-  ) => FlagsClient<Entities>;
+  createClient: CreateClient;
 } {
   let _defaultFlagsClient: FlagsClient | null = null;
 
@@ -28,13 +35,29 @@ export function make(
   // - data source must specify the environment & projectId as sdkKey has that info
   // - "reuse" functionality relies on the data source having the data for all envs
   function createClient<Entities = Record<string, unknown>>(
+    options: CreateClientOptions,
+  ): FlagsClient<Entities>;
+  function createClient<Entities = Record<string, unknown>>(
     sdkKeyOrConnectionString?: string,
     options?: CreateClientOptions,
+  ): FlagsClient<Entities>;
+  function createClient<Entities = Record<string, unknown>>(
+    sdkKeyOrConnectionStringOrOptions?: string | CreateClientOptions,
+    options?: CreateClientOptions,
   ): FlagsClient<Entities> {
+    const optionsOnly =
+      typeof sdkKeyOrConnectionStringOrOptions === 'object' &&
+      sdkKeyOrConnectionStringOrOptions !== null;
+    const sdkKeyOrConnectionString = optionsOnly
+      ? undefined
+      : sdkKeyOrConnectionStringOrOptions;
+    const createClientOptions = optionsOnly
+      ? sdkKeyOrConnectionStringOrOptions
+      : options;
     const auth = new Authentication(sdkKeyOrConnectionString);
 
     // sdk key contains the environment
-    const controller = new Controller({ auth, ...options });
+    const controller = new Controller({ auth, ...createClientOptions });
     return createRawClient<Entities>({
       controller,
       origin: { provider: 'vercel', sdkKey: auth.sdkKey },


### PR DESCRIPTION
## Summary
- Add an options-first `createClient` overload for OIDC-authenticated clients
- Accept SDK key, connection string, or options as the first argument
- Update the public doc comment to reflect the expanded API
- Cover the new calling convention with a unit test

## Testing
- Unit tests updated to verify options-first client creation
- Not run (not requested)