### PR TITLE
[vercel-flags-core] fix datafile serialization

### DIFF
--- a/.changeset/many-berries-sell.md
+++ b/.changeset/many-berries-sell.md
@@ -1,0 +1,14 @@
+---
+'@vercel/flags-core': patch
+---
+
+Fix datafile serialization across the RSC server/client boundary.
+
+Evaluation memoized scaled split weights and compiled regexes by attaching
+symbol-keyed properties directly onto objects inside the datafile. While
+symbols are invisible to `JSON.stringify`, React Server Components serialization
+walks objects directly and chokes on these (notably the non-serializable
+`RegExp`), so datafiles could no longer be passed from server to client
+components. Memoization now uses module-level `WeakMap`s keyed by the
+outcome/rhs objects, leaving datafile objects pristine while keeping identical
+caching semantics and lifetime.

--- a/packages/vercel-flags-core/src/evaluate.ts
+++ b/packages/vercel-flags-core/src/evaluate.ts
@@ -15,28 +15,27 @@ const MAX_REGEX_INPUT_LENGTH = 10_000;
 /** uint32 max — domain of xxHash32 output, used for split/rollout thresholds */
 const UINT32_MAX = 4_294_967_295;
 
-// Symbol-keyed caches attached to outcome / rhs objects on first evaluation.
-// Symbols are invisible to JSON.stringify, for..in, and Object.keys, so they
-// don't leak into serialized datafiles or surprise consumers.
-const SCALED_WEIGHTS = Symbol('@vercel/flags-core:scaledWeights');
-const COMPILED_REGEX = Symbol('@vercel/flags-core:compiledRegex');
+// Per-object memoization caches keyed by the outcome / rhs objects from the
+// datafile. Using WeakMaps (instead of mutating the objects with symbol-keyed
+// props) keeps datafile objects pristine so they serialize cleanly across the
+// RSC server/client boundary. Entries are GC'd when the datafile is dropped.
+const scaledWeightsCache = new WeakMap<Packed.SplitOutcome, number[]>();
+const compiledRegexCache = new WeakMap<object, RegExp>();
 
 function getScaledWeights(outcome: Packed.SplitOutcome): number[] {
-  const cached = (outcome as unknown as Record<symbol, number[]>)[
-    SCALED_WEIGHTS
-  ];
+  const cached = scaledWeightsCache.get(outcome);
   if (cached) return cached;
   const total = sum(outcome.weights);
   const scaled = outcome.weights.map((w) => (w / total) * UINT32_MAX);
-  (outcome as unknown as Record<symbol, number[]>)[SCALED_WEIGHTS] = scaled;
+  scaledWeightsCache.set(outcome, scaled);
   return scaled;
 }
 
 function getCompiledRegex(rhs: { pattern: string; flags: string }): RegExp {
-  const cached = (rhs as unknown as Record<symbol, RegExp>)[COMPILED_REGEX];
+  const cached = compiledRegexCache.get(rhs);
   if (cached) return cached;
   const compiled = new RegExp(rhs.pattern, rhs.flags);
-  (rhs as unknown as Record<symbol, RegExp>)[COMPILED_REGEX] = compiled;
+  compiledRegexCache.set(rhs, compiled);
   return compiled;
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to caching in evaluate.ts with the same memoization semantics and no API surface changes.
> 
> **Overview**
> **Fixes datafiles failing to cross the React Server Components boundary** when passed from server to client components.
> 
> Evaluation used to cache scaled split weights and compiled regexes by attaching **symbol-keyed properties** on objects inside the datafile. That stayed hidden from `JSON.stringify`, but RSC’s serializer walks objects directly and breaks on non-serializable values (especially **`RegExp`**).
> 
> Memoization now lives in **module-level `WeakMap`s** keyed by the same outcome / regex rhs objects, so datafile payloads stay unmodified while cache lifetime and behavior stay equivalent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94629d95f4cbf82b5747384cf7d3ae69b9ab48e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->