### PR TITLE
flags-sdk: use scoped skill identifier for vercel-cli install

### DIFF
--- a/skills/flags-sdk/SKILL.md
+++ b/skills/flags-sdk/SKILL.md
@@ -85,7 +85,7 @@ Check the project state to adapt commands and decide which steps you can skip:
 
 2. **Register the flag with Vercel**: Run `vercel flags add <flag-key> --kind boolean --description "<description>"`.
 
-   > **Prerequisite**: The `vercel flags` commands require the Vercel CLI to be installed and authenticated. If the Vercel CLI is not installed, run `pnpm i -g vercel`. For authentication or linking issues, read and follow the `vercel-cli` skill. If it's not installed, run `npx skills add https://github.com/vercel/vercel --skill vercel-cli`.
+   > **Prerequisite**: The `vercel flags` commands require the Vercel CLI to be installed and authenticated. If the Vercel CLI is not installed, run `pnpm i -g vercel`. For authentication or linking issues, follow the `vercel-cli` skill if it's already available. If it isn't, suggest the user install it with `npx skills add vercel/vercel@vercel-cli` (don't auto-install it) and rely on `vercel <command> --help` in the meantime.
 
    Before running `vercel flags add`, verify the project is linked to Vercel. Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link` first.
 

--- a/skills/flags-sdk/references/providers.md
+++ b/skills/flags-sdk/references/providers.md
@@ -28,7 +28,7 @@ pnpm i flags @flags-sdk/vercel
 
 ### Setup
 
-> **Prerequisite**: The `vercel flags` commands require the Vercel CLI to be installed and authenticated. If the Vercel CLI is not installed, run `pnpm i -g vercel`. For authentication or linking issues, read and follow the `vercel-cli` skill. If it's not installed, run `npx skills add https://github.com/vercel/vercel --skill vercel-cli`.
+> **Prerequisite**: The `vercel flags` commands require the Vercel CLI to be installed and authenticated. If the Vercel CLI is not installed, run `pnpm i -g vercel`. For authentication or linking issues, follow the `vercel-cli` skill if it's already available. If it isn't, suggest the user install it with `npx skills add vercel/vercel@vercel-cli` (don't auto-install it) and rely on `vercel <command> --help` in the meantime.
 
 Before running any `vercel flags` command, verify the project is linked to Vercel. Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link` first.
 
@@ -186,7 +186,7 @@ vercel flags sdk-keys add
 vercel flags sdk-keys rm <sdk-key-id>
 ```
 
-These examples cover common flag operations. For the full `vercel flags` reference and other Vercel CLI commands, see the `vercel-cli` skill. If it's not installed: `npx skills add https://github.com/vercel/vercel --skill vercel-cli`
+These examples cover common flag operations. For the full `vercel flags` reference and other Vercel CLI commands, see the `vercel-cli` skill. If it isn't installed, suggest the user install it with `npx skills add vercel/vercel@vercel-cli`.
 
 Full CLI reference: https://vercel.com/docs/cli/flags
 


### PR DESCRIPTION
## Summary

Removes the raw runtime install URL flagged by the [Snyk security audit](https://www.skills.sh/vercel/flags/flags-sdk/security/snyk) (**W012, MEDIUM** — "unverifiable external dependency: runtime URL that controls agent").

The `flags-sdk` skill instructed agents to run `npx skills add https://github.com/vercel/vercel --skill vercel-cli`, fetching and executing code from a full repo URL at runtime. This PR:

- Switches to the scoped registry identifier `vercel/vercel@vercel-cli` (matching this repo's own `vercel/flags@flags-sdk` convention and next.js's `owner/repo --skill` pattern).
- Reframes it as a user-facing suggestion rather than an agent auto-install, following next.js's "suggest, let the user decide" pattern for optional companion skills.

## Changes

- `skills/flags-sdk/SKILL.md` — prerequisite block
- `skills/flags-sdk/references/providers.md` — two occurrences (setup prerequisite + CLI reference note)

## Test plan

- [ ] Re-run the Snyk skill audit; confirm W012 is resolved
- [ ] Verify no remaining raw `github.com/...` install URLs in `skills/flags-sdk/`