### PR TITLE
[adapter-launchdarkly] support native Marketplace integration

### DIFF
--- a/.changeset/launchdarkly-experimentation-config.md
+++ b/.changeset/launchdarkly-experimentation-config.md
@@ -19,5 +19,3 @@ Support the native LaunchDarkly Marketplace integration.
     edgeConfigConnectionString: process.env.EDGE_CONFIG,
   });
   ```
-
-- `LAUNCHDARKLY_PROJECT_SLUG` / `projectSlug` is now optional. It is only used to deep-link flags to the LaunchDarkly dashboard. When it is not set, flag evaluation is unaffected, but `variation().origin` is now `undefined` instead of always being a function.

--- a/.changeset/launchdarkly-experimentation-config.md
+++ b/.changeset/launchdarkly-experimentation-config.md
@@ -8,24 +8,16 @@ Support the native LaunchDarkly Marketplace integration.
 
 - The default adapter (`ldAdapter`) now reads the Edge Config connection string from the `EXPERIMENTATION_CONFIG` environment variable instead of `EDGE_CONFIG`. This aligns with the native LaunchDarkly Marketplace integration and matches the behavior of other adapters (e.g. Statsig). `EDGE_CONFIG` is no longer read by the default adapter. The error thrown when `EXPERIMENTATION_CONFIG` is not set changed to `LaunchDarkly Adapter: Missing EXPERIMENTATION_CONFIG environment variable`.
 
-  **If you use the legacy LaunchDarkly Vercel integration** (which provides the connection string as `EDGE_CONFIG`), do one of the following:
+  **If you use the legacy LaunchDarkly Vercel integration** (which provides the connection string as `EDGE_CONFIG`), pass the connection string explicitly with `createLaunchDarklyAdapter`:
 
-  1. Set `EXPERIMENTATION_CONFIG` to the same value as `EDGE_CONFIG`, for example in your project's environment variables:
+  ```ts
+  import { createLaunchDarklyAdapter } from '@flags-sdk/launchdarkly';
 
-     ```sh
-     EXPERIMENTATION_CONFIG=$EDGE_CONFIG
-     ```
-
-  2. Or pass the connection string explicitly with `createLaunchDarklyAdapter`:
-
-     ```ts
-     import { createLaunchDarklyAdapter } from '@flags-sdk/launchdarkly';
-
-     const ldAdapter = createLaunchDarklyAdapter({
-       projectSlug: process.env.LAUNCHDARKLY_PROJECT_SLUG,
-       clientSideId: process.env.LAUNCHDARKLY_CLIENT_SIDE_ID,
-       edgeConfigConnectionString: process.env.EDGE_CONFIG,
-     });
-     ```
+  const ldAdapter = createLaunchDarklyAdapter({
+    projectSlug: process.env.LAUNCHDARKLY_PROJECT_SLUG,
+    clientSideId: process.env.LAUNCHDARKLY_CLIENT_SIDE_ID,
+    edgeConfigConnectionString: process.env.EDGE_CONFIG,
+  });
+  ```
 
 - `LAUNCHDARKLY_PROJECT_SLUG` / `projectSlug` is now optional. It is only used to deep-link flags to the LaunchDarkly dashboard. When it is not set, flag evaluation is unaffected, but `variation().origin` is now `undefined` instead of always being a function.

--- a/.changeset/launchdarkly-experimentation-config.md
+++ b/.changeset/launchdarkly-experimentation-config.md
@@ -6,5 +6,26 @@ Support the native LaunchDarkly Marketplace integration.
 
 **Breaking changes:**
 
-- The adapter now reads the Edge Config connection string from `EXPERIMENTATION_CONFIG` first, falling back to `EDGE_CONFIG` for the legacy Vercel integration. If both are set to different values, `EXPERIMENTATION_CONFIG` now takes precedence. The error thrown when neither is set changed to `LaunchDarkly Adapter: Missing EXPERIMENTATION_CONFIG or EDGE_CONFIG environment variable`.
+- The default adapter (`ldAdapter`) now reads the Edge Config connection string from the `EXPERIMENTATION_CONFIG` environment variable instead of `EDGE_CONFIG`. This aligns with the native LaunchDarkly Marketplace integration and matches the behavior of other adapters (e.g. Statsig). `EDGE_CONFIG` is no longer read by the default adapter. The error thrown when `EXPERIMENTATION_CONFIG` is not set changed to `LaunchDarkly Adapter: Missing EXPERIMENTATION_CONFIG environment variable`.
+
+  **If you use the legacy LaunchDarkly Vercel integration** (which provides the connection string as `EDGE_CONFIG`), do one of the following:
+
+  1. Set `EXPERIMENTATION_CONFIG` to the same value as `EDGE_CONFIG`, for example in your project's environment variables:
+
+     ```sh
+     EXPERIMENTATION_CONFIG=$EDGE_CONFIG
+     ```
+
+  2. Or pass the connection string explicitly with `createLaunchDarklyAdapter`:
+
+     ```ts
+     import { createLaunchDarklyAdapter } from '@flags-sdk/launchdarkly';
+
+     const ldAdapter = createLaunchDarklyAdapter({
+       projectSlug: process.env.LAUNCHDARKLY_PROJECT_SLUG,
+       clientSideId: process.env.LAUNCHDARKLY_CLIENT_SIDE_ID,
+       edgeConfigConnectionString: process.env.EDGE_CONFIG,
+     });
+     ```
+
 - `LAUNCHDARKLY_PROJECT_SLUG` / `projectSlug` is now optional. It is only used to deep-link flags to the LaunchDarkly dashboard. When it is not set, flag evaluation is unaffected, but `variation().origin` is now `undefined` instead of always being a function.

--- a/.changeset/launchdarkly-experimentation-config.md
+++ b/.changeset/launchdarkly-experimentation-config.md
@@ -1,5 +1,5 @@
 ---
-'@flags-sdk/launchdarkly': minor
+'@flags-sdk/launchdarkly': major
 ---
 
 Support the native LaunchDarkly Marketplace integration.

--- a/.changeset/launchdarkly-experimentation-config.md
+++ b/.changeset/launchdarkly-experimentation-config.md
@@ -1,0 +1,10 @@
+---
+'@flags-sdk/launchdarkly': minor
+---
+
+Support the native LaunchDarkly Marketplace integration.
+
+**Breaking changes:**
+
+- The adapter now reads the Edge Config connection string from `EXPERIMENTATION_CONFIG` first, falling back to `EDGE_CONFIG` for the legacy Vercel integration. If both are set to different values, `EXPERIMENTATION_CONFIG` now takes precedence. The error thrown when neither is set changed to `LaunchDarkly Adapter: Missing EXPERIMENTATION_CONFIG or EDGE_CONFIG environment variable`.
+- `LAUNCHDARKLY_PROJECT_SLUG` / `projectSlug` is now optional. It is only used to deep-link flags to the LaunchDarkly dashboard. When it is not set, flag evaluation is unaffected, but `variation().origin` is now `undefined` instead of always being a function.

--- a/apps/docs/content/docs/providers/launchdarkly.mdx
+++ b/apps/docs/content/docs/providers/launchdarkly.mdx
@@ -58,17 +58,15 @@ const customLdAdapter = createLaunchDarklyAdapter({
 
 | Option key                   | Type     | Description                                                        |
 | ---------------------------- | ---------| ------------------------------------------------------------------ |
-| `projectSlug`                | `string` | LaunchDarkly project slug. Optional, only used for dashboard links |
+| `projectSlug`                | `string` | LaunchDarkly project slug                                          |
 | `clientSideId`               | `string` | LaunchDarkly client-side ID                                        |
 | `edgeConfigConnectionString` | `string` | Edge Config connection string                                      |
 
 The default LaunchDarkly adapter configures itself based on the following environment variables:
 
 - `LAUNCHDARKLY_CLIENT_SIDE_ID` _(required)_ → `clientSideId`
-- `LAUNCHDARKLY_PROJECT_SLUG` _(optional)_ → `projectSlug`
+- `LAUNCHDARKLY_PROJECT_SLUG` _(required)_ → `projectSlug`
 - `EXPERIMENTATION_CONFIG` _(required)_ → `edgeConfigConnectionString`
-
-`LAUNCHDARKLY_PROJECT_SLUG` is only used to deep-link flags to the LaunchDarkly dashboard. When it is not set, flag evaluation is unaffected but the adapter does not expose an `origin`.
 
 The native LaunchDarkly [Marketplace integration](https://vercel.com/marketplace/launchdarkly) exposes the Edge Config connection string as `EXPERIMENTATION_CONFIG` when Edge Config is enabled for the collection.
 

--- a/apps/docs/content/docs/providers/launchdarkly.mdx
+++ b/apps/docs/content/docs/providers/launchdarkly.mdx
@@ -49,21 +49,26 @@ import { createLaunchDarklyAdapter } from '@flags-sdk/launchdarkly';
 const customLdAdapter = createLaunchDarklyAdapter({
   projectSlug: process.env.LAUNCHDARKLY_PROJECT_SLUG,
   clientSideId: process.env.LAUNCHDARKLY_CLIENT_SIDE_ID,
-  edgeConfigConnectionString: process.env.EDGE_CONFIG,
+  edgeConfigConnectionString:
+    process.env.EXPERIMENTATION_CONFIG ?? process.env.EDGE_CONFIG,
 });
 ```
 
-| Option key                   | Type     | Description                   |
-| ---------------------------- | ---------| ----------------------------- |
-| `projectSlug`                | `string` | LaunchDarkly project slug     |
-| `clientSideId`               | `string` | LaunchDarkly client-side ID   |
-| `edgeConfigConnectionString` | `string` | Edge Config connection string |
+| Option key                   | Type     | Description                                                        |
+| ---------------------------- | ---------| ------------------------------------------------------------------ |
+| `projectSlug`                | `string` | LaunchDarkly project slug. Optional, only used for dashboard links |
+| `clientSideId`               | `string` | LaunchDarkly client-side ID                                        |
+| `edgeConfigConnectionString` | `string` | Edge Config connection string                                      |
 
 The default LaunchDarkly adapter configures itself based on the following environment variables:
 
 - `LAUNCHDARKLY_CLIENT_SIDE_ID` _(required)_ → `clientSideId`
-- `LAUNCHDARKLY_PROJECT_SLUG` _(required)_ → `projectSlug`
-- `EDGE_CONFIG` _(required)_ → `edgeConfigConnectionString`
+- `LAUNCHDARKLY_PROJECT_SLUG` _(optional)_ → `projectSlug`
+- `EXPERIMENTATION_CONFIG` _(required)_ → `edgeConfigConnectionString`
+
+`LAUNCHDARKLY_PROJECT_SLUG` is only used to deep-link flags to the LaunchDarkly dashboard. When it is not set, flag evaluation is unaffected but the adapter does not expose an `origin`.
+
+The native LaunchDarkly [Marketplace integration](https://vercel.com/marketplace/launchdarkly) exposes the Edge Config connection string as `EXPERIMENTATION_CONFIG` when Edge Config is enabled for the collection. The adapter falls back to `EDGE_CONFIG` (used by the legacy Vercel integration) when `EXPERIMENTATION_CONFIG` is not set.
 
 
 ---
@@ -143,7 +148,7 @@ The LaunchDarkly adapter loads the configuration from [Edge Config](https://verc
 
 Edge Config is a global, ultra-low latency store which uses active replication and is specifically designed for serving feature flag configuration.
 
-The default LaunchDarkly adapter, exported as `ldAdapter`, will automatically connect to Edge Config when the required environment variables are set.
+The default LaunchDarkly adapter, exported as `ldAdapter`, will automatically connect to Edge Config when the required environment variables are set. It reads the connection string from `EXPERIMENTATION_CONFIG` (native Marketplace integration) and falls back to `EDGE_CONFIG` (legacy Vercel integration).
 
 ---
 

--- a/apps/docs/content/docs/providers/launchdarkly.mdx
+++ b/apps/docs/content/docs/providers/launchdarkly.mdx
@@ -49,6 +49,8 @@ import { createLaunchDarklyAdapter } from '@flags-sdk/launchdarkly';
 const customLdAdapter = createLaunchDarklyAdapter({
   projectSlug: process.env.LAUNCHDARKLY_PROJECT_SLUG,
   clientSideId: process.env.LAUNCHDARKLY_CLIENT_SIDE_ID,
+  // Legacy integrations that provide the connection string as `EDGE_CONFIG`
+  // can pass it explicitly here.
   edgeConfigConnectionString:
     process.env.EXPERIMENTATION_CONFIG ?? process.env.EDGE_CONFIG,
 });
@@ -68,7 +70,9 @@ The default LaunchDarkly adapter configures itself based on the following enviro
 
 `LAUNCHDARKLY_PROJECT_SLUG` is only used to deep-link flags to the LaunchDarkly dashboard. When it is not set, flag evaluation is unaffected but the adapter does not expose an `origin`.
 
-The native LaunchDarkly [Marketplace integration](https://vercel.com/marketplace/launchdarkly) exposes the Edge Config connection string as `EXPERIMENTATION_CONFIG` when Edge Config is enabled for the collection. The adapter falls back to `EDGE_CONFIG` (used by the legacy Vercel integration) when `EXPERIMENTATION_CONFIG` is not set.
+The native LaunchDarkly [Marketplace integration](https://vercel.com/marketplace/launchdarkly) exposes the Edge Config connection string as `EXPERIMENTATION_CONFIG` when Edge Config is enabled for the collection.
+
+If you use the legacy LaunchDarkly Vercel integration, which provides the connection string as `EDGE_CONFIG`, set `EXPERIMENTATION_CONFIG` to the same value, or use `createLaunchDarklyAdapter` to pass `edgeConfigConnectionString` explicitly.
 
 
 ---
@@ -148,7 +152,7 @@ The LaunchDarkly adapter loads the configuration from [Edge Config](https://verc
 
 Edge Config is a global, ultra-low latency store which uses active replication and is specifically designed for serving feature flag configuration.
 
-The default LaunchDarkly adapter, exported as `ldAdapter`, will automatically connect to Edge Config when the required environment variables are set. It reads the connection string from `EXPERIMENTATION_CONFIG` (native Marketplace integration) and falls back to `EDGE_CONFIG` (legacy Vercel integration).
+The default LaunchDarkly adapter, exported as `ldAdapter`, will automatically connect to Edge Config when the required environment variables are set. It reads the connection string from `EXPERIMENTATION_CONFIG` (provided by the native Marketplace integration).
 
 ---
 

--- a/packages/adapter-launchdarkly/README.md
+++ b/packages/adapter-launchdarkly/README.md
@@ -24,8 +24,13 @@ The default adapter uses the following environment variables to configure itself
 
 ```sh
 export LAUNCHDARKLY_CLIENT_SIDE_ID="612376f91b8f5713a58777a1"
+# Optional. Only used to deep-link flags to the LaunchDarkly dashboard.
 export LAUNCHDARKLY_PROJECT_SLUG="my-project"
-# Provided by Vercel when connecting an Edge Config to the project
+# Provided by the LaunchDarkly Marketplace integration when Edge Config is
+# enabled for the collection.
+export EXPERIMENTATION_CONFIG="https://edge-config.vercel.com/ecfg_abdc1234?token=xxx-xxx-xxx"
+# Provided by Vercel when connecting an Edge Config. Used as a fallback when
+# EXPERIMENTATION_CONFIG is not set.
 export EDGE_CONFIG="https://edge-config.vercel.com/ecfg_abdc1234?token=xxx-xxx-xxx"
 ```
 
@@ -57,8 +62,9 @@ import { createLaunchDarklyAdapter } from "@flags-sdk/launchdarkly";
 
 const adapter = createLaunchDarklyAdapter({
   projectSlug: "my-project",
-  ldClientSideKey: "612376f91b8f5713a58777a1",
-  edgeConfigConnectionString: process.env.EDGE_CONFIG,
+  clientSideId: "612376f91b8f5713a58777a1",
+  edgeConfigConnectionString:
+    process.env.EXPERIMENTATION_CONFIG ?? process.env.EDGE_CONFIG,
 });
 ```
 

--- a/packages/adapter-launchdarkly/README.md
+++ b/packages/adapter-launchdarkly/README.md
@@ -29,10 +29,13 @@ export LAUNCHDARKLY_PROJECT_SLUG="my-project"
 # Provided by the LaunchDarkly Marketplace integration when Edge Config is
 # enabled for the collection.
 export EXPERIMENTATION_CONFIG="https://edge-config.vercel.com/ecfg_abdc1234?token=xxx-xxx-xxx"
-# Provided by Vercel when connecting an Edge Config. Used as a fallback when
-# EXPERIMENTATION_CONFIG is not set.
-export EDGE_CONFIG="https://edge-config.vercel.com/ecfg_abdc1234?token=xxx-xxx-xxx"
 ```
+
+> **Using the legacy LaunchDarkly Vercel integration?** The default adapter reads
+> the Edge Config connection string from `EXPERIMENTATION_CONFIG` only. If your
+> project provides the connection string as `EDGE_CONFIG`, set
+> `EXPERIMENTATION_CONFIG` to the same value, or pass it explicitly with
+> [`createLaunchDarklyAdapter`](#custom-adapter).
 
 ## Example
 
@@ -63,6 +66,8 @@ import { createLaunchDarklyAdapter } from "@flags-sdk/launchdarkly";
 const adapter = createLaunchDarklyAdapter({
   projectSlug: "my-project",
   clientSideId: "612376f91b8f5713a58777a1",
+  // Legacy integrations that provide the connection string as `EDGE_CONFIG`
+  // can pass it explicitly here.
   edgeConfigConnectionString:
     process.env.EXPERIMENTATION_CONFIG ?? process.env.EDGE_CONFIG,
 });

--- a/packages/adapter-launchdarkly/README.md
+++ b/packages/adapter-launchdarkly/README.md
@@ -24,7 +24,6 @@ The default adapter uses the following environment variables to configure itself
 
 ```sh
 export LAUNCHDARKLY_CLIENT_SIDE_ID="612376f91b8f5713a58777a1"
-# Optional. Only used to deep-link flags to the LaunchDarkly dashboard.
 export LAUNCHDARKLY_PROJECT_SLUG="my-project"
 # Provided by the LaunchDarkly Marketplace integration when Edge Config is
 # enabled for the collection.

--- a/packages/adapter-launchdarkly/src/index.test.ts
+++ b/packages/adapter-launchdarkly/src/index.test.ts
@@ -1,6 +1,6 @@
 import type { ReadonlyHeaders, ReadonlyRequestCookies } from 'flags';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
-import { createLaunchDarklyAdapter, type LDContext, ldAdapter } from '.';
+import { type LDContext, ldAdapter } from '.';
 
 const ldClientMock = {
   waitForInitialization: vi.fn(),
@@ -66,16 +66,6 @@ describe('ldAdapter', () => {
 
         await expect(valuePromise).resolves.toEqual(true);
         expect(ldClientMock.variation).toHaveBeenCalled();
-      });
-
-      it('should not expose an origin when projectSlug is omitted', () => {
-        const adapter = createLaunchDarklyAdapter({
-          clientSideId: 'test-client-side-id',
-          edgeConfigConnectionString:
-            'https://edge-config.com/test-experimentation-config',
-        });
-
-        expect(adapter.variation().origin).toBeUndefined();
       });
     });
   });

--- a/packages/adapter-launchdarkly/src/index.test.ts
+++ b/packages/adapter-launchdarkly/src/index.test.ts
@@ -24,7 +24,7 @@ describe('ldAdapter', () => {
   describe('with a missing environment', () => {
     it('should throw an error', () => {
       expect(() => ldAdapter.variation()).toThrowError(
-        'LaunchDarkly Adapter: Missing EXPERIMENTATION_CONFIG or EDGE_CONFIG environment variable',
+        'LaunchDarkly Adapter: Missing EXPERIMENTATION_CONFIG environment variable',
       );
     });
   });

--- a/packages/adapter-launchdarkly/src/index.test.ts
+++ b/packages/adapter-launchdarkly/src/index.test.ts
@@ -1,6 +1,6 @@
 import type { ReadonlyHeaders, ReadonlyRequestCookies } from 'flags';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
-import { type LDContext, ldAdapter } from '.';
+import { createLaunchDarklyAdapter, type LDContext, ldAdapter } from '.';
 
 const ldClientMock = {
   waitForInitialization: vi.fn(),
@@ -24,7 +24,7 @@ describe('ldAdapter', () => {
   describe('with a missing environment', () => {
     it('should throw an error', () => {
       expect(() => ldAdapter.variation()).toThrowError(
-        'LaunchDarkly Adapter: Missing EDGE_CONFIG environment variable',
+        'LaunchDarkly Adapter: Missing EXPERIMENTATION_CONFIG or EDGE_CONFIG environment variable',
       );
     });
   });
@@ -33,7 +33,8 @@ describe('ldAdapter', () => {
     beforeAll(() => {
       process.env.LAUNCHDARKLY_PROJECT_SLUG = 'test-project';
       process.env.LAUNCHDARKLY_CLIENT_SIDE_ID = 'test-client-side-id';
-      process.env.EDGE_CONFIG = 'https://edge-config.com/test-edge-config';
+      process.env.EXPERIMENTATION_CONFIG =
+        'https://edge-config.com/test-experimentation-config';
     });
 
     it('should expose the ldClient', () => {
@@ -65,6 +66,16 @@ describe('ldAdapter', () => {
 
         await expect(valuePromise).resolves.toEqual(true);
         expect(ldClientMock.variation).toHaveBeenCalled();
+      });
+
+      it('should not expose an origin when projectSlug is omitted', () => {
+        const adapter = createLaunchDarklyAdapter({
+          clientSideId: 'test-client-side-id',
+          edgeConfigConnectionString:
+            'https://edge-config.com/test-experimentation-config',
+        });
+
+        expect(adapter.variation().origin).toBeUndefined();
       });
     });
   });

--- a/packages/adapter-launchdarkly/src/index.ts
+++ b/packages/adapter-launchdarkly/src/index.ts
@@ -36,24 +36,6 @@ function assertEnv(name: string): string {
   return value;
 }
 
-/**
- * Resolves the Edge Config connection string used to load LaunchDarkly flag data.
- *
- * The native LaunchDarkly Marketplace integration exposes the connection string
- * as `EXPERIMENTATION_CONFIG`, while the legacy Vercel integration exposes it as
- * `EDGE_CONFIG`. We prefer `EXPERIMENTATION_CONFIG` and fall back to `EDGE_CONFIG`
- * for backwards compatibility.
- */
-function assertEdgeConfigConnectionString(): string {
-  const value = process.env.EXPERIMENTATION_CONFIG || process.env.EDGE_CONFIG;
-  if (!value) {
-    throw new Error(
-      'LaunchDarkly Adapter: Missing EXPERIMENTATION_CONFIG or EDGE_CONFIG environment variable',
-    );
-  }
-  return value;
-}
-
 export function createLaunchDarklyAdapter({
   projectSlug,
   clientSideId,
@@ -133,7 +115,7 @@ export function createLaunchDarklyAdapter({
 
 function getOrCreateDeaultAdapter() {
   if (!defaultLaunchDarklyAdapter) {
-    const edgeConfigConnectionString = assertEdgeConfigConnectionString();
+    const edgeConfigConnectionString = assertEnv('EXPERIMENTATION_CONFIG');
     const clientSideId = assertEnv('LAUNCHDARKLY_CLIENT_SIDE_ID');
     // Optional: only used to build the dashboard deep-link (`origin`). The
     // native Marketplace integration may not provide this.

--- a/packages/adapter-launchdarkly/src/index.ts
+++ b/packages/adapter-launchdarkly/src/index.ts
@@ -36,12 +36,35 @@ function assertEnv(name: string): string {
   return value;
 }
 
+/**
+ * Resolves the Edge Config connection string used to load LaunchDarkly flag data.
+ *
+ * The native LaunchDarkly Marketplace integration exposes the connection string
+ * as `EXPERIMENTATION_CONFIG`, while the legacy Vercel integration exposes it as
+ * `EDGE_CONFIG`. We prefer `EXPERIMENTATION_CONFIG` and fall back to `EDGE_CONFIG`
+ * for backwards compatibility.
+ */
+function assertEdgeConfigConnectionString(): string {
+  const value = process.env.EXPERIMENTATION_CONFIG || process.env.EDGE_CONFIG;
+  if (!value) {
+    throw new Error(
+      'LaunchDarkly Adapter: Missing EXPERIMENTATION_CONFIG or EDGE_CONFIG environment variable',
+    );
+  }
+  return value;
+}
+
 export function createLaunchDarklyAdapter({
   projectSlug,
   clientSideId,
   edgeConfigConnectionString,
 }: {
-  projectSlug: string;
+  /**
+   * LaunchDarkly project slug. Only used to construct the `origin` URL that
+   * deep-links a flag to its LaunchDarkly dashboard page. When omitted, the
+   * adapter does not expose an `origin`, but flag evaluation is unaffected.
+   */
+  projectSlug?: string;
   clientSideId: string;
   edgeConfigConnectionString: string;
 }): AdapterResponse {
@@ -80,7 +103,9 @@ export function createLaunchDarklyAdapter({
     options: AdapterOptions<ValueType> = {},
   ): Adapter<ValueType, LDContext> {
     return {
-      origin,
+      // Only expose `origin` when a project slug is available, otherwise the
+      // deep-link would be incorrect.
+      origin: projectSlug ? origin : undefined,
       async decide({ key, entities, headers }): Promise<ValueType> {
         if (!ldClient.initialized()) {
           if (!initPromise) initPromise = ldClient.waitForInitialization();
@@ -108,9 +133,11 @@ export function createLaunchDarklyAdapter({
 
 function getOrCreateDeaultAdapter() {
   if (!defaultLaunchDarklyAdapter) {
-    const edgeConfigConnectionString = assertEnv('EDGE_CONFIG');
+    const edgeConfigConnectionString = assertEdgeConfigConnectionString();
     const clientSideId = assertEnv('LAUNCHDARKLY_CLIENT_SIDE_ID');
-    const projectSlug = assertEnv('LAUNCHDARKLY_PROJECT_SLUG');
+    // Optional: only used to build the dashboard deep-link (`origin`). The
+    // native Marketplace integration may not provide this.
+    const projectSlug = process.env.LAUNCHDARKLY_PROJECT_SLUG;
 
     defaultLaunchDarklyAdapter = createLaunchDarklyAdapter({
       projectSlug,

--- a/packages/adapter-launchdarkly/src/index.ts
+++ b/packages/adapter-launchdarkly/src/index.ts
@@ -41,12 +41,7 @@ export function createLaunchDarklyAdapter({
   clientSideId,
   edgeConfigConnectionString,
 }: {
-  /**
-   * LaunchDarkly project slug. Only used to construct the `origin` URL that
-   * deep-links a flag to its LaunchDarkly dashboard page. When omitted, the
-   * adapter does not expose an `origin`, but flag evaluation is unaffected.
-   */
-  projectSlug?: string;
+  projectSlug: string;
   clientSideId: string;
   edgeConfigConnectionString: string;
 }): AdapterResponse {
@@ -85,9 +80,7 @@ export function createLaunchDarklyAdapter({
     options: AdapterOptions<ValueType> = {},
   ): Adapter<ValueType, LDContext> {
     return {
-      // Only expose `origin` when a project slug is available, otherwise the
-      // deep-link would be incorrect.
-      origin: projectSlug ? origin : undefined,
+      origin,
       async decide({ key, entities, headers }): Promise<ValueType> {
         if (!ldClient.initialized()) {
           if (!initPromise) initPromise = ldClient.waitForInitialization();
@@ -117,9 +110,7 @@ function getOrCreateDeaultAdapter() {
   if (!defaultLaunchDarklyAdapter) {
     const edgeConfigConnectionString = assertEnv('EXPERIMENTATION_CONFIG');
     const clientSideId = assertEnv('LAUNCHDARKLY_CLIENT_SIDE_ID');
-    // Optional: only used to build the dashboard deep-link (`origin`). The
-    // native Marketplace integration may not provide this.
-    const projectSlug = process.env.LAUNCHDARKLY_PROJECT_SLUG;
+    const projectSlug = assertEnv('LAUNCHDARKLY_PROJECT_SLUG');
 
     defaultLaunchDarklyAdapter = createLaunchDarklyAdapter({
       projectSlug,


### PR DESCRIPTION
## Summary

Updates the `@flags-sdk/launchdarkly` adapter to support LaunchDarkly's new native Marketplace integration.

When Edge Config is enabled for the collection, the native integration exposes the connection string as `EXPERIMENTATION_CONFIG` rather than the `EDGE_CONFIG` var used by the legacy Vercel integration. The native integration also does not currently provide `LAUNCHDARKLY_PROJECT_SLUG`.

## Changes

- **Edge Config connection string:** the default adapter now reads `EXPERIMENTATION_CONFIG` instead of `EDGE_CONFIG`. This aligns with the native Marketplace integration and matches the behavior of the Statsig adapter, which reads `EXPERIMENTATION_CONFIG` only. The missing-env error message was updated accordingly.
- **Optional project slug:** `LAUNCHDARKLY_PROJECT_SLUG` / `projectSlug` is now optional. It is only used to deep-link flags to the LaunchDarkly dashboard (the adapter's `origin`). When it is not set, flag evaluation is unaffected, but `variation().origin` is `undefined`.
- Docs (README + provider mdx) and tests updated. Also fixed a pre-existing README typo (`ldClientSideKey` → `clientSideId`).

## Breaking changes

Released as a `major` bump (`0.3.4` → `1.0.0`):

- The default adapter reads the Edge Config connection string from `EXPERIMENTATION_CONFIG` and **no longer reads `EDGE_CONFIG`**. The missing-env error text changed to `LaunchDarkly Adapter: Missing EXPERIMENTATION_CONFIG environment variable`.
- `variation().origin` can now be `undefined` (previously always a function) when no `projectSlug` is configured.

### Migration for legacy Vercel integration users

If your project provides the connection string as `EDGE_CONFIG`, either:

1. Set `EXPERIMENTATION_CONFIG` to the same value (`EXPERIMENTATION_CONFIG=$EDGE_CONFIG`), or
2. Pass it explicitly via `createLaunchDarklyAdapter({ edgeConfigConnectionString: process.env.EDGE_CONFIG })`.

Full migration instructions are in the changeset.

## Test plan

- [x] `pnpm test` (10/10 pass)
- [x] `pnpm type-check`
- [x] `pnpm check` (biome)