### PR TITLE
Bound ingest POSTs to 2000 events and stop retrying 4xx responses

### DIFF
--- a/packages/vercel-flags-core/src/utils/ingest.ts
+++ b/packages/vercel-flags-core/src/utils/ingest.ts
@@ -3,9 +3,20 @@ import { version } from '../../package.json';
 import type { Auth } from '../controller/auth';
 import { getRetryDelayMs } from './backoff';
 import type { FlushReason } from './scheduler';
-import type { UsageEvent } from './usage/events';
+import type { IngestEvent, UsageEvent } from './usage/events';
 
 const MAX_RETRIES = 3;
+
+/**
+ * Maximum number of events sent in a single POST to the ingest endpoint.
+ *
+ * The server rejects request bodies with more events than its `maxItems` cap
+ * (see `services/api-flags-ingestion/src/index.ts` in vercel/api) — this
+ * constant must stay below that cap. Batches can exceed the scheduler's flush
+ * threshold because events accumulate until the flush microtask runs, so every
+ * flush is chunked to keep each request under the server limit.
+ */
+export const MAX_EVENTS_PER_REQUEST = 2000;
 
 export const EVALUATING_OIDC_TOKEN_HEADER = 'X-Vercel-Flags-OIDC-Token';
 export const FLUSH_REASON_HEADER = 'X-Vercel-Flags-Flush-Reason';
@@ -63,6 +74,22 @@ export async function sendIngestEvents(
 ): Promise<void> {
   const eventsToSend = events.map((event) => event.ingestEvent());
 
+  for (let i = 0; i < eventsToSend.length; i += MAX_EVENTS_PER_REQUEST) {
+    await sendIngestChunk(
+      options,
+      eventsToSend.slice(i, i + MAX_EVENTS_PER_REQUEST),
+      flushId,
+      flushReason,
+    );
+  }
+}
+
+async function sendIngestChunk(
+  options: IngestOptions,
+  eventsToSend: IngestEvent[],
+  flushId: number,
+  flushReason: FlushReason,
+): Promise<void> {
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
       const response = await options.fetch(`${options.host}/v1/ingest`, {
@@ -76,6 +103,16 @@ export async function sendIngestEvents(
       );
 
       if (response.ok) {
+        break;
+      }
+
+      // 4xx responses are deterministic; retrying the same payload cannot
+      // succeed, so drop the chunk immediately instead of retrying.
+      if (response.status >= 400 && response.status < 500) {
+        console.error(
+          `@vercel/flags-core: Dropped ${eventsToSend.length} events after non-retryable status ${response.status} on request ${response.headers.get('x-vercel-id')} (flushId=${flushId}).\n` +
+            `Response body: ${await response.text().catch(() => null)}`,
+        );
         break;
       }
 

--- a/packages/vercel-flags-core/src/utils/usage-tracker.test.ts
+++ b/packages/vercel-flags-core/src/utils/usage-tracker.test.ts
@@ -997,6 +997,31 @@ describe('UsageTracker', () => {
       consoleSpy.mockRestore();
     });
 
+    it('should not retry 4xx responses and log the drop', async () => {
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      fetchMock.mockImplementation(async () => {
+        return new Response('Bad Request', { status: 400 });
+      });
+
+      const tracker = createTracker();
+      tracker.trackRead();
+      await tracker.shutdown();
+
+      // A 400 is deterministic — a single attempt, no retries
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const droppedLogs = consoleSpy.mock.calls.filter(
+        ([msg]) =>
+          typeof msg === 'string' &&
+          msg.includes('Dropped 1 events after non-retryable status 400'),
+      );
+      expect(droppedLogs).toHaveLength(1);
+
+      consoleSpy.mockRestore();
+    });
+
     it('should not log the exhaustion warning when a retry eventually succeeds', async () => {
       vi.spyOn(Math, 'random').mockReturnValue(0);
       const consoleSpy = vi
@@ -1049,6 +1074,38 @@ describe('UsageTracker', () => {
       const events = getBody() as Array<{ type: string }>;
       expect(events).toHaveLength(2000);
       expect(getHeaders()[FLUSH_REASON_HEADER]).toBe('max_count');
+    });
+
+    it('should split a flush of more than 2000 events into multiple POSTs', async () => {
+      fetchMock.mockImplementation(() => jsonResponse({ ok: true }));
+
+      const tracker = createTracker();
+
+      // Synchronously track 2500 distinct events. The scheduler resolves the
+      // max_count flush at 2000, but the flush reads the event maps in a
+      // microtask that only runs after this loop, so the batch overshoots.
+      for (let i = 0; i < 2500; i++) {
+        tracker.trackEvaluation({
+          flagKey: `flag-${i}`,
+          variant: 'var_0',
+          reason: ResolutionReason.FALLTHROUGH,
+        });
+      }
+
+      await vi.waitFor(() => {
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      });
+
+      // Each POST stays at or below the 2000-event chunk size, and both
+      // chunks belong to the same flush (same flush reason header).
+      expect(getBody(0)).toHaveLength(2000);
+      expect(getBody(1)).toHaveLength(500);
+      expect(getHeaders(0)[FLUSH_REASON_HEADER]).toBe('max_count');
+      expect(getHeaders(1)[FLUSH_REASON_HEADER]).toBe('max_count');
+
+      // Everything was sent; shutdown has nothing left to flush.
+      await tracker.shutdown();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
     });
   });
 


### PR DESCRIPTION
Flushes can overshoot the scheduler's MAX_COUNT because the map read happens in a microtask, so a single POST could exceed the server-side maxItems cap and be rejected with a 400. Chunk sendIngestEvents so each POST carries at most MAX_EVENTS_PER_REQUEST events, and fail fast on 4xx responses instead of retrying deterministic failures.