### PR TITLE
feat(flags): share the evaluation pipeline + SvelteKit parity (2/3)

### DIFF
--- a/packages/flags/src/next/evaluate.ts
+++ b/packages/flags/src/next/evaluate.ts
@@ -1,7 +1,12 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { IncomingHttpHeaders } from 'node:http';
-import { internalReportValue, reportValue } from '../lib/report-value';
 import { setSpanAttribute, trace } from '../lib/tracing';
+import {
+  applyResult,
+  getCachedValuePromise,
+  getEntities,
+  hasOverride,
+} from '../shared/evaluation';
 import { readOverrides } from '../shared/overrides';
 import { sealCookies, sealHeaders, transformToHeaders } from '../shared/seal';
 import type { ReadonlyHeaders } from '../spec-extension/adapters/headers';
@@ -10,7 +15,6 @@ import type {
   Adapter,
   Decide,
   FlagDeclaration,
-  FlagParamsType,
   ResolvedFlagDeclaration,
 } from '../types';
 import { isInternalNextError } from './is-internal-next-error';
@@ -28,84 +32,6 @@ import type { Flag, PagesRouterRequest } from './types';
 export const BULK_IDENTIFY_REF = Symbol('flags.bulkIdentifyRef');
 export const BULKABLE = Symbol('flags.bulkable');
 
-// a map of (headers, flagKey, entitiesKey) => value
-const evaluationCache = new WeakMap<
-  Headers | IncomingHttpHeaders,
-  Map</* flagKey */ string, Map</* entitiesKey */ string, any>>
->();
-
-function getCachedValuePromise(
-  /**
-   * supports Headers for App Router and IncomingHttpHeaders for Pages Router
-   */
-  headers: Headers | IncomingHttpHeaders,
-  flagKey: string,
-  entitiesKey: string,
-): any {
-  return evaluationCache.get(headers)?.get(flagKey)?.get(entitiesKey);
-}
-
-function setCachedValuePromise(
-  /**
-   * supports Headers for App Router and IncomingHttpHeaders for Pages Router
-   */
-  headers: Headers | IncomingHttpHeaders,
-  flagKey: string,
-  entitiesKey: string,
-  flagValue: any,
-): any {
-  const byHeaders = evaluationCache.get(headers);
-
-  if (!byHeaders) {
-    evaluationCache.set(
-      headers,
-      new Map([[flagKey, new Map([[entitiesKey, flagValue]])]]),
-    );
-    return;
-  }
-
-  const byFlagKey = byHeaders.get(flagKey);
-  if (!byFlagKey) {
-    byHeaders.set(flagKey, new Map([[entitiesKey, flagValue]]));
-    return;
-  }
-
-  byFlagKey.set(entitiesKey, flagValue);
-}
-
-type IdentifyArgs = Parameters<
-  Exclude<FlagDeclaration<any, any>['identify'], undefined>
->;
-const identifyArgsMap = new WeakMap<
-  Headers | IncomingHttpHeaders,
-  IdentifyArgs
->();
-
-function isIdentifyFunction<ValueType, EntitiesType>(
-  identify: FlagDeclaration<ValueType, EntitiesType>['identify'] | EntitiesType,
-): identify is FlagDeclaration<ValueType, EntitiesType>['identify'] {
-  return typeof identify === 'function';
-}
-
-async function getEntities<ValueType, EntitiesType>(
-  identify: FlagDeclaration<ValueType, EntitiesType>['identify'] | EntitiesType,
-  dedupeCacheKey: Headers | IncomingHttpHeaders,
-  readonlyHeaders: ReadonlyHeaders,
-  readonlyCookies: ReadonlyRequestCookies,
-): Promise<EntitiesType | undefined> {
-  if (!identify) return undefined;
-  if (!isIdentifyFunction(identify)) return identify;
-
-  const args = identifyArgsMap.get(dedupeCacheKey);
-  if (args) return identify(...(args as [FlagParamsType]));
-
-  const nextArgs: IdentifyArgs = [
-    { headers: readonlyHeaders, cookies: readonlyCookies },
-  ];
-  identifyArgsMap.set(dedupeCacheKey, nextArgs);
-  return identify(...(nextArgs as [FlagParamsType]));
-}
-
 interface BulkStoreData {
   headers: ReadonlyHeaders;
   cookies: ReadonlyRequestCookies;
@@ -117,136 +43,6 @@ const bulkStore = new AsyncLocalStorage<BulkStoreData>();
 
 let headersModulePromise: Promise<typeof import('next/headers')> | undefined;
 let headersModule: typeof import('next/headers') | undefined;
-
-/**
- * Subset of a flag declaration / flag function that `applyResult` reads.
- * `FlagDeclaration` (passed from `getRun`) and the `api` (passed from
- * `evaluate()`) both satisfy this shape after `flag()` stamps `config` onto
- * the api.
- */
-type FlagInfo<ValueType> = {
-  key: string;
-  defaultValue?: ValueType;
-  config?: { reportValue?: boolean };
-  adapter?: { config?: { reportValue?: boolean } };
-};
-
-function hasOverride(
-  overrides: Record<string, any> | null,
-  key: string,
-): overrides is Record<string, any> {
-  return overrides !== null && overrides[key] !== undefined;
-}
-
-function shouldReportValue(definition: FlagInfo<any>): boolean {
-  return (
-    (definition.config?.reportValue ??
-      definition.adapter?.config?.reportValue) !== false
-  );
-}
-
-/**
- * Finalize a flag evaluation given an already-computed `entitiesKey`.
- *
- * Shared by `getRun` (single-flag path) and `evaluate()` (group path). Handles,
- * in order: cache hit → override → produce → defaultValue/error normalization
- * → cache write → reportValue. Override and cache writes write to the same
- * `evaluationCache` either path uses, so a subsequent `flagFn()` in the same
- * request hits cache regardless of which path populated it.
- */
-async function applyResult<ValueType>(args: {
-  definition: FlagInfo<ValueType>;
-  readonlyHeaders: ReadonlyHeaders;
-  entitiesKey: string;
-  overrides: Record<string, any> | null;
-  produce: () => ValueType | PromiseLike<ValueType>;
-}): Promise<ValueType> {
-  const { definition, readonlyHeaders, entitiesKey, overrides, produce } = args;
-
-  const cachedValue = getCachedValuePromise(
-    readonlyHeaders,
-    definition.key,
-    entitiesKey,
-  );
-  if (cachedValue !== undefined) {
-    setSpanAttribute('method', 'cached');
-    return await cachedValue;
-  }
-
-  if (hasOverride(overrides, definition.key)) {
-    setSpanAttribute('method', 'override');
-    const decision = overrides[definition.key] as ValueType;
-    setCachedValuePromise(
-      readonlyHeaders,
-      definition.key,
-      entitiesKey,
-      Promise.resolve(decision),
-    );
-    internalReportValue(definition.key, decision, {
-      reason: 'override',
-    });
-    return decision;
-  }
-
-  // Normalize the result of produce() into a promise. produce() may return
-  // synchronously or asynchronously, and may also throw synchronously.
-  // Fall back to defaultValue when produce returns undefined or throws.
-  let decisionResult: ValueType | PromiseLike<ValueType>;
-  try {
-    decisionResult = produce();
-  } catch (error) {
-    decisionResult = Promise.reject(error);
-  }
-
-  const decisionPromise = Promise.resolve(decisionResult).then<
-    ValueType,
-    ValueType
-  >(
-    (value) => {
-      if (value !== undefined) return value;
-      if (definition.defaultValue !== undefined) return definition.defaultValue;
-      throw new Error(
-        `flags: Flag "${definition.key}" must have a defaultValue or a decide function that returns a value`,
-      );
-    },
-    (error: Error) => {
-      if (isInternalNextError(error)) throw error;
-
-      // try to recover if defaultValue is set
-      if (definition.defaultValue !== undefined) {
-        if (process.env.NODE_ENV === 'development') {
-          console.info(
-            `flags: Flag "${definition.key}" is falling back to its defaultValue`,
-          );
-        } else {
-          console.warn(
-            `flags: Flag "${definition.key}" is falling back to its defaultValue after catching the following error`,
-            error,
-          );
-        }
-        return definition.defaultValue;
-      }
-      console.warn(`flags: Flag "${definition.key}" could not be evaluated`);
-      throw error;
-    },
-  );
-
-  setCachedValuePromise(
-    readonlyHeaders,
-    definition.key,
-    entitiesKey,
-    decisionPromise,
-  );
-
-  const decision = await decisionPromise;
-
-  if (shouldReportValue(definition)) {
-    // Overrides return before this point and report with `reason: "override"`.
-    reportValue(definition.key, decision);
-  }
-
-  return decision;
-}
 
 type Run<ValueType, EntitiesType> = (options: {
   entities?: EntitiesType;
@@ -333,6 +129,7 @@ export function getRun<ValueType, EntitiesType>(
       readonlyHeaders,
       entitiesKey,
       overrides,
+      isFrameworkError: isInternalNextError,
       produce: () =>
         decide({
           // @ts-expect-error TypeScript will not be able to process `getPrecomputed` when added to `Decide`. It is, however, part of the `Adapter` type
@@ -572,6 +369,7 @@ async function evaluateImpl(
                     readonlyHeaders,
                     entitiesKey,
                     overrides,
+                    isFrameworkError: isInternalNextError,
                     produce: () => {
                       if (bulkError) throw bulkError;
                       return bulkResult![flagFn.key];

--- a/packages/flags/src/next/index.ts
+++ b/packages/flags/src/next/index.ts
@@ -1,13 +1,16 @@
 import { normalizeOptions } from '../lib/normalize-options';
 import { setSpanAttribute, trace } from '../lib/tracing';
+import {
+  getDecide,
+  getIdentify,
+  getOrigin,
+  resolveAdapter,
+} from '../shared/flag-meta';
 import type {
-  Decide,
   FlagDeclaration,
   FlagDefinitionsType,
   FlagDefinitionType,
-  Identify,
   JsonValue,
-  Origin,
   ProviderData,
   ResolvedFlagDeclaration,
 } from '../types';
@@ -25,58 +28,6 @@ export {
   serialize,
 } from './precompute';
 export type { Flag } from './types';
-
-function getDecide<ValueType, EntitiesType>(
-  definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
-): Decide<ValueType, EntitiesType> {
-  if (definition.adapter && typeof definition.adapter.decide !== 'function') {
-    throw new Error(
-      `flags: The adapter passed to flag "${definition.key}" does not have a "decide" method.`,
-    );
-  }
-
-  if (
-    typeof definition.decide !== 'function' &&
-    typeof definition.adapter?.decide !== 'function'
-  ) {
-    throw new Error(
-      `flags: You passed a flag declaration that does not have a "decide" method for flag "${definition.key}"`,
-    );
-  }
-
-  return function decide(params) {
-    if (typeof definition.decide === 'function') {
-      return definition.decide(params);
-    }
-    if (typeof definition.adapter?.decide === 'function') {
-      return definition.adapter.decide({ key: definition.key, ...params });
-    }
-    throw new Error(`flags: No decide function provided for ${definition.key}`);
-  };
-}
-
-function getIdentify<ValueType, EntitiesType>(
-  definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
-): Identify<EntitiesType> {
-  return function identify(params) {
-    if (typeof definition.identify === 'function') {
-      return definition.identify(params);
-    }
-    if (typeof definition.adapter?.identify === 'function') {
-      return definition.adapter.identify(params);
-    }
-    return definition.identify;
-  };
-}
-
-function getOrigin<ValueType, EntitiesType>(
-  definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
-): string | Origin | undefined {
-  if (definition.origin) return definition.origin;
-  if (typeof definition.adapter?.origin === 'function')
-    return definition.adapter.origin(definition.key);
-  return definition.adapter?.origin;
-}
 
 /**
  * Declares a feature flag.
@@ -100,10 +51,7 @@ export function flag<
   // Allow passing the adapter factory directly (`adapter: vercelAdapter`) as a
   // shorthand for calling it (`adapter: vercelAdapter()`). Resolve it once here
   // so every consumer below works with a concrete Adapter instance.
-  const adapter =
-    typeof definition.adapter === 'function'
-      ? definition.adapter()
-      : definition.adapter;
+  const adapter = resolveAdapter(definition);
   // Cast: spreading the discriminated union widens `decide`/`adapter` so TS no
   // longer sees the "decide or adapter is present" guarantee, but the original
   // `definition` upheld it and we only narrowed `adapter` to an instance.

--- a/packages/flags/src/shared/evaluation.ts
+++ b/packages/flags/src/shared/evaluation.ts
@@ -1,0 +1,256 @@
+import type { IncomingHttpHeaders } from 'node:http';
+import { internalReportValue, reportValue } from '../lib/report-value';
+import { setSpanAttribute } from '../lib/tracing';
+import type { ReadonlyHeaders } from '../spec-extension/adapters/headers';
+import type { ReadonlyRequestCookies } from '../spec-extension/adapters/request-cookies';
+import type { FlagDeclaration, FlagParamsType, JsonValue } from '../types';
+
+/**
+ * Per-request evaluation cache, keyed by the request's headers identity so the
+ * same flag (and entities) only decides once per request. Supports `Headers`
+ * (App Router / SvelteKit / Web requests) and `IncomingHttpHeaders` (Pages
+ * Router `IncomingMessage`) as the outer key.
+ *
+ * Shape: `(headers) -> (flagKey) -> (entitiesKey) -> valuePromise`.
+ */
+const evaluationCache = new WeakMap<
+  Headers | IncomingHttpHeaders,
+  Map</* flagKey */ string, Map</* entitiesKey */ string, any>>
+>();
+
+export function getCachedValuePromise(
+  headers: Headers | IncomingHttpHeaders,
+  flagKey: string,
+  entitiesKey: string,
+): any {
+  return evaluationCache.get(headers)?.get(flagKey)?.get(entitiesKey);
+}
+
+export function setCachedValuePromise(
+  headers: Headers | IncomingHttpHeaders,
+  flagKey: string,
+  entitiesKey: string,
+  flagValue: any,
+): void {
+  const byHeaders = evaluationCache.get(headers);
+
+  if (!byHeaders) {
+    evaluationCache.set(
+      headers,
+      new Map([[flagKey, new Map([[entitiesKey, flagValue]])]]),
+    );
+    return;
+  }
+
+  const byFlagKey = byHeaders.get(flagKey);
+  if (!byFlagKey) {
+    byHeaders.set(flagKey, new Map([[entitiesKey, flagValue]]));
+    return;
+  }
+
+  byFlagKey.set(entitiesKey, flagValue);
+}
+
+/**
+ * Returns the flags evaluated so far for a given request, as a record of flag
+ * key to value promise. When a flag was evaluated for multiple entity sets in
+ * the same request, the most recently evaluated value wins.
+ *
+ * Used to report which flags a request used (e.g. SvelteKit injects these into
+ * the rendered HTML for the Vercel Toolbar).
+ */
+export function getUsedFlags(
+  headers: Headers | IncomingHttpHeaders,
+): Record<string, Promise<JsonValue>> {
+  const byFlagKey = evaluationCache.get(headers);
+  const result: Record<string, Promise<JsonValue>> = {};
+  if (!byFlagKey) return result;
+
+  for (const [flagKey, byEntitiesKey] of byFlagKey) {
+    let last: Promise<JsonValue> | undefined;
+    for (const valuePromise of byEntitiesKey.values()) last = valuePromise;
+    if (last !== undefined) result[flagKey] = last;
+  }
+
+  return result;
+}
+
+type IdentifyArgs = Parameters<
+  Exclude<FlagDeclaration<any, any>['identify'], undefined>
+>;
+const identifyArgsMap = new WeakMap<
+  Headers | IncomingHttpHeaders,
+  IdentifyArgs
+>();
+
+function isIdentifyFunction<ValueType, EntitiesType>(
+  identify: FlagDeclaration<ValueType, EntitiesType>['identify'] | EntitiesType,
+): identify is FlagDeclaration<ValueType, EntitiesType>['identify'] {
+  return typeof identify === 'function';
+}
+
+/**
+ * Resolves the entities for a flag evaluation. When `identify` is a function it
+ * is called with a stable args object (cached per `dedupeCacheKey`) so that a
+ * user-supplied `dedupe()` wrapper deduplicates across flags sharing the same
+ * request. When `identify` is already an entities value it is returned as-is.
+ */
+export async function getEntities<ValueType, EntitiesType>(
+  identify: FlagDeclaration<ValueType, EntitiesType>['identify'] | EntitiesType,
+  dedupeCacheKey: Headers | IncomingHttpHeaders,
+  readonlyHeaders: ReadonlyHeaders,
+  readonlyCookies: ReadonlyRequestCookies,
+): Promise<EntitiesType | undefined> {
+  if (!identify) return undefined;
+  if (!isIdentifyFunction(identify)) return identify;
+
+  const args = identifyArgsMap.get(dedupeCacheKey);
+  if (args) return identify(...(args as [FlagParamsType]));
+
+  const nextArgs: IdentifyArgs = [
+    { headers: readonlyHeaders, cookies: readonlyCookies },
+  ];
+  identifyArgsMap.set(dedupeCacheKey, nextArgs);
+  return identify(...(nextArgs as [FlagParamsType]));
+}
+
+/**
+ * Subset of a flag declaration / flag function that `applyResult` reads.
+ * Both a `FlagDeclaration` and the flag `api` (after `flag()` stamps `config`
+ * onto it) satisfy this shape.
+ */
+export type FlagInfo<ValueType> = {
+  key: string;
+  defaultValue?: ValueType;
+  config?: { reportValue?: boolean };
+  adapter?: { config?: { reportValue?: boolean } };
+};
+
+export function hasOverride(
+  overrides: Record<string, any> | null,
+  key: string,
+): overrides is Record<string, any> {
+  return overrides !== null && overrides[key] !== undefined;
+}
+
+function shouldReportValue(definition: FlagInfo<any>): boolean {
+  return (
+    (definition.config?.reportValue ??
+      definition.adapter?.config?.reportValue) !== false
+  );
+}
+
+/**
+ * Finalize a flag evaluation given an already-computed `entitiesKey`.
+ *
+ * Handles, in order: cache hit → override → produce → defaultValue/error
+ * normalization → cache write → reportValue. Override and cache writes write to
+ * the same `evaluationCache` every caller uses, so a subsequent evaluation of
+ * the same flag in the same request hits cache regardless of which path
+ * populated it.
+ *
+ * `isFrameworkError` lets a framework opt certain errors out of the
+ * defaultValue fallback so they propagate (e.g. Next's `redirect()` /
+ * `notFound()` control-flow errors). Defaults to never matching.
+ */
+export async function applyResult<ValueType>(args: {
+  definition: FlagInfo<ValueType>;
+  readonlyHeaders: ReadonlyHeaders;
+  entitiesKey: string;
+  overrides: Record<string, any> | null;
+  produce: () => ValueType | PromiseLike<ValueType>;
+  isFrameworkError?: (error: unknown) => boolean;
+}): Promise<ValueType> {
+  const {
+    definition,
+    readonlyHeaders,
+    entitiesKey,
+    overrides,
+    produce,
+    isFrameworkError = () => false,
+  } = args;
+
+  const cachedValue = getCachedValuePromise(
+    readonlyHeaders,
+    definition.key,
+    entitiesKey,
+  );
+  if (cachedValue !== undefined) {
+    setSpanAttribute('method', 'cached');
+    return await cachedValue;
+  }
+
+  if (hasOverride(overrides, definition.key)) {
+    setSpanAttribute('method', 'override');
+    const decision = overrides[definition.key] as ValueType;
+    setCachedValuePromise(
+      readonlyHeaders,
+      definition.key,
+      entitiesKey,
+      Promise.resolve(decision),
+    );
+    internalReportValue(definition.key, decision, {
+      reason: 'override',
+    });
+    return decision;
+  }
+
+  // Normalize the result of produce() into a promise. produce() may return
+  // synchronously or asynchronously, and may also throw synchronously.
+  // Fall back to defaultValue when produce returns undefined or throws.
+  let decisionResult: ValueType | PromiseLike<ValueType>;
+  try {
+    decisionResult = produce();
+  } catch (error) {
+    decisionResult = Promise.reject(error);
+  }
+
+  const decisionPromise = Promise.resolve(decisionResult).then<
+    ValueType,
+    ValueType
+  >(
+    (value) => {
+      if (value !== undefined) return value;
+      if (definition.defaultValue !== undefined) return definition.defaultValue;
+      throw new Error(
+        `flags: Flag "${definition.key}" must have a defaultValue or a decide function that returns a value`,
+      );
+    },
+    (error: Error) => {
+      if (isFrameworkError(error)) throw error;
+
+      // try to recover if defaultValue is set
+      if (definition.defaultValue !== undefined) {
+        if (process.env.NODE_ENV === 'development') {
+          console.info(
+            `flags: Flag "${definition.key}" is falling back to its defaultValue`,
+          );
+        } else {
+          console.warn(
+            `flags: Flag "${definition.key}" is falling back to its defaultValue after catching the following error`,
+            error,
+          );
+        }
+        return definition.defaultValue;
+      }
+      console.warn(`flags: Flag "${definition.key}" could not be evaluated`);
+      throw error;
+    },
+  );
+
+  setCachedValuePromise(
+    readonlyHeaders,
+    definition.key,
+    entitiesKey,
+    decisionPromise,
+  );
+
+  const decision = await decisionPromise;
+
+  if (shouldReportValue(definition)) {
+    // Overrides return before this point and report with `reason: "override"`.
+    reportValue(definition.key, decision);
+  }
+
+  return decision;
+}

--- a/packages/flags/src/shared/flag-meta.ts
+++ b/packages/flags/src/shared/flag-meta.ts
@@ -1,0 +1,89 @@
+import type {
+  Adapter,
+  Decide,
+  FlagDeclaration,
+  Identify,
+  Origin,
+  ResolvedFlagDeclaration,
+} from '../types';
+
+/**
+ * Allow passing the adapter factory directly (`adapter: vercelAdapter`) as a
+ * shorthand for calling it (`adapter: vercelAdapter()`). Resolves it once so
+ * every consumer works with a concrete {@link Adapter} instance.
+ */
+export function resolveAdapter<ValueType, EntitiesType>(
+  definition: FlagDeclaration<ValueType, EntitiesType>,
+): Adapter<ValueType, EntitiesType> | undefined {
+  return typeof definition.adapter === 'function'
+    ? definition.adapter()
+    : definition.adapter;
+}
+
+/**
+ * Builds the `decide` function for a flag, preferring an inline
+ * `definition.decide` over the adapter's `decide`. Throws when neither is
+ * available, or when an adapter is present but lacks a `decide` method.
+ */
+export function getDecide<ValueType, EntitiesType>(
+  definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
+): Decide<ValueType, EntitiesType> {
+  if (definition.adapter && typeof definition.adapter.decide !== 'function') {
+    throw new Error(
+      `flags: The adapter passed to flag "${definition.key}" does not have a "decide" method.`,
+    );
+  }
+
+  if (
+    typeof definition.decide !== 'function' &&
+    typeof definition.adapter?.decide !== 'function'
+  ) {
+    throw new Error(
+      `flags: You passed a flag declaration that does not have a "decide" method for flag "${definition.key}"`,
+    );
+  }
+
+  return function decide(params) {
+    if (typeof definition.decide === 'function') {
+      return definition.decide(params);
+    }
+    if (typeof definition.adapter?.decide === 'function') {
+      return definition.adapter.decide({ key: definition.key, ...params });
+    }
+    throw new Error(`flags: No decide function provided for ${definition.key}`);
+  };
+}
+
+/**
+ * Builds the `identify` function for a flag, preferring an inline
+ * `definition.identify` over the adapter's `identify`. Always returns a
+ * function; when neither source provides one the function resolves to
+ * `undefined` (no entities).
+ */
+export function getIdentify<ValueType, EntitiesType>(
+  definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
+): Identify<EntitiesType> {
+  return function identify(params) {
+    if (typeof definition.identify === 'function') {
+      return definition.identify(params);
+    }
+    if (typeof definition.adapter?.identify === 'function') {
+      return definition.adapter.identify(params);
+    }
+    return definition.identify;
+  };
+}
+
+/**
+ * Resolves the `origin` of a flag, preferring an inline `definition.origin`
+ * over the adapter's `origin` (which may be a value or a `(key) => origin`
+ * function).
+ */
+export function getOrigin<ValueType, EntitiesType>(
+  definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
+): string | Origin | undefined {
+  if (definition.origin) return definition.origin;
+  if (typeof definition.adapter?.origin === 'function')
+    return definition.adapter.origin(definition.key);
+  return definition.adapter?.origin;
+}

--- a/packages/flags/src/sveltekit/index.test.ts
+++ b/packages/flags/src/sveltekit/index.test.ts
@@ -1,11 +1,72 @@
-import { describe, expect, it, vi } from 'vitest';
-import { flag, getProviderData } from '.';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { encryptOverrides, flag, getProviderData } from '.';
 
-vi.mock('$env/dynamic/private', () => ({ FLAGS_SECRET: 'secret' }));
+// A valid 32-byte (256-bit) base64url key, required by the crypto helpers.
+const { secret } = vi.hoisted(() => ({
+  secret: Buffer.alloc(32, 7).toString('base64url'),
+}));
+vi.mock('$env/static/private', () => ({ FLAGS_SECRET: secret }));
+
+const requestContextSymbol = Symbol.for('@vercel/request-context');
+const previousRequestContext = Reflect.get(globalThis, requestContextSymbol);
+
+type ReportCall = {
+  readonly key: string;
+  readonly value: unknown;
+  readonly data: Record<string, unknown>;
+};
+
+function installRequestContext() {
+  const calls: ReportCall[] = [];
+  const flags = {
+    calls,
+    reportValue(
+      this: { calls: ReportCall[] },
+      key: string,
+      value: unknown,
+      data: Record<string, unknown>,
+    ) {
+      this.calls.push({ key, value, data });
+    },
+  };
+  Reflect.set(globalThis, requestContextSymbol, { get: () => ({ flags }) });
+  return calls;
+}
+
+afterEach(() => {
+  Reflect.set(globalThis, requestContextSymbol, previousRequestContext);
+  vi.restoreAllMocks();
+});
 
 describe('getProviderData', () => {
   it('is a function', () => {
     expect(typeof getProviderData).toBe('function');
+  });
+
+  it('includes declaredInCode and defaultValue', () => {
+    const f = flag<boolean>({
+      key: 'pd-flag',
+      defaultValue: true,
+      description: 'desc',
+      decide: () => false,
+    });
+    const data = getProviderData({ f });
+    expect(data.definitions?.['pd-flag']).toMatchObject({
+      description: 'desc',
+      defaultValue: true,
+      declaredInCode: true,
+    });
+  });
+
+  it('surfaces an adapter origin', () => {
+    const f = flag<boolean>({
+      key: 'origin-flag',
+      adapter: { origin: 'https://origin.example', decide: () => true },
+    });
+    const data = getProviderData({ f });
+    expect(data.definitions?.['origin-flag']?.origin).toBe(
+      'https://origin.example',
+    );
   });
 });
 
@@ -13,5 +74,88 @@ describe('flag', () => {
   it('defines a key', async () => {
     const f = flag<boolean>({ key: 'first-flag', decide: () => false });
     expect(f).toHaveProperty('key', 'first-flag');
+  });
+
+  it('falls back to defaultValue when decide throws', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const f = flag<boolean>({
+      key: 'throwing-flag',
+      defaultValue: true,
+      decide: () => {
+        throw new Error('boom');
+      },
+    });
+    await expect(f(new Request('https://example.com'))).resolves.toBe(true);
+  });
+
+  it('falls back to defaultValue when decide returns undefined', async () => {
+    const f = flag<boolean>({
+      key: 'undefined-flag',
+      defaultValue: false,
+      decide: () => undefined as unknown as boolean,
+    });
+    await expect(f(new Request('https://example.com'))).resolves.toBe(false);
+  });
+
+  it('reports the evaluated value by default', async () => {
+    const calls = installRequestContext();
+    const f = flag<boolean>({ key: 'reported-flag', decide: () => true });
+    await expect(f(new Request('https://example.com'))).resolves.toBe(true);
+    expect(calls).toEqual([
+      {
+        key: 'reported-flag',
+        value: true,
+        data: expect.objectContaining({ sdkVersion: expect.any(String) }),
+      },
+    ]);
+  });
+
+  it('honors config.reportValue: false', async () => {
+    const calls = installRequestContext();
+    const f = flag<boolean>({
+      key: 'silent-flag',
+      decide: () => true,
+      config: { reportValue: false },
+    });
+    await expect(f(new Request('https://example.com'))).resolves.toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  it('honors adapter-level reportValue: false', async () => {
+    const calls = installRequestContext();
+    const f = flag<boolean>({
+      key: 'silent-adapter-flag',
+      adapter: { config: { reportValue: false }, decide: () => true },
+    });
+    await expect(f(new Request('https://example.com'))).resolves.toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  it('resolves origin from an adapter', () => {
+    const value = flag<boolean>({
+      key: 'origin-value',
+      adapter: { origin: 'https://origin.example', decide: () => true },
+    });
+    expect(value.origin).toBe('https://origin.example');
+
+    const fn = flag<boolean>({
+      key: 'origin-fn',
+      adapter: {
+        origin: (key) => `https://origin.example/${key}`,
+        decide: () => true,
+      },
+    });
+    expect(fn.origin).toBe('https://origin.example/origin-fn');
+  });
+
+  it('uses an override cookie instead of calling decide', async () => {
+    const decide = vi.fn(() => false);
+    const f = flag<boolean>({ key: 'override-flag', decide });
+    const override = await encryptOverrides({ 'override-flag': true });
+    const request = new Request('https://example.com', {
+      headers: { cookie: `vercel-flag-overrides=${override}` },
+    });
+    await expect(f(request)).resolves.toBe(true);
+    expect(decide).not.toHaveBeenCalled();
   });
 });

--- a/packages/flags/src/sveltekit/index.ts
+++ b/packages/flags/src/sveltekit/index.ts
@@ -16,21 +16,25 @@ import {
   type ApiData,
   type FlagDefinitionsType,
   type JsonValue,
-  reportValue,
   safeJsonStringify,
   verifyAccess,
   version,
 } from '..';
 import { normalizeOptions } from '../lib/normalize-options';
 import { handleDiscoveryRequest } from '../shared/discovery';
+import { applyResult, getEntities, getUsedFlags } from '../shared/evaluation';
+import {
+  getDecide,
+  getIdentify,
+  getOrigin,
+  resolveAdapter,
+} from '../shared/flag-meta';
 import { readOverrides } from '../shared/overrides';
 import { sealCookies, sealHeaders } from '../shared/seal';
 import type {
-  Decide,
   FlagDeclaration,
   FlagOverridesType,
   FlagValuesType,
-  Identify,
   ResolvedFlagDeclaration,
 } from '../types';
 import { tryGetSecret } from './env';
@@ -40,14 +44,6 @@ import {
   getPrecomputed,
 } from './precompute';
 import type { Flag, FlagsArray } from './types';
-
-// biome-ignore lint/suspicious/noShadowRestrictedNames: for type safety
-function hasOwnProperty<X extends {}, Y extends PropertyKey>(
-  obj: X,
-  prop: Y,
-): obj is X & Record<Y, unknown> {
-  return Object.hasOwn(obj, prop);
-}
 
 type PromisesMap<T> = {
   [K in keyof T]: Promise<T[K]>;
@@ -69,31 +65,6 @@ async function resolveObjectPromises<T>(obj: PromisesMap<T>): Promise<T> {
   return Object.fromEntries(resolvedEntries) as T;
 }
 
-function getDecide<ValueType, EntitiesType>(
-  definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
-): Decide<ValueType, EntitiesType> {
-  return function decide(params) {
-    if (typeof definition.decide === 'function') {
-      return definition.decide(params);
-    }
-    if (typeof definition.adapter?.decide === 'function') {
-      return definition.adapter.decide({ key: definition.key, ...params });
-    }
-    throw new Error(`flags: No decide function provided for ${definition.key}`);
-  };
-}
-
-function getIdentify<ValueType, EntitiesType>(
-  definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
-): Identify<EntitiesType> | undefined {
-  if (typeof definition.identify === 'function') {
-    return definition.identify;
-  }
-  if (typeof definition.adapter?.identify === 'function') {
-    return definition.adapter.identify;
-  }
-}
-
 /**
  * Used when a flag is called outside of a request context, i.e. outside of the lifecycle of the `handle` hook.
  * This could be the case when the flag is called from routing functions.
@@ -109,17 +80,15 @@ export function flag<
 >(definition: FlagDeclaration<ValueType, EntitiesType>): Flag<ValueType> {
   // Allow passing the adapter factory directly (`adapter: vercelAdapter`) as a
   // shorthand for calling it (`adapter: vercelAdapter()`). Resolve it once here.
-  const adapter =
-    typeof definition.adapter === 'function'
-      ? definition.adapter()
-      : definition.adapter;
+  const adapter = resolveAdapter(definition);
   const resolvedDefinition = {
     ...definition,
     adapter,
   } as ResolvedFlagDeclaration<ValueType, EntitiesType>;
 
   const decide = getDecide<ValueType, EntitiesType>(resolvedDefinition);
-  const identify = getIdentify(resolvedDefinition);
+  const identify = getIdentify<ValueType, EntitiesType>(resolvedDefinition);
+  const origin = getOrigin(resolvedDefinition);
 
   const flagImpl = async function flagImpl(
     requestOrCode?: string | Request,
@@ -154,56 +123,35 @@ export function flag<
       );
     }
 
-    if (hasOwnProperty(store.usedFlags, definition.key)) {
-      const valuePromise = store.usedFlags[definition.key];
-      if (typeof valuePromise !== 'undefined') {
-        return valuePromise as Promise<ValueType>;
-      }
-    }
-
+    // `request.headers` is a stable identity for the duration of the request,
+    // so it doubles as the dedupe key for the shared evaluation cache and the
+    // identify-args cache.
+    const dedupeCacheKey = store.request.headers;
     const headers = sealHeaders(store.request.headers);
     const cookies = sealCookies(store.request.headers);
 
     const overrides = await readOverrides(cookies, store.secret);
 
-    if (overrides && hasOwnProperty(overrides, definition.key)) {
-      const value = overrides[definition.key];
-      if (typeof value !== 'undefined') {
-        reportValue(definition.key, value);
-        store.usedFlags[definition.key] = Promise.resolve(value as JsonValue);
-        return value;
-      }
-    }
-
-    let entities: EntitiesType | undefined;
-    if (identify) {
-      // Deduplicate calls to identify, key being the function itself
-      if (!store.identifiers.has(identify)) {
-        const entities = identify({
-          headers,
-          cookies,
-        });
-        store.identifiers.set(identify, entities);
-      }
-
-      entities = (await store.identifiers.get(identify)) as EntitiesType;
-    }
-
-    const valuePromise = decide({
+    const entities = await getEntities(
+      identify,
+      dedupeCacheKey,
       headers,
       cookies,
-      entities,
-    });
-    store.usedFlags[definition.key] = valuePromise as Promise<JsonValue>;
+    );
+    const entitiesKey = JSON.stringify(entities) ?? '';
 
-    const value = await valuePromise;
-    reportValue(definition.key, value);
-    return value;
+    return applyResult({
+      definition: resolvedDefinition,
+      readonlyHeaders: headers,
+      entitiesKey,
+      overrides,
+      produce: () => decide({ headers, cookies, entities }),
+    });
   };
 
   flagImpl.key = definition.key;
   flagImpl.defaultValue = definition.defaultValue;
-  flagImpl.origin = definition.origin;
+  flagImpl.origin = origin;
   flagImpl.description = definition.description;
   flagImpl.options = normalizeOptions(definition.options);
   flagImpl.decide = decide;
@@ -219,6 +167,8 @@ export function getProviderData(flags: Record<string, Flag<any>>): ApiData {
         options: normalizeOptions(d.options),
         origin: d.origin,
         description: d.description,
+        defaultValue: d.defaultValue,
+        declaredInCode: true,
       };
       return acc;
     },
@@ -232,8 +182,6 @@ interface AsyncLocalContext {
   request: Request;
   secret: string;
   params: Record<string, string>;
-  usedFlags: Record<string, Promise<JsonValue>>;
-  identifiers: Map<Identify<unknown>, ReturnType<Identify<unknown>>>;
 }
 
 function createContext(
@@ -245,8 +193,6 @@ function createContext(
     request,
     secret,
     params: params ?? {},
-    usedFlags: {},
-    identifiers: new Map(),
   };
 }
 
@@ -298,14 +244,18 @@ export function createHandle({
     return flagStorage.run(flagContext, () =>
       resolve(event, {
         transformPageChunk: async ({ html }) => {
-          const store = flagStorage.getStore();
-          if (!store || Object.keys(store.usedFlags).length === 0) return html;
+          // Which flags were used while rendering this page lives in the shared
+          // evaluation cache, keyed by the sealed request headers (the same key
+          // `applyResult` writes under). `sealHeaders` is memoized by the raw
+          // headers identity, so this returns the same sealed object.
+          const usedFlags = getUsedFlags(sealHeaders(event.request.headers));
+          if (Object.keys(usedFlags).length === 0) return html;
 
           // This is for reporting which flags were used when this page was generated,
           // so the value shows up in Vercel Toolbar, without the client ever being
           // aware of this feature flag.
           const encryptedFlagValues = await _encryptFlagValues(
-            await resolveObjectPromises(store.usedFlags),
+            await resolveObjectPromises(usedFlags),
             secret,
           );
 

--- a/packages/flags/src/sveltekit/types.ts
+++ b/packages/flags/src/sveltekit/types.ts
@@ -2,6 +2,7 @@ import type { FlagOption } from '../types';
 
 type FlagsMeta<ReturnValue> = {
   key: string;
+  defaultValue?: ReturnValue;
   description?: string;
   origin?: string | Record<string, unknown>;
   options?: FlagOption<ReturnValue>[];


### PR DESCRIPTION
**Stacked PR 2 of 3** · base: `shared/extraction` (#412)

Lifts the per-request evaluation pipeline into `src/shared/` and points both frameworks at it, so behavior is defined once. The Next-specific `isInternalNextError` check becomes an injected `isFrameworkError` hook on `applyResult`.

- `shared/evaluation.ts` — headers-keyed `evaluationCache` (+ `getUsedFlags`), `getEntities` + identify-args dedupe, and `applyResult` (cache → override → produce → defaultValue/error → report)
- `shared/flag-meta.ts` — `resolveAdapter`, `getDecide` (with adapter validation), `getIdentify`, `getOrigin`

**Behavior change (version bump):** SvelteKit's `flag()` now runs through this pipeline, reaching parity with Next. SvelteKit now:
- falls back to `defaultValue` when `decide` throws or returns `undefined`
- honors `config.reportValue` / `adapter.config.reportValue`
- resolves `adapter.origin` (value or `(key) => origin`)
- dedupes via the shared headers-keyed cache (replacing per-store `usedFlags`/`identifiers`); `transformPageChunk` reads used flags via `getUsedFlags()`
- `getProviderData` emits `defaultValue` + `declaredInCode`

Adds `defaultValue?` to the SvelteKit `Flag` type (additive) and 9 parity tests. **Next's public `.d.ts` is unchanged.**

### Verification
121/121 tests pass · type-check · biome · `attw` green · `next.d.ts` byte-identical · `@flags-sdk/vercel` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)