### PR TITLE
feat(flags): share bulk evaluate() + give SvelteKit evaluate() (3/3)

### DIFF
--- a/packages/flags/src/next/evaluate.ts
+++ b/packages/flags/src/next/evaluate.ts
@@ -1,18 +1,13 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { IncomingHttpHeaders } from 'node:http';
-import { setSpanAttribute, trace } from '../lib/tracing';
-import {
-  applyResult,
-  getCachedValuePromise,
-  getEntities,
-  hasOverride,
-} from '../shared/evaluation';
+import { trace } from '../lib/tracing';
+import { evaluateFlags } from '../shared/evaluate';
+import { applyResult, getEntities } from '../shared/evaluation';
 import { readOverrides } from '../shared/overrides';
 import { sealCookies, sealHeaders, transformToHeaders } from '../shared/seal';
 import type { ReadonlyHeaders } from '../spec-extension/adapters/headers';
 import type { ReadonlyRequestCookies } from '../spec-extension/adapters/request-cookies';
 import type {
-  Adapter,
   Decide,
   FlagDeclaration,
   ResolvedFlagDeclaration,
@@ -20,17 +15,9 @@ import type {
 import { isInternalNextError } from './is-internal-next-error';
 import type { Flag, PagesRouterRequest } from './types';
 
-// Internal markers stamped on the flag api by `flag()`. Read by `evaluate()`
-// to partition flags into adapter groups.
-//
-// - BULK_IDENTIFY_REF: the raw identify source for reference-equality
-//   comparison across flags. The wrapped `api.identify` is created per
-//   `flag()` call, so it can't be used for grouping.
-// - BULKABLE: whether the flag can participate in adapter-level bulk
-//   evaluation. An inline `definition.decide` disqualifies the flag
-//   because `getDecide` prefers it over the adapter's decide.
-export const BULK_IDENTIFY_REF = Symbol('flags.bulkIdentifyRef');
-export const BULKABLE = Symbol('flags.bulkable');
+// Re-export the bulk markers from their shared home so `flag()` (which stamps
+// them) and existing importers keep importing from `./evaluate`.
+export { BULK_IDENTIFY_REF, BULKABLE } from '../shared/evaluate';
 
 interface BulkStoreData {
   headers: ReadonlyHeaders;
@@ -254,181 +241,18 @@ async function evaluateImpl(
     overrides,
   };
 
-  return bulkStore.run(storeData, async () => {
-    const entries = Object.entries(flags);
-
-    const standalone: { name: string; flagFn: Flag<any, any> }[] = [];
-    // adapterId -> identifyRef -> { adapter, entries }
-    const groups = new Map<
-      string | symbol,
-      Map<
-        unknown,
-        {
-          adapter: Adapter<any, any>;
-          entries: { name: string; flagFn: Flag<any, any> }[];
-        }
-      >
-    >();
-
-    for (const [name, flagFn] of entries) {
-      const entry = { name, flagFn };
-      if (!(flagFn as any)[BULKABLE]) {
-        standalone.push(entry);
-        continue;
-      }
-      const adapter = flagFn.adapter as Adapter<any, any>;
-      const groupId = adapter.adapterId as string | symbol;
-      const identifyRef = (flagFn as any)[BULK_IDENTIFY_REF] ?? null;
-      let byIdentify = groups.get(groupId);
-      if (!byIdentify) {
-        byIdentify = new Map();
-        groups.set(groupId, byIdentify);
-      }
-      let bucket = byIdentify.get(identifyRef);
-      if (!bucket) {
-        // Capture the first adapter for this group — any adapter with the
-        // same adapterId must wrap the same underlying resource.
-        bucket = { adapter, entries: [] };
-        byIdentify.set(identifyRef, bucket);
-      }
-      bucket.entries.push(entry);
-    }
-
-    const valuesByName: Record<string, any> = {};
-    const groupPromises: Promise<unknown>[] = [];
-
-    for (const byIdentify of groups.values()) {
-      for (const [identifyRef, { adapter, entries: list }] of byIdentify) {
-        groupPromises.push(
-          // One `batch` span per bulk-evaluated group (a batch being a single
-          // group within the overall `evaluate()` bulk), replacing the
-          // per-flag `run` span that bulkable flags would otherwise get via
-          // `flagFn()`. A per-flag span here would reintroduce the per-flag
-          // instrumentation overhead (closure + span + microtask) that bulk
-          // evaluation exists to avoid, so the batch reports an aggregate
-          // `method`/count summary instead. Standalone flags still emit their
-          // own `flag` span.
-          trace(
-            async () => {
-              // Resolve entities once for the entire group. The dedupe key is
-              // the same one `getRun` uses (`request.headers` for Pages Router,
-              // the `headers()` store for App Router), so any flag called
-              // individually before/after `evaluate()` reuses the cached
-              // identify args from `identifyArgsMap`.
-              const entities = identifyRef
-                ? await getEntities(
-                    identifyRef as any,
-                    dedupeCacheKey,
-                    readonlyHeaders,
-                    readonlyCookies,
-                  )
-                : undefined;
-              const entitiesKey = JSON.stringify(entities) ?? '';
-
-              // Skip flags already resolved this request — `applyResult` would
-              // discard the bulk result for them anyway.
-              const uncached = list.filter(
-                ({ flagFn }) =>
-                  getCachedValuePromise(
-                    readonlyHeaders,
-                    flagFn.key,
-                    entitiesKey,
-                  ) === undefined,
-              );
-              const undecided = uncached.filter(
-                ({ flagFn }) => !hasOverride(overrides, flagFn.key),
-              );
-
-              // Call bulkDecide only for flags that are neither cached nor
-              // overridden. If it throws, every undecided flag still goes
-              // through `applyResult` — its producer just rethrows, so the
-              // catch arm handles the per-flag defaultValue fallback (or
-              // rejects for flags without a defaultValue).
-              let bulkResult: Record<string, any> | null = null;
-              let bulkError: unknown = null;
-              if (undecided.length > 0) {
-                try {
-                  bulkResult = await adapter.bulkDecide!({
-                    flags: undecided.map(({ flagFn }) => ({
-                      key: flagFn.key,
-                      defaultValue: flagFn.defaultValue,
-                    })),
-                    entities,
-                    headers: readonlyHeaders,
-                    cookies: readonlyCookies,
-                  });
-                } catch (err) {
-                  bulkError = err;
-                }
-              }
-
-              await Promise.all(
-                list.map(async ({ name, flagFn }) => {
-                  valuesByName[name] = await applyResult({
-                    definition: flagFn,
-                    readonlyHeaders,
-                    entitiesKey,
-                    overrides,
-                    isFrameworkError: isInternalNextError,
-                    produce: () => {
-                      if (bulkError) throw bulkError;
-                      return bulkResult![flagFn.key];
-                    },
-                  });
-                }),
-              );
-
-              // `applyResult` stamps a per-flag `method` onto the active span;
-              // here that span is shared by the whole group, so overwrite it
-              // with `bulk`. `trace` flushes the span-context store last, so
-              // this final write wins over the per-flag ones. The per-flag
-              // breakdown is reported as counts via `attributesSuccess`.
-              setSpanAttribute('method', 'bulk');
-
-              // Returned so the span can derive aggregate counts lazily —
-              // `attributesSuccess` only runs when a tracer is registered, so
-              // nothing here costs anything on the untraced hot path.
-              return { uncached, undecided };
-            },
-            {
-              name: 'batch',
-              isVerboseTrace: false,
-              attributes: { adapterId: String(adapter.adapterId) },
-              attributesSuccess: ({ uncached, undecided }) => {
-                const cachedCount = list.length - uncached.length;
-                const overrideCount = uncached.length - undecided.length;
-                return {
-                  keys: list.map(({ flagFn }) => flagFn.key),
-                  cachedCount,
-                  overrideCount,
-                  decidedCount: undecided.length,
-                };
-              },
-            },
-          )(),
-        );
-      }
-    }
-
-    if (standalone.length > 0) {
-      groupPromises.push(
-        (async () => {
-          const values = await Promise.all(
-            standalone.map(({ flagFn }) => flagFn()),
-          );
-          standalone.forEach(({ name }, i) => {
-            valuesByName[name] = values[i];
-          });
-        })(),
-      );
-    }
-
-    await Promise.all(groupPromises);
-
-    const result: any = Array.isArray(flags) ? new Array(entries.length) : {};
-    for (const [name] of entries) {
-      result[name] = valuesByName[name];
-    }
-    return result;
-  });
+  // Run inside `bulkStore` so standalone flags invoked via `flagFn()` reuse the
+  // pre-read headers/cookies/overrides (see `getRun`) instead of reading
+  // `next/headers` again.
+  return bulkStore.run(storeData, () =>
+    evaluateFlags({
+      flags,
+      readonlyHeaders,
+      readonlyCookies,
+      dedupeCacheKey,
+      overrides,
+      isFrameworkError: isInternalNextError,
+      invokeStandalone: (flagFn) => flagFn(),
+    }),
+  );
 }

--- a/packages/flags/src/shared/README.md
+++ b/packages/flags/src/shared/README.md
@@ -1,0 +1,55 @@
+# `shared/` — the framework-agnostic Flags core
+
+This directory holds the parts of the Flags SDK that don't depend on a specific
+framework. `flags/next` and `flags/sveltekit` are thin adapters over it, and a
+new framework integration should be too.
+
+> Named `shared` (not `core`) to avoid confusion with the separate
+> `@vercel/flags-core` package.
+
+## Modules
+
+| Module | Responsibility |
+|--------|----------------|
+| `seal.ts` | `sealHeaders` / `sealCookies` (read-only adapters, memoized by headers identity) and `transformToHeaders` (Node `IncomingHttpHeaders` → `Headers`). |
+| `overrides.ts` | `readOverrides(cookies, secret?)` — reads & decrypts the `vercel-flag-overrides` cookie (memoized). |
+| `flag-meta.ts` | `resolveAdapter`, `getDecide` (with adapter validation), `getIdentify`, `getOrigin` — derive a flag's behavior from its declaration. |
+| `evaluation.ts` | The per-request pipeline: the headers-keyed `evaluationCache` (+ `getUsedFlags`), `getEntities` (identify + dedupe), and `applyResult` (cache → override → produce → defaultValue/error → reportValue). |
+| `evaluate.ts` | `evaluateFlags(...)` — the bulk path: partition flags by `(adapterId, identify)`, call `adapter.bulkDecide` once per group, run the rest standalone. Owns the `BULKABLE` / `BULK_IDENTIFY_REF` markers. |
+| `precompute.ts` | `serialize` / `deserialize` / `combine` / `generatePermutations` / `readFlagValue` (signed value (de)serialization). |
+| `discovery.ts` | `handleDiscoveryRequest(...)` — authorize → 401-or-data → set `x-flags-sdk-version`, for the well-known endpoint. |
+
+## The contract a framework implements
+
+Everything framework-specific reduces to **"given the invocation, produce the
+request context"** plus output integration. Concretely a framework adapter:
+
+1. **Resolves a request context** — sealed `headers` + `cookies` and a stable
+   `dedupeCacheKey` (object identity used to key the per-request caches; use the
+   request's `Headers` instance, or `IncomingHttpHeaders` for Node). All three
+   feed `getEntities` / `applyResult` / `evaluateFlags`.
+
+2. **Resolves the secret** — its own strategy (env var, framework config, …),
+   passed to `readOverrides` and the precompute helpers.
+
+3. **Wires `flag()`** — call `resolveAdapter` → `getDecide` / `getIdentify` /
+   `getOrigin`, then on invocation: `readOverrides` → `getEntities` →
+   `applyResult({ definition, readonlyHeaders, entitiesKey, overrides, produce,
+   isFrameworkError })`. Stamp `BULKABLE` / `BULK_IDENTIFY_REF` (and `adapter`)
+   on the returned function so it can participate in `evaluateFlags`.
+
+4. **Provides `isFrameworkError`** — errors that must NOT be swallowed by the
+   defaultValue fallback (e.g. Next's `redirect()` / `notFound()` control flow).
+   Defaults to `() => false`.
+
+5. **Invokes standalone flags for `evaluateFlags`** — `invokeStandalone`: Next
+   calls `flagFn()` (reads ambient `next/headers`); SvelteKit calls
+   `flagFn(request)`.
+
+6. **Integrates output** — e.g. SvelteKit reads `getUsedFlags(sealHeaders(req.headers))`
+   in `transformPageChunk` to inject evaluated values into the HTML; the
+   discovery endpoint uses `handleDiscoveryRequest`.
+
+`flags/next` (App Router via `next/headers`, Pages Router via the request, bulk
+via an `AsyncLocalStorage`) and `flags/sveltekit` (its `handle` ALS or an
+explicit `Request`) are the two reference implementations.

--- a/packages/flags/src/shared/evaluate.ts
+++ b/packages/flags/src/shared/evaluate.ts
@@ -1,0 +1,238 @@
+import type { IncomingHttpHeaders } from 'node:http';
+import { setSpanAttribute, trace } from '../lib/tracing';
+import type { ReadonlyHeaders } from '../spec-extension/adapters/headers';
+import type { ReadonlyRequestCookies } from '../spec-extension/adapters/request-cookies';
+import type { Adapter } from '../types';
+import {
+  applyResult,
+  getCachedValuePromise,
+  getEntities,
+  hasOverride,
+} from './evaluation';
+
+// Internal markers stamped on the flag api by each framework's `flag()`. Read
+// by `evaluateFlags` to partition flags into adapter groups.
+//
+// - BULK_IDENTIFY_REF: the raw identify source for reference-equality
+//   comparison across flags. The wrapped `api.identify` is created per
+//   `flag()` call, so it can't be used for grouping.
+// - BULKABLE: whether the flag can participate in adapter-level bulk
+//   evaluation. An inline `definition.decide` disqualifies the flag
+//   because `getDecide` prefers it over the adapter's decide.
+export const BULK_IDENTIFY_REF = Symbol('flags.bulkIdentifyRef');
+export const BULKABLE = Symbol('flags.bulkable');
+
+/** The minimal flag-function shape `evaluateFlags` reads. */
+export type EvaluableFlag = {
+  (...args: any[]): Promise<any>;
+  key: string;
+  defaultValue?: any;
+  adapter?: Adapter<any, any>;
+};
+
+/**
+ * Framework-agnostic core of `evaluate()`. Given pre-read request context,
+ * partitions flags by `(adapterId, identify)` so adapters that implement
+ * `bulkDecide` resolve an entire group in a single call, and runs the rest
+ * through the per-flag path. Returns positional results for an array input and
+ * keyed results for an object input.
+ *
+ * Context acquisition (e.g. `next/headers` vs a `Request`) and how standalone
+ * flags are invoked are supplied by the caller:
+ * - `invokeStandalone` runs a flag that isn't bulk-eligible (Next calls
+ *   `flagFn()`; SvelteKit calls `flagFn(request)`).
+ * - `isFrameworkError` opts framework control-flow errors out of the
+ *   per-flag defaultValue fallback.
+ */
+export async function evaluateFlags({
+  flags,
+  readonlyHeaders,
+  readonlyCookies,
+  dedupeCacheKey,
+  overrides,
+  invokeStandalone,
+  isFrameworkError,
+}: {
+  flags: Record<string, EvaluableFlag> | readonly EvaluableFlag[];
+  readonlyHeaders: ReadonlyHeaders;
+  readonlyCookies: ReadonlyRequestCookies;
+  dedupeCacheKey: Headers | IncomingHttpHeaders;
+  overrides: Record<string, any> | null;
+  invokeStandalone: (flagFn: EvaluableFlag) => Promise<any>;
+  isFrameworkError?: (error: unknown) => boolean;
+}): Promise<any> {
+  const entries = Object.entries(flags);
+
+  const standalone: { name: string; flagFn: EvaluableFlag }[] = [];
+  // adapterId -> identifyRef -> { adapter, entries }
+  const groups = new Map<
+    string | symbol,
+    Map<
+      unknown,
+      {
+        adapter: Adapter<any, any>;
+        entries: { name: string; flagFn: EvaluableFlag }[];
+      }
+    >
+  >();
+
+  for (const [name, flagFn] of entries) {
+    const entry = { name, flagFn };
+    if (!(flagFn as any)[BULKABLE]) {
+      standalone.push(entry);
+      continue;
+    }
+    const adapter = flagFn.adapter as Adapter<any, any>;
+    const groupId = adapter.adapterId as string | symbol;
+    const identifyRef = (flagFn as any)[BULK_IDENTIFY_REF] ?? null;
+    let byIdentify = groups.get(groupId);
+    if (!byIdentify) {
+      byIdentify = new Map();
+      groups.set(groupId, byIdentify);
+    }
+    let bucket = byIdentify.get(identifyRef);
+    if (!bucket) {
+      // Capture the first adapter for this group — any adapter with the
+      // same adapterId must wrap the same underlying resource.
+      bucket = { adapter, entries: [] };
+      byIdentify.set(identifyRef, bucket);
+    }
+    bucket.entries.push(entry);
+  }
+
+  const valuesByName: Record<string, any> = {};
+  const groupPromises: Promise<unknown>[] = [];
+
+  for (const byIdentify of groups.values()) {
+    for (const [identifyRef, { adapter, entries: list }] of byIdentify) {
+      groupPromises.push(
+        // One `batch` span per bulk-evaluated group (a batch being a single
+        // group within the overall `evaluate()` bulk), replacing the
+        // per-flag `run` span that bulkable flags would otherwise get via
+        // `flagFn()`. A per-flag span here would reintroduce the per-flag
+        // instrumentation overhead (closure + span + microtask) that bulk
+        // evaluation exists to avoid, so the batch reports an aggregate
+        // `method`/count summary instead. Standalone flags still emit their
+        // own `flag` span.
+        trace(
+          async () => {
+            // Resolve entities once for the entire group. The dedupe key is
+            // the same one the per-flag path uses, so any flag called
+            // individually before/after `evaluate()` reuses the cached
+            // identify args.
+            const entities = identifyRef
+              ? await getEntities(
+                  identifyRef as any,
+                  dedupeCacheKey,
+                  readonlyHeaders,
+                  readonlyCookies,
+                )
+              : undefined;
+            const entitiesKey = JSON.stringify(entities) ?? '';
+
+            // Skip flags already resolved this request — `applyResult` would
+            // discard the bulk result for them anyway.
+            const uncached = list.filter(
+              ({ flagFn }) =>
+                getCachedValuePromise(
+                  readonlyHeaders,
+                  flagFn.key,
+                  entitiesKey,
+                ) === undefined,
+            );
+            const undecided = uncached.filter(
+              ({ flagFn }) => !hasOverride(overrides, flagFn.key),
+            );
+
+            // Call bulkDecide only for flags that are neither cached nor
+            // overridden. If it throws, every undecided flag still goes
+            // through `applyResult` — its producer just rethrows, so the
+            // catch arm handles the per-flag defaultValue fallback (or
+            // rejects for flags without a defaultValue).
+            let bulkResult: Record<string, any> | null = null;
+            let bulkError: unknown = null;
+            if (undecided.length > 0) {
+              try {
+                bulkResult = await adapter.bulkDecide!({
+                  flags: undecided.map(({ flagFn }) => ({
+                    key: flagFn.key,
+                    defaultValue: flagFn.defaultValue,
+                  })),
+                  entities,
+                  headers: readonlyHeaders,
+                  cookies: readonlyCookies,
+                });
+              } catch (err) {
+                bulkError = err;
+              }
+            }
+
+            await Promise.all(
+              list.map(async ({ name, flagFn }) => {
+                valuesByName[name] = await applyResult({
+                  definition: flagFn,
+                  readonlyHeaders,
+                  entitiesKey,
+                  overrides,
+                  isFrameworkError,
+                  produce: () => {
+                    if (bulkError) throw bulkError;
+                    return bulkResult![flagFn.key];
+                  },
+                });
+              }),
+            );
+
+            // `applyResult` stamps a per-flag `method` onto the active span;
+            // here that span is shared by the whole group, so overwrite it
+            // with `bulk`. `trace` flushes the span-context store last, so
+            // this final write wins over the per-flag ones. The per-flag
+            // breakdown is reported as counts via `attributesSuccess`.
+            setSpanAttribute('method', 'bulk');
+
+            // Returned so the span can derive aggregate counts lazily —
+            // `attributesSuccess` only runs when a tracer is registered, so
+            // nothing here costs anything on the untraced hot path.
+            return { uncached, undecided };
+          },
+          {
+            name: 'batch',
+            isVerboseTrace: false,
+            attributes: { adapterId: String(adapter.adapterId) },
+            attributesSuccess: ({ uncached, undecided }) => {
+              const cachedCount = list.length - uncached.length;
+              const overrideCount = uncached.length - undecided.length;
+              return {
+                keys: list.map(({ flagFn }) => flagFn.key),
+                cachedCount,
+                overrideCount,
+                decidedCount: undecided.length,
+              };
+            },
+          },
+        )(),
+      );
+    }
+  }
+
+  if (standalone.length > 0) {
+    groupPromises.push(
+      (async () => {
+        const values = await Promise.all(
+          standalone.map(({ flagFn }) => invokeStandalone(flagFn)),
+        );
+        standalone.forEach(({ name }, i) => {
+          valuesByName[name] = values[i];
+        });
+      })(),
+    );
+  }
+
+  await Promise.all(groupPromises);
+
+  const result: any = Array.isArray(flags) ? new Array(entries.length) : {};
+  for (const [name] of entries) {
+    result[name] = valuesByName[name];
+  }
+  return result;
+}

--- a/packages/flags/src/sveltekit/evaluate.ts
+++ b/packages/flags/src/sveltekit/evaluate.ts
@@ -1,0 +1,56 @@
+import { evaluateFlags } from '../shared/evaluate';
+import { readOverrides } from '../shared/overrides';
+import { sealCookies, sealHeaders } from '../shared/seal';
+import { tryGetSecret } from './env';
+import type { Flag } from './types';
+
+// Distributive value extraction so positional results infer per-element.
+type BulkValue<F> = F extends Flag<infer V> ? V : never;
+
+/**
+ * Resolves a set of flags in a single call.
+ *
+ * Pre-reads headers, cookies, and the override cookie once for the whole batch,
+ * then partitions flags by `(adapterId, identify)` so adapters that implement
+ * `bulkDecide` evaluate an entire group in a single call. Flags whose adapters
+ * don't opt into bulk evaluation, and flags with an inline `decide`, fall back
+ * to the per-flag path — they still share the pre-read headers, cookies, and
+ * overrides.
+ *
+ * Accepts either an array of flags (positional results) or an object whose
+ * values are flags (keyed results).
+ */
+export async function evaluate<const T extends readonly Flag<any>[]>(
+  flags: T,
+  request: Request,
+  secret?: string,
+): Promise<{ [K in keyof T]: BulkValue<T[K]> }>;
+export async function evaluate<T extends Record<string, Flag<any>>>(
+  flags: T,
+  request: Request,
+  secret?: string,
+): Promise<{ [K in keyof T]: BulkValue<T[K]> }>;
+export async function evaluate(
+  flags: Record<string, Flag<any>> | readonly Flag<any>[],
+  request: Request,
+  secret?: string,
+): Promise<any> {
+  const resolvedSecret = await tryGetSecret(secret);
+
+  const headers = sealHeaders(request.headers);
+  const cookies = sealCookies(request.headers);
+  const overrides = await readOverrides(cookies, resolvedSecret);
+
+  return evaluateFlags({
+    // SvelteKit `Flag` functions carry `key`/`defaultValue`/`adapter` and the
+    // bulk markers at runtime; the cast bridges the public type to the
+    // internal `EvaluableFlag` shape.
+    flags: flags as any,
+    readonlyHeaders: headers,
+    readonlyCookies: cookies,
+    dedupeCacheKey: request.headers,
+    overrides,
+    invokeStandalone: (flagFn) =>
+      (flagFn as (request: Request) => Promise<any>)(request),
+  });
+}

--- a/packages/flags/src/sveltekit/index.test.ts
+++ b/packages/flags/src/sveltekit/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { encryptOverrides, flag, getProviderData } from '.';
+import type { Adapter } from '..';
+import { encryptOverrides, evaluate, flag, getProviderData } from '.';
 
 // A valid 32-byte (256-bit) base64url key, required by the crypto helpers.
 const { secret } = vi.hoisted(() => ({
@@ -157,5 +158,59 @@ describe('flag', () => {
     });
     await expect(f(request)).resolves.toBe(true);
     expect(decide).not.toHaveBeenCalled();
+  });
+});
+
+describe('evaluate', () => {
+  function createBulkAdapter() {
+    const bulkDecide = vi.fn(({ flags }: { flags: { key: string }[] }) =>
+      Object.fromEntries(flags.map(({ key }) => [key, `bulk:${key}`])),
+    );
+    const adapter: Adapter<string, unknown> = {
+      adapterId: 'test-adapter',
+      // inline decide is never used for bulkable flags, but the type requires it
+      decide: () => 'single',
+      bulkDecide,
+    };
+    return { adapter, bulkDecide };
+  }
+
+  it('bulk-evaluates flags sharing an adapter in a single call', async () => {
+    const { adapter, bulkDecide } = createBulkAdapter();
+    const a = flag<string>({ key: 'bulk-a', adapter });
+    const b = flag<string>({ key: 'bulk-b', adapter });
+    const standalone = flag<string>({
+      key: 'standalone',
+      decide: () => 'inline',
+    });
+
+    const values = await evaluate(
+      [a, b, standalone],
+      new Request('https://example.com'),
+    );
+
+    expect(values).toEqual(['bulk:bulk-a', 'bulk:bulk-b', 'inline']);
+    // The two bulkable flags resolve through a single bulkDecide call.
+    expect(bulkDecide).toHaveBeenCalledTimes(1);
+    expect(bulkDecide.mock.calls[0]![0].flags.map((f) => f.key)).toEqual([
+      'bulk-a',
+      'bulk-b',
+    ]);
+  });
+
+  it('returns keyed results for an object input', async () => {
+    const { adapter } = createBulkAdapter();
+    const a = flag<string>({ key: 'bulk-a', adapter });
+    const standalone = flag<string>({
+      key: 'standalone',
+      decide: () => 'inline',
+    });
+
+    const values = await evaluate(
+      { a, standalone },
+      new Request('https://example.com'),
+    );
+
+    expect(values).toEqual({ a: 'bulk:bulk-a', standalone: 'inline' });
   });
 });

--- a/packages/flags/src/sveltekit/index.ts
+++ b/packages/flags/src/sveltekit/index.ts
@@ -22,6 +22,7 @@ import {
 } from '..';
 import { normalizeOptions } from '../lib/normalize-options';
 import { handleDiscoveryRequest } from '../shared/discovery';
+import { BULK_IDENTIFY_REF, BULKABLE } from '../shared/evaluate';
 import { applyResult, getEntities, getUsedFlags } from '../shared/evaluation';
 import {
   getDecide,
@@ -44,6 +45,8 @@ import {
   getPrecomputed,
 } from './precompute';
 import type { Flag, FlagsArray } from './types';
+
+export { evaluate } from './evaluate';
 
 type PromisesMap<T> = {
   [K in keyof T]: Promise<T[K]>;
@@ -156,6 +159,17 @@ export function flag<
   flagImpl.options = normalizeOptions(definition.options);
   flagImpl.decide = decide;
   flagImpl.identify = identify;
+  flagImpl.adapter = adapter;
+  flagImpl.config = definition.config;
+
+  // Internal markers read by `evaluate()` to partition flags into adapter
+  // groups. See `../shared/evaluate.ts` for the symbol definitions.
+  (flagImpl as any)[BULK_IDENTIFY_REF] =
+    definition.identify ?? adapter?.identify ?? null;
+  (flagImpl as any)[BULKABLE] =
+    !definition.decide &&
+    !!adapter?.bulkDecide &&
+    adapter.adapterId !== undefined;
 
   return flagImpl;
 }

--- a/packages/flags/src/sveltekit/precompute.ts
+++ b/packages/flags/src/sveltekit/precompute.ts
@@ -1,22 +1,9 @@
 import type { JsonValue } from '..';
 import * as shared from '../shared/precompute';
+import { evaluate } from './evaluate';
 import type { Flag, FlagsArray } from './types';
 
 type ValuesArray = readonly any[];
-
-/**
- * Resolves a list of flags
- * @param flags - list of flags
- * @returns - an array of evaluated flag values with one entry per flag
- */
-async function evaluate<T extends FlagsArray>(
-  flags: T,
-  request: Request,
-): Promise<{ [K in keyof T]: Awaited<ReturnType<T[K]>> }> {
-  return Promise.all(flags.map((flag) => flag(request))) as Promise<{
-    [K in keyof T]: Awaited<ReturnType<T[K]>>;
-  }>;
-}
 
 /**
  * Evaluate a list of feature flags and generate a signed string representing their values.
@@ -31,7 +18,7 @@ export async function precompute<T extends FlagsArray>(
   request: Request,
   secret: string,
 ): Promise<string> {
-  const values = await evaluate(flags, request);
+  const values = await evaluate(flags, request, secret);
   return serialize(flags, values, secret);
 }
 


### PR DESCRIPTION
**Stacked PR 3 of 3** · base: `shared/evaluation` (#413)

Extracts the bulk-evaluation orchestration into `shared/evaluate.ts` (`evaluateFlags` + the `BULKABLE` / `BULK_IDENTIFY_REF` markers), parameterized by how standalone flags are invoked and which errors are framework control flow. Next wraps it in its `bulkStore` ALS and invokes standalone flags via `flagFn()`; **behavior and public `.d.ts` are unchanged.**

SvelteKit gains a real bulk **`evaluate(flags, request, secret?)`** (`src/sveltekit/evaluate.ts`), exported from `flags/sveltekit` and used by its `precompute`. SvelteKit's `flag()` now stamps `adapter`, `config`, and the bulk markers so adapters implementing `bulkDecide` resolve a whole group in one call. Adds 2 bulk-evaluate tests.

Documents the framework contract (context resolution, secret strategy, `isFrameworkError`, `invokeStandalone`, output integration) in `shared/README.md` so adding a new framework only means writing a thin adapter.

### Verification
123/123 tests pass · type-check · biome · `attw` green · `next.d.ts` byte-identical · `@flags-sdk/vercel` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)