### PR TITLE
docs: use adapter factory shorthand (adapter: vercelAdapter)

### DIFF
--- a/apps/docs/content/docs/providers/custom-adapters.mdx
+++ b/apps/docs/content/docs/providers/custom-adapters.mdx
@@ -61,7 +61,7 @@ const exampleAdapter = createExampleAdapter();
 export const exampleFlag = flag({
   key: 'example-flag',
   // use the adapter for many feature flags
-  adapter: exampleAdapter(),
+  adapter: exampleAdapter,
 });
 ```
 
@@ -90,7 +90,7 @@ import { exampleAdapter } from './example-adapter';
 export const exampleFlag = flag({
   key: 'example-flag',
   // use the adapter for many feature flags
-  adapter: exampleAdapter(),
+  adapter: exampleAdapter,
 });
 ```
 

--- a/apps/docs/content/docs/providers/edge-config.mdx
+++ b/apps/docs/content/docs/providers/edge-config.mdx
@@ -35,7 +35,7 @@ import { edgeConfigAdapter } from '@flags-sdk/edge-config';
 
 export const exampleFlag = flag({
   // Will load the `flags` key from Edge Config
-  adapter: edgeConfigAdapter(),
+  adapter: edgeConfigAdapter,
   // Will get the `example-flag` key from the `flags` object
   key: 'example-flag',
 });
@@ -65,7 +65,7 @@ and that it contains a `flags` object with each key corresponding to a flag you 
 import { edgeConfigAdapter } from '@flags-sdk/edge-config';
 
 export const exampleFlag = flag({
-  adapter: edgeConfigAdapter(),
+  adapter: edgeConfigAdapter,
   key: 'example-flag',
 });
 ```
@@ -92,7 +92,7 @@ const myEdgeConfigAdapter = createEdgeConfigAdapter({
 });
 
 export const exampleFlag = flag({
-  adapter: myEdgeConfigAdapter(),
+  adapter: myEdgeConfigAdapter,
   key: 'example-flag',
 });
 ```

--- a/apps/docs/content/docs/providers/vercel.mdx
+++ b/apps/docs/content/docs/providers/vercel.mdx
@@ -60,11 +60,11 @@ import { vercelAdapter } from '@flags-sdk/vercel';
 
 export const exampleFlag = flag({
   key: "example-flag",
-  adapter: vercelAdapter()
+  adapter: vercelAdapter
 });
 ```
 
-The `vercelAdapter()` automatically uses the `FLAGS` environment variable to connect to your Vercel Flags project.
+The `vercelAdapter` automatically uses the `FLAGS` environment variable to connect to your Vercel Flags project.
 
 ### 4. Use the flag
 
@@ -107,7 +107,7 @@ const identify = dedupe(async (): Promise<Entities> => {
 export const exampleFlag = flag<boolean, Entities>({
   key: "example-flag",
   identify,
-  adapter: vercelAdapter()
+  adapter: vercelAdapter
 });
 ```
 
@@ -156,7 +156,7 @@ const customAdapter = createVercelAdapter(
 
 export const exampleFlag = flag({
   key: "example-flag",
-  adapter: customAdapter()
+  adapter: customAdapter
 });
 ```
 

--- a/apps/playground/flags.ts
+++ b/apps/playground/flags.ts
@@ -3,5 +3,5 @@ import { flag } from 'flags/next';
 
 export const jsonFlag = flag({
   key: 'json-flag',
-  adapter: vercelAdapter(),
+  adapter: vercelAdapter,
 });

--- a/examples/snippets/app/concepts/adapters/flags.tsx
+++ b/examples/snippets/app/concepts/adapters/flags.tsx
@@ -6,5 +6,5 @@ const edgeConfigAdapter = createEdgeConfigAdapter(process.env.EDGE_CONFIG!);
 export const customAdapterFlag = flag<boolean>({
   key: 'custom-adapter-flag',
   description: 'Shows how to use a custom flags adapter',
-  adapter: edgeConfigAdapter(),
+  adapter: edgeConfigAdapter,
 });

--- a/packages/adapter-edge-config/README.md
+++ b/packages/adapter-edge-config/README.md
@@ -18,7 +18,7 @@ import { edgeConfigAdapter } from "@flags-sdk/edge-config";
 
 export const exampleFlag = flag({
   key: "example-flag",
-  adapter: edgeConfigAdapter(),
+  adapter: edgeConfigAdapter,
 });
 ```
 
@@ -47,7 +47,7 @@ const edgeConfigAdapter = createEdgeConfigAdapter(process.env.EDGE_CONFIG, {
 
 export const exampleFlag = flag({
   key: "example-flag",
-  adapter: edgeConfigAdapter(),
+  adapter: edgeConfigAdapter,
 });
 ```
 

--- a/packages/adapter-vercel/README.md
+++ b/packages/adapter-vercel/README.md
@@ -16,7 +16,7 @@ import { vercelAdapter } from '@flags-sdk/vercel';
 
 export const exampleFlag = flag({
   key: 'example-flag',
-  adapter: vercelAdapter(),
+  adapter: vercelAdapter,
 });
 ```
 
@@ -33,7 +33,7 @@ const vercelAdapter = createVercelAdapter(vercelFlagsClient);
 
 export const exampleFlag = flag({
   key: 'example-flag',
-  adapter: vercelAdapter(),
+  adapter: vercelAdapter,
 });
 ```
 

--- a/skills/flags-sdk/SKILL.md
+++ b/skills/flags-sdk/SKILL.md
@@ -2,7 +2,7 @@
 name: flags-sdk
 description: >
   Guide for feature flags and A/B tests with the Flags SDK (`flags` npm package) and Vercel Flags.
-  Use when: declaring flags with `flag()`, using `vercelAdapter()` or `vercel flags` CLI
+  Use when: declaring flags with `flag()`, using `vercelAdapter` or `vercel flags` CLI
   (add, list, enable, disable, inspect, archive, rm, sdk-keys),
   setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog, GrowthBook, Hypertune,
   Edge Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom adapters),
@@ -54,7 +54,7 @@ import { vercelAdapter } from '@flags-sdk/vercel';
 
 export const exampleFlag = flag({
   key: 'example-flag',
-  adapter: vercelAdapter(),
+  adapter: vercelAdapter,
 });
 ```
 
@@ -87,16 +87,16 @@ Check the project state to adapt commands and decide which steps you can skip:
 
    Before running `vercel flags add`, verify the project is linked to Vercel. Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link` first.
 
-3. **Pull environment variables**: Run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter()` will not be able to evaluate flags. This step is **mandatory** after creating a flag.
+3. **Pull environment variables**: Run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter` will not be able to evaluate flags. This step is **mandatory** after creating a flag.
 
-4. **Declare the flag in code**: Add it to `flags.ts` (or create the file if it doesn't exist) using `vercelAdapter()`:
+4. **Declare the flag in code**: Add it to `flags.ts` (or create the file if it doesn't exist) using `vercelAdapter`:
    ```ts
    import { flag } from 'flags/next';
    import { vercelAdapter } from '@flags-sdk/vercel';
 
    export const myFlag = flag({
      key: 'my-flag',
-     adapter: vercelAdapter(),
+     adapter: vercelAdapter,
    });
    ```
 
@@ -128,7 +128,7 @@ For the full Vercel provider reference — user targeting, `vercel flags` CLI su
 
 ## Declaring flags
 
-When using Vercel Flags, declare flags with `vercelAdapter()` as shown in the [Agent workflow](#agent-workflow-creating-a-new-flag). For other providers, see [references/providers.md](references/providers.md). Below are the general `flag()` patterns.
+When using Vercel Flags, declare flags with `vercelAdapter` as shown in the [Agent workflow](#agent-workflow-creating-a-new-flag). For other providers, see [references/providers.md](references/providers.md). Below are the general `flag()` patterns.
 
 ### Basic flag
 

--- a/skills/flags-sdk/references/providers.md
+++ b/skills/flags-sdk/references/providers.md
@@ -33,7 +33,7 @@ pnpm i flags @flags-sdk/vercel
 Before running any `vercel flags` command, verify the project is linked to Vercel. Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link` first.
 
 1. Create a flag in the Vercel dashboard or via CLI: `vercel flags add <flag-key> --kind boolean --description "<description>"`
-2. Pull env vars: you **must** run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter()` will not be able to evaluate flags.
+2. Pull env vars: you **must** run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter` will not be able to evaluate flags.
 3. Declare the flag:
 
 ```ts
@@ -42,7 +42,7 @@ import { vercelAdapter } from '@flags-sdk/vercel';
 
 export const exampleFlag = flag({
   key: 'example-flag',
-  adapter: vercelAdapter(),
+  adapter: vercelAdapter,
 });
 ```
 
@@ -65,7 +65,7 @@ const identify = dedupe(async (): Promise<Entities> => ({
 export const exampleFlag = flag<boolean, Entities>({
   key: 'example-flag',
   identify,
-  adapter: vercelAdapter(),
+  adapter: vercelAdapter,
 });
 ```
 
@@ -90,7 +90,7 @@ const customAdapter = createVercelAdapter(process.env.CUSTOM_FLAGS_KEY!);
 
 export const exampleFlag = flag({
   key: 'example-flag',
-  adapter: customAdapter(),
+  adapter: customAdapter,
 });
 ```
 
@@ -107,7 +107,7 @@ const vercelAdapter = createVercelAdapter(vercelFlagsClient);
 
 export const exampleFlag = flag({
   key: 'example-flag',
-  adapter: vercelAdapter(),
+  adapter: vercelAdapter,
 });
 ```
 
@@ -209,7 +209,7 @@ import { flag } from 'flags/next';
 import { edgeConfigAdapter } from '@flags-sdk/edge-config';
 
 export const exampleFlag = flag({
-  adapter: edgeConfigAdapter(),
+  adapter: edgeConfigAdapter,
   key: 'example-flag',
 });
 ```
@@ -689,6 +689,6 @@ import { myAdapter } from './my-adapter';
 
 export const exampleFlag = flag({
   key: 'example',
-  adapter: myAdapter(),
+  adapter: myAdapter,
 });
 ```


### PR DESCRIPTION
## Summary

The adapter API now accepts a zero-arg factory passed directly — `adapter: vercelAdapter` — as shorthand for calling it (`adapter: vercelAdapter()`). `flag()` resolves the factory internally (`AdapterOrFactory` in `packages/flags/src/types.ts`).

This PR updates the docs and examples to use the new shorthand. Since the change applies to every zero-arg factory adapter, it's applied consistently across the Vercel adapter, the Edge Config adapter, and the custom-adapter examples.

## Changes

- `apps/docs/content/docs/providers/vercel.mdx` — basic, user-targeting, and custom-adapter examples + prose
- `apps/docs/content/docs/providers/edge-config.mdx` — usage, API reference, custom-adapter examples
- `apps/docs/content/docs/providers/custom-adapters.mdx` — both adapter examples
- `apps/playground/flags.ts`
- `examples/snippets/app/concepts/adapters/flags.tsx`
- `packages/adapter-vercel/README.md`
- `packages/adapter-edge-config/README.md`
- `skills/flags-sdk/SKILL.md` and `skills/flags-sdk/references/providers.md`

Adapters that require config arguments are still created via `createXAdapter(...)`; only the resulting zero-arg factories use the new shorthand. The unrelated SvelteKit build `adapter()` and the adapter `src/`/CHANGELOG files are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)