### PR TITLE
Align rollouts assignments with split assignments

### DIFF
--- a/.changeset/align-rollout-split-assignment.md
+++ b/.changeset/align-rollout-split-assignment.md
@@ -1,0 +1,9 @@
+---
+"@vercel/flags-core": minor
+---
+
+Align rollout, split, and segment split user assignment onto a single hash bucketing scheme.
+
+Previously splits and rollouts bucketed users with opposite conventions, so switching a flag between a split and a rollout (or locking in a rollout as a split) could reassign users even when the effective distribution was unchanged. All three now derive their cut points from one shared boundary function over the full hash space, so a rollout at a given percentage is identical to the equivalent split.
+
+Split assignments are effectively unchanged. Rollouts and segment splits are re-bucketed once with this release; after that, converting a flag between outcome types never reassigns anyone.

--- a/packages/vercel-flags-core/src/evaluate.test.ts
+++ b/packages/vercel-flags-core/src/evaluate.test.ts
@@ -2473,6 +2473,98 @@ describe('evaluate', () => {
         outcomeType: OutcomeType.ROLLOUT,
       });
     });
+
+    describe('assigns identically to the equivalent split (no reassignment on type change)', () => {
+      const SEED = 7;
+      const VARIANTS = [false, true] as const;
+      const USER_COUNT = 1000;
+
+      // Evaluate a rollout pinned to `promille` (single slot active at t=0).
+      const rolloutValue = (
+        rollFromVariant: number,
+        rollToVariant: number,
+        promille: number,
+        uid: string,
+      ): unknown => {
+        vi.setSystemTime(startTimestamp);
+        return evaluate({
+          definition: {
+            environments: {
+              production: {
+                fallthrough: makeRollout({
+                  rollFromVariant,
+                  rollToVariant,
+                  defaultVariant: rollFromVariant,
+                  slots: [[promille, 100 * HOUR]],
+                }),
+              },
+            },
+            seed: SEED,
+            variants: [...VARIANTS],
+          },
+          environment: 'production',
+          entities: { user: { id: uid } },
+        }).value;
+      };
+
+      // Evaluate the split that expresses the same instantaneous distribution:
+      // rollToVariant gets `promille`, rollFromVariant gets the remainder.
+      const splitValue = (
+        rollFromVariant: number,
+        rollToVariant: number,
+        promille: number,
+        uid: string,
+      ): unknown => {
+        const weights = [0, 0];
+        weights[rollFromVariant] = 100_000 - promille;
+        weights[rollToVariant] = promille;
+        return evaluate({
+          definition: {
+            environments: {
+              production: {
+                fallthrough: {
+                  type: 'split',
+                  base: ['user', 'id'],
+                  defaultVariant: rollFromVariant,
+                  weights,
+                },
+              },
+            },
+            seed: SEED,
+            variants: [...VARIANTS],
+          },
+          environment: 'production',
+          entities: { user: { id: uid } },
+        }).value;
+      };
+
+      // Both index orderings: rollTo after rollFrom, and rollTo before rollFrom.
+      const orderings = [
+        {
+          rollFromVariant: 0,
+          rollToVariant: 1,
+          label: 'rollTo index > rollFrom',
+        },
+        {
+          rollFromVariant: 1,
+          rollToVariant: 0,
+          label: 'rollTo index < rollFrom',
+        },
+      ];
+
+      for (const { rollFromVariant, rollToVariant, label } of orderings) {
+        for (const promille of [1_000, 30_000, 50_000, 70_000, 99_000]) {
+          it(`matches split at ${promille / 1_000}% (${label})`, () => {
+            for (let i = 0; i < USER_COUNT; i++) {
+              const uid = `uid${i}`;
+              expect(
+                rolloutValue(rollFromVariant, rollToVariant, promille, uid),
+              ).toBe(splitValue(rollFromVariant, rollToVariant, promille, uid));
+            }
+          });
+        }
+      }
+    });
   });
 });
 

--- a/packages/vercel-flags-core/src/evaluate.test.ts
+++ b/packages/vercel-flags-core/src/evaluate.test.ts
@@ -595,7 +595,7 @@ describe('evaluate', () => {
       const trueCount = results.filter((r) => r.value).length;
       const falseCount = results.filter((r) => !r.value).length;
 
-      // both should be close to 500
+      // both should be close to 5000 (50% of 10k)
       expect(trueCount).toBe(5023);
       expect(falseCount).toBe(4977);
     });
@@ -630,7 +630,7 @@ describe('evaluate', () => {
       const trueCount = results.filter((r) => r.value).length;
       const falseCount = results.filter((r) => !r.value).length;
 
-      // both should be close to 100 (1%)
+      // should be close to 100 (1% of 10k)
       expect(trueCount).toBe(118);
       expect(falseCount).toBe(9882);
     });
@@ -652,7 +652,7 @@ describe('evaluate', () => {
                     outcome: {
                       type: 'split',
                       base: ['user', 'name'],
-                      passPromille: 99_000, // pass 1%
+                      passPromille: 99_000, // pass 99%
                     },
                   },
                 ],
@@ -665,7 +665,7 @@ describe('evaluate', () => {
       const trueCount = results.filter((r) => r.value).length;
       const falseCount = results.filter((r) => !r.value).length;
 
-      // both should be close to 9900 (99%)
+      // both should be close to 9900 (99% of 10k)
       expect(trueCount).toBe(9903);
       expect(falseCount).toBe(97);
     });

--- a/packages/vercel-flags-core/src/evaluate.test.ts
+++ b/packages/vercel-flags-core/src/evaluate.test.ts
@@ -596,8 +596,8 @@ describe('evaluate', () => {
       const falseCount = results.filter((r) => !r.value).length;
 
       // both should be close to 500
-      expect(trueCount).toBe(5070);
-      expect(falseCount).toBe(4930);
+      expect(trueCount).toBe(5023);
+      expect(falseCount).toBe(4977);
     });
 
     it('should split roughly equally on a 50/50 split', () => {
@@ -631,8 +631,8 @@ describe('evaluate', () => {
       const falseCount = results.filter((r) => !r.value).length;
 
       // both should be close to 100 (1%)
-      expect(trueCount).toBe(102);
-      expect(falseCount).toBe(9898);
+      expect(trueCount).toBe(118);
+      expect(falseCount).toBe(9882);
     });
 
     it('should split roughly equally on a 50/50 split', () => {
@@ -666,8 +666,8 @@ describe('evaluate', () => {
       const falseCount = results.filter((r) => !r.value).length;
 
       // both should be close to 9900 (99%)
-      expect(trueCount).toBe(9891);
-      expect(falseCount).toBe(109);
+      expect(trueCount).toBe(9903);
+      expect(falseCount).toBe(97);
     });
   });
 
@@ -2230,10 +2230,10 @@ describe('evaluate', () => {
       // these show how many people were assigned to each group,
       // an ideal distribution would assign 2500 to each group
       const expectedTotals = {
-        a: 2570,
-        b: 2477,
-        c: 2516,
-        d: 2437,
+        a: 2477,
+        b: 2602,
+        c: 2458,
+        d: 2463,
       };
       expect(getTotals([1, 1, 1, 1], 9)).toEqual(expectedTotals);
       expect(getTotals([1000, 1000, 1000, 1000], 9)).toEqual(expectedTotals);

--- a/packages/vercel-flags-core/src/evaluate.test.ts
+++ b/packages/vercel-flags-core/src/evaluate.test.ts
@@ -2230,10 +2230,10 @@ describe('evaluate', () => {
       // these show how many people were assigned to each group,
       // an ideal distribution would assign 2500 to each group
       const expectedTotals = {
-        a: 2477,
-        b: 2602,
-        c: 2458,
-        d: 2463,
+        a: 2570,
+        b: 2477,
+        c: 2516,
+        d: 2437,
       };
       expect(getTotals([1, 1, 1, 1], 9)).toEqual(expectedTotals);
       expect(getTotals([1000, 1000, 1000, 1000], 9)).toEqual(expectedTotals);

--- a/packages/vercel-flags-core/src/evaluate.test.ts
+++ b/packages/vercel-flags-core/src/evaluate.test.ts
@@ -2238,6 +2238,54 @@ describe('evaluate', () => {
       expect(getTotals([1, 1, 1, 1], 9)).toEqual(expectedTotals);
       expect(getTotals([1000, 1000, 1000, 1000], 9)).toEqual(expectedTotals);
     });
+
+    it.each([
+      { weights: [30_000, 70_000] },
+      { weights: [1, 99] },
+      { weights: [10_000, 20_000, 30_000, 40_000] },
+      { weights: [1, 1, 1, 1] },
+    ])('assigns roughly proportional to weights $weights across many ids (statistical check)', ({
+      weights,
+    }) => {
+      const N = 20_000;
+      const variants = weights.map((_, i) => `v${i}`);
+      const counts = new Array(weights.length).fill(0) as number[];
+
+      for (let i = 0; i < N; i++) {
+        const result = evaluate({
+          definition: {
+            environments: {
+              production: {
+                fallthrough: {
+                  type: 'split',
+                  base: ['user', 'id'],
+                  defaultVariant: 0,
+                  weights,
+                },
+              },
+            },
+            variants,
+            seed: 7,
+          } satisfies Packed.FlagDefinition,
+          environment: 'production',
+          entities: { user: { id: `uid${i}` } },
+        }).value as string;
+        counts[variants.indexOf(result)]!++;
+      }
+
+      // Expected count per variant under its configured weight, with a
+      // binomial standard error; assignment is hash-based (deterministic),
+      // so this is not flaky, but confirms the actual split tracks the
+      // configured weight ratios rather than some other distribution.
+      const totalWeight = weights.reduce((a, b) => a + b, 0);
+      weights.forEach((weight, index) => {
+        const p = weight / totalWeight;
+        const expected = N * p;
+        const stderr = Math.sqrt(N * p * (1 - p));
+        expect(counts[index]).toBeGreaterThan(expected - 4 * stderr);
+        expect(counts[index]).toBeLessThan(expected + 4 * stderr);
+      });
+    });
   });
 
   describe('rollouts', () => {
@@ -2442,6 +2490,40 @@ describe('evaluate', () => {
 
       // All users should get rollToVariant
       expect(trueCount).toBe(1000);
+    });
+
+    it.each([
+      1_000, 10_000, 25_000, 50_000, 75_000, 90_000, 99_000,
+    ])('assigns roughly %i/100000 of entities to rollToVariant across many ids (statistical check)', (promille) => {
+      const N = 20_000;
+      vi.setSystemTime(startTimestamp);
+      const rollout = makeRollout({
+        slots: [[promille, 100 * HOUR]],
+      });
+
+      let rollToCount = 0;
+      for (let i = 0; i < N; i++) {
+        const result = evaluate({
+          definition: {
+            environments: { production: { fallthrough: rollout } },
+            seed: 7,
+            variants: [false, true],
+          },
+          environment: 'production',
+          entities: { user: { id: `uid${i}` } },
+        });
+        if (result.value === true) rollToCount++;
+      }
+
+      // Expected count under the configured promille, with a binomial
+      // standard error; assignment is hash-based (deterministic), so this
+      // is not flaky, but confirms the actual split tracks the configured
+      // percentage rather than some other distribution.
+      const p = promille / 100_000;
+      const expected = N * p;
+      const stderr = Math.sqrt(N * p * (1 - p));
+      expect(rollToCount).toBeGreaterThan(expected - 2 * stderr);
+      expect(rollToCount).toBeLessThan(expected + 2 * stderr);
     });
 
     it('works as a rule outcome', () => {

--- a/packages/vercel-flags-core/src/evaluate.ts
+++ b/packages/vercel-flags-core/src/evaluate.ts
@@ -37,7 +37,7 @@ const PROMILLE_SCALE = 100_000;
  * The single boundary function every splitting path shares.
  *
  * Maps the fraction `numerator / denominator` to an integer cut point in
- * `[0, HASH_SPACE]`; a hash is "below" the fraction iff `hash < hashBoundary(…)`.
+ * `[0, HASH_SPACE]`; a hash is "below" the fraction if `hash < hashBoundary(…)`.
  * Because splits, rollouts, and segments all derive their cut points from this
  * one expression, a rollout at promille `p` produces a bit-for-bit identical cut
  * to the split `{ rollFrom: PROMILLE_SCALE - p, rollTo: p }` — which is what lets

--- a/packages/vercel-flags-core/src/evaluate.ts
+++ b/packages/vercel-flags-core/src/evaluate.ts
@@ -14,19 +14,10 @@ type PathArray = (string | number)[];
 const MAX_REGEX_INPUT_LENGTH = 10_000;
 
 /**
- * Size of the hash bucket space that all traffic splitting operates in.
- *
- * `hashInput` (xxHash32) returns an integer in `[0, 2**32 - 1]`, i.e. exactly
- * `2**32` distinct values, so we use `2**32` directly as the bucket space and
- * compare the raw hash against boundaries in it — no modulo. Two consequences
- * we rely on:
- *
- * - **No modulo bias.** Folding the hash into a smaller range with `%` would
- *   make the low buckets slightly heavier (since `2**32` is not divisible by
- *   e.g. 100_000). Using the full range as-is keeps every bucket uniform.
- * - **No unassigned value.** The final variant's boundary is exactly `2**32`
- *   (its cumulative weight equals the total), and every hash is `< 2**32`, so
- *   the top variant catches the whole tail. Nothing falls through to a default.
+ * Bucket space for all traffic splitting. `hashInput` (xxHash32) returns exactly
+ * `2**32` distinct values, so we use `2**32` as the space and compare the raw
+ * hash against boundaries in it — no modulo (which would bias low buckets), and
+ * the final variant's boundary is exactly `2**32` so nothing falls through.
  */
 const HASH_SPACE = 2 ** 32;
 
@@ -34,36 +25,27 @@ const HASH_SPACE = 2 ** 32;
 const PROMILLE_SCALE = 100_000;
 
 /**
- * The single boundary function every splitting path shares.
- *
- * Maps the fraction `numerator / denominator` to an integer cut point in
- * `[0, HASH_SPACE]`; a hash is "below" the fraction if `hash < boundaryFor(…)`.
- * Because splits, rollouts, and segments all derive their cut points from this
- * one expression, a rollout at promille `p` produces a bit-for-bit identical cut
- * to the split `{ rollFrom: PROMILLE_SCALE - p, rollTo: p }` — which is what lets
- * a flag switch between split and rollout without reassigning anyone.
- *
- * `numerator === denominator` yields exactly `HASH_SPACE` (the final variant
- * catches everything); `denominator === 0` yields `NaN`, so every `hash < NaN`
- * check is false and evaluation falls through to the default.
+ * Maps the fraction `numerator / denominator` to a cut point in `[0, HASH_SPACE]`;
+ * a hash is "below" the fraction iff `hash < boundaryFor(…)`. Splits, rollouts,
+ * and segments all cut with this one function, so a rollout at promille `p` is
+ * bit-for-bit identical to the split `{ rollFrom: PROMILLE_SCALE - p, rollTo: p }`
+ * — which is what lets a flag switch between split and rollout without reassigning
+ * anyone. `denominator === 0` yields `NaN`, so evaluation falls through to default.
  */
 function boundaryFor(numerator: number, denominator: number): number {
   return Math.floor((numerator / denominator) * HASH_SPACE);
 }
 
-// Per-object memoization caches keyed by the outcome / rhs objects from the
-// datafile. Using WeakMaps (instead of mutating the objects with symbol-keyed
-// props) keeps datafile objects pristine so they serialize cleanly across the
-// RSC server/client boundary. Entries are GC'd when the datafile is dropped.
-//
-// Split boundaries are static per outcome (weights don't change), so the
-// cumulative cut points are computed once and reused across every evaluation.
+// WeakMaps keyed by datafile objects, so those objects stay pristine (no
+// symbol-keyed props) and serialize cleanly across the RSC boundary; entries
+// are GC'd with the datafile. Split boundaries are static per outcome, so the
+// cumulative cut points are computed once and reused across evaluations.
 const splitBoundariesCache = new WeakMap<Packed.SplitOutcome, number[]>();
 const compiledRegexCache = new WeakMap<object, RegExp>();
 
 /**
- * Cumulative hash boundaries for a split, one per variant, in variant-index
- * order. Variant `i` is served for hashes in `[boundaries[i-1], boundaries[i])`.
+ * Cumulative hash boundaries for a split, one per variant in index order.
+ * Variant `i` is served for hashes in `[boundaries[i-1], boundaries[i])`.
  */
 function getSplitBoundaries(outcome: Packed.SplitOutcome): number[] {
   const cached = splitBoundariesCache.get(outcome);
@@ -476,8 +458,7 @@ function handleOutcome<T>(
         }
       }
 
-      // Only reached when the weights sum to 0 (every boundary is NaN, so no
-      // bucket claims any traffic).
+      // Only reached when the weights sum to 0 (every boundary is NaN).
       return {
         ...defaultOutcome,
         outcomeType: OutcomeType.SPLIT,
@@ -549,14 +530,10 @@ function handleOutcome<T>(
 
       const bucket = hashInput(lhs, params.definition.seed);
 
-      // A rollout at promille `p` is exactly the split
-      // { rollFromVariant: PROMILLE_SCALE - p, rollToVariant: p }, laid out with
-      // the same boundaryFor cut points. So rollTo occupies the low buckets
-      // `[0, boundary(p))` when it is the lower-index variant (matching where the
-      // split would place it), otherwise rollFrom holds the low buckets and
-      // rollTo takes the top. Sharing boundaryFor with the split path is what
-      // makes the two bit-for-bit identical, so switching outcome type reassigns
-      // nobody.
+      // Equivalent to the split { rollFrom: PROMILLE_SCALE - p, rollTo: p }: the
+      // lower-index variant takes the low buckets, matching where the split
+      // places it (see boundaryFor). So rollTo holds `[0, boundary(p))` when it
+      // has the lower index, otherwise rollFrom holds the low buckets.
       if (outcome.rollToVariant < outcome.rollFromVariant) {
         const rollToBoundary = boundaryFor(currentPromille, PROMILLE_SCALE);
         return {

--- a/packages/vercel-flags-core/src/evaluate.ts
+++ b/packages/vercel-flags-core/src/evaluate.ts
@@ -500,9 +500,31 @@ function handleOutcome<T>(
       }
 
       const value = hashInput(lhs, params.definition.seed);
-      const threshold = (currentPromille / 100_000) * UINT32_MAX;
 
-      const variant = value < threshold ? rollToVariant : rollFromVariant;
+      // Lay the two rollout variants into the hash space using the same
+      // variant-index-ordered bucketing that splits use (getScaledWeights +
+      // findWeightedIndex). A rollout at promille `p` is exactly the split
+      // { rollFromVariant: 100_000 - p, rollToVariant: p }, so a user is
+      // assigned the same variant whether the flag is expressed as a rollout or
+      // as the equivalent split — switching outcome type reassigns nobody.
+      //
+      // We cannot reuse the memoized getScaledWeights() here because the weights
+      // change with `currentPromille`, so we scale inline. The total is always
+      // 100_000 (the two weights sum to it), matching how getScaledWeights
+      // divides by the weight total.
+      const rolloutWeights = new Array<number>(
+        params.definition.variants.length,
+      ).fill(0);
+      rolloutWeights[outcome.rollFromVariant] = 100_000 - currentPromille;
+      rolloutWeights[outcome.rollToVariant] = currentPromille;
+      const scaledWeights = rolloutWeights.map(
+        (w) => (w / 100_000) * UINT32_MAX,
+      );
+      const variantIndex = findWeightedIndex(scaledWeights, value, UINT32_MAX);
+      const variant =
+        variantIndex === -1
+          ? defaultOutcome
+          : getVariant<T>(params.definition, variantIndex);
 
       return {
         ...variant,

--- a/packages/vercel-flags-core/src/evaluate.ts
+++ b/packages/vercel-flags-core/src/evaluate.ts
@@ -502,34 +502,40 @@ function handleOutcome<T>(
       const value = hashInput(lhs, params.definition.seed);
 
       // Lay the two rollout variants into the hash space using the same
-      // variant-index-ordered bucketing that splits use (getScaledWeights +
-      // findWeightedIndex). A rollout at promille `p` is exactly the split
-      // { rollFromVariant: 100_000 - p, rollToVariant: p }, so a user is
-      // assigned the same variant whether the flag is expressed as a rollout or
-      // as the equivalent split — switching outcome type reassigns nobody.
+      // variant-index-ordered bucketing that splits use. A rollout at promille
+      // `p` is exactly the split { rollFromVariant: 100_000 - p,
+      // rollToVariant: p }, so a user is assigned the same variant whether the
+      // flag is expressed as a rollout or as the equivalent split — switching
+      // outcome type reassigns nobody.
       //
-      // We cannot reuse the memoized getScaledWeights() here because the weights
-      // change with `currentPromille`, so we scale inline. The total is always
-      // 100_000 (the two weights sum to it), matching how getScaledWeights
-      // divides by the weight total.
-      const rolloutWeights = new Array<number>(
-        params.definition.variants.length,
-      ).fill(0);
-      rolloutWeights[outcome.rollFromVariant] = 100_000 - currentPromille;
-      rolloutWeights[outcome.rollToVariant] = currentPromille;
-      const scaledWeights = rolloutWeights.map(
-        (w) => (w / 100_000) * UINT32_MAX,
-      );
-      const variantIndex = findWeightedIndex(scaledWeights, value, UINT32_MAX);
-      const variant =
-        variantIndex === -1
-          ? defaultOutcome
-          : getVariant<T>(params.definition, variantIndex);
+      // Since only two variants carry weight, the split's findWeightedIndex walk
+      // over a mostly-zero weights array collapses to two boundary comparisons,
+      // so we compute it inline without allocating any array. The lower-index
+      // variant occupies the low bucket [0, itsShare), matching the order in
+      // which findWeightedIndex accumulates. The remaining branches mirror
+      // findWeightedIndex's -1 result (→ defaultOutcome): the >= UINT32_MAX
+      // guard, and the floating-point sliver above both shares when they don't
+      // sum to exactly UINT32_MAX.
+      const rollToShare = (currentPromille / 100_000) * UINT32_MAX;
+      const rollFromShare =
+        ((100_000 - currentPromille) / 100_000) * UINT32_MAX;
 
-      return {
-        ...variant,
-        outcomeType: OutcomeType.ROLLOUT,
-      };
+      const rollToIsLowerIndex =
+        outcome.rollToVariant < outcome.rollFromVariant;
+      const lowShare = rollToIsLowerIndex ? rollToShare : rollFromShare;
+      const lowVariant = rollToIsLowerIndex ? rollToVariant : rollFromVariant;
+      const highVariant = rollToIsLowerIndex ? rollFromVariant : rollToVariant;
+
+      if (value >= UINT32_MAX) {
+        return { ...defaultOutcome, outcomeType: OutcomeType.ROLLOUT };
+      }
+      if (value < lowShare) {
+        return { ...lowVariant, outcomeType: OutcomeType.ROLLOUT };
+      }
+      if (value < rollToShare + rollFromShare) {
+        return { ...highVariant, outcomeType: OutcomeType.ROLLOUT };
+      }
+      return { ...defaultOutcome, outcomeType: OutcomeType.ROLLOUT };
     }
     default: {
       const { type } = outcome;

--- a/packages/vercel-flags-core/src/evaluate.ts
+++ b/packages/vercel-flags-core/src/evaluate.ts
@@ -37,7 +37,7 @@ const PROMILLE_SCALE = 100_000;
  * The single boundary function every splitting path shares.
  *
  * Maps the fraction `numerator / denominator` to an integer cut point in
- * `[0, HASH_SPACE]`; a hash is "below" the fraction if `hash < hashBoundary(…)`.
+ * `[0, HASH_SPACE]`; a hash is "below" the fraction if `hash < boundaryFor(…)`.
  * Because splits, rollouts, and segments all derive their cut points from this
  * one expression, a rollout at promille `p` produces a bit-for-bit identical cut
  * to the split `{ rollFrom: PROMILLE_SCALE - p, rollTo: p }` — which is what lets
@@ -47,7 +47,7 @@ const PROMILLE_SCALE = 100_000;
  * catches everything); `denominator === 0` yields `NaN`, so every `hash < NaN`
  * check is false and evaluation falls through to the default.
  */
-function hashBoundary(numerator: number, denominator: number): number {
+function boundaryFor(numerator: number, denominator: number): number {
   return Math.floor((numerator / denominator) * HASH_SPACE);
 }
 
@@ -73,7 +73,7 @@ function getSplitBoundaries(outcome: Packed.SplitOutcome): number[] {
   let cumulative = 0;
   for (const weight of outcome.weights) {
     cumulative += weight;
-    boundaries.push(hashBoundary(cumulative, total));
+    boundaries.push(boundaryFor(cumulative, total));
   }
   splitBoundariesCache.set(outcome, boundaries);
   return boundaries;
@@ -400,7 +400,7 @@ function handleSegmentOutcome<T>(
       if (outcome.passPromille >= PROMILLE_SCALE) return true;
 
       const bucket = hashInput(lhs, params.definition.seed);
-      return bucket < hashBoundary(outcome.passPromille, PROMILLE_SCALE);
+      return bucket < boundaryFor(outcome.passPromille, PROMILLE_SCALE);
     }
     default: {
       const { type } = outcome;
@@ -551,20 +551,20 @@ function handleOutcome<T>(
 
       // A rollout at promille `p` is exactly the split
       // { rollFromVariant: PROMILLE_SCALE - p, rollToVariant: p }, laid out with
-      // the same hashBoundary cut points. So rollTo occupies the low buckets
+      // the same boundaryFor cut points. So rollTo occupies the low buckets
       // `[0, boundary(p))` when it is the lower-index variant (matching where the
       // split would place it), otherwise rollFrom holds the low buckets and
-      // rollTo takes the top. Sharing hashBoundary with the split path is what
+      // rollTo takes the top. Sharing boundaryFor with the split path is what
       // makes the two bit-for-bit identical, so switching outcome type reassigns
       // nobody.
       if (outcome.rollToVariant < outcome.rollFromVariant) {
-        const rollToBoundary = hashBoundary(currentPromille, PROMILLE_SCALE);
+        const rollToBoundary = boundaryFor(currentPromille, PROMILLE_SCALE);
         return {
           ...(bucket < rollToBoundary ? rollToVariant : rollFromVariant),
           outcomeType: OutcomeType.ROLLOUT,
         };
       }
-      const rollFromBoundary = hashBoundary(
+      const rollFromBoundary = boundaryFor(
         PROMILLE_SCALE - currentPromille,
         PROMILLE_SCALE,
       );

--- a/packages/vercel-flags-core/src/evaluate.ts
+++ b/packages/vercel-flags-core/src/evaluate.ts
@@ -13,24 +13,31 @@ type PathArray = (string | number)[];
 
 const MAX_REGEX_INPUT_LENGTH = 10_000;
 
-/** uint32 max — domain of xxHash32 output, used for split/rollout thresholds */
-const UINT32_MAX = 4_294_967_295;
+/**
+ * Number of buckets that traffic-splitting hashes into.
+ *
+ * Splits, rollouts, and segment splits all fold the 32-bit hash into
+ * `[0, SPLIT_BUCKET_COUNT)` with a modulo and compare against integer
+ * thresholds (weights for splits, promille for rollouts and segments — promille
+ * is already expressed out of 100_000). Working in this integer space — rather
+ * than scaling floats over the full uint32 range — has two properties we rely
+ * on: every hash lands in a bucket (there is no unassigned top value that would
+ * fall through to a default), and a rollout at promille `p` is bucket-for-bucket
+ * identical to the equivalent split. That identity is what lets a flag switch
+ * between split and rollout without reassigning anyone.
+ */
+const SPLIT_BUCKET_COUNT = 100_000;
 
-// Per-object memoization caches keyed by the outcome / rhs objects from the
-// datafile. Using WeakMaps (instead of mutating the objects with symbol-keyed
-// props) keeps datafile objects pristine so they serialize cleanly across the
-// RSC server/client boundary. Entries are GC'd when the datafile is dropped.
-const scaledWeightsCache = new WeakMap<Packed.SplitOutcome, number[]>();
-const compiledRegexCache = new WeakMap<object, RegExp>();
-
-function getScaledWeights(outcome: Packed.SplitOutcome): number[] {
-  const cached = scaledWeightsCache.get(outcome);
-  if (cached) return cached;
-  const total = sum(outcome.weights);
-  const scaled = outcome.weights.map((w) => (w / total) * UINT32_MAX);
-  scaledWeightsCache.set(outcome, scaled);
-  return scaled;
+/** Folds the hash of `lhs` into a bucket in `[0, SPLIT_BUCKET_COUNT)`. */
+function splitBucket(lhs: string, seed: number): number {
+  return hashInput(lhs, seed) % SPLIT_BUCKET_COUNT;
 }
+
+// Per-object memoization cache keyed by the rhs regex objects from the datafile.
+// Using a WeakMap (instead of mutating the objects with symbol-keyed props)
+// keeps datafile objects pristine so they serialize cleanly across the RSC
+// server/client boundary. Entries are GC'd when the datafile is dropped.
+const compiledRegexCache = new WeakMap<object, RegExp>();
 
 function getCompiledRegex(rhs: { pattern: string; flags: string }): RegExp {
   const cached = compiledRegexCache.get(rhs);
@@ -348,14 +355,11 @@ function handleSegmentOutcome<T>(
       // exclude from segment if the lhs is not a string
       if (typeof lhs !== 'string') return false;
 
-      const maxValue = 100_000;
-
       // bypass hashing for common values and edges
       if (outcome.passPromille <= 0) return false;
-      if (outcome.passPromille >= maxValue) return true;
+      if (outcome.passPromille >= SPLIT_BUCKET_COUNT) return true;
 
-      const value = hashInput(lhs, params.definition.seed) % maxValue;
-      return value < outcome.passPromille;
+      return splitBucket(lhs, params.definition.seed) < outcome.passPromille;
     }
     default: {
       const { type } = outcome;
@@ -418,20 +422,28 @@ function handleOutcome<T>(
         };
       }
 
-      /**
-       * (xxHash32): turns the string into a number between 0 and 2^32-1 (max uint32 value)
-       * Since we know the range of the hash function, we don't use modulo here. If we change
-       * the hash function, or if the range changes, we should add a modulo here and/or adjust UINT32_MAX.
-       */
-      const value = hashInput(lhs, params.definition.seed);
-      const scaledWeights = getScaledWeights(outcome);
-      const variantIndex = findWeightedIndex(scaledWeights, value, UINT32_MAX);
-      const variant =
-        variantIndex === -1
-          ? defaultOutcome
-          : getVariant<T>(params.definition, variantIndex);
+      const bucket = splitBucket(lhs, params.definition.seed);
+      const total = sum(outcome.weights);
+
+      // Walk the weights in variant-index order and return the first variant
+      // whose cumulative weight covers the bucket. The comparison is
+      // cross-multiplied to stay in integer arithmetic (no floats, no rounding):
+      //   bucket / SPLIT_BUCKET_COUNT < cumulative / total
+      //   ⟺ bucket * total < cumulative * SPLIT_BUCKET_COUNT
+      let cumulative = 0;
+      for (let index = 0; index < outcome.weights.length; index++) {
+        cumulative += outcome.weights[index] as number;
+        if (bucket * total < cumulative * SPLIT_BUCKET_COUNT) {
+          return {
+            ...getVariant<T>(params.definition, index),
+            outcomeType: OutcomeType.SPLIT,
+          };
+        }
+      }
+
+      // Only reached when the weights sum to 0 (no bucket claims any traffic).
       return {
-        ...variant,
+        ...defaultOutcome,
         outcomeType: OutcomeType.SPLIT,
       };
     }
@@ -499,43 +511,30 @@ function handleOutcome<T>(
         };
       }
 
-      const value = hashInput(lhs, params.definition.seed);
+      const bucket = splitBucket(lhs, params.definition.seed);
 
-      // Lay the two rollout variants into the hash space using the same
-      // variant-index-ordered bucketing that splits use. A rollout at promille
-      // `p` is exactly the split { rollFromVariant: 100_000 - p,
-      // rollToVariant: p }, so a user is assigned the same variant whether the
-      // flag is expressed as a rollout or as the equivalent split — switching
-      // outcome type reassigns nobody.
-      //
-      // Since only two variants carry weight, the split's findWeightedIndex walk
-      // over a mostly-zero weights array collapses to two boundary comparisons,
-      // so we compute it inline without allocating any array. The lower-index
-      // variant occupies the low bucket [0, itsShare), matching the order in
-      // which findWeightedIndex accumulates. The remaining branches mirror
-      // findWeightedIndex's -1 result (→ defaultOutcome): the >= UINT32_MAX
-      // guard, and the floating-point sliver above both shares when they don't
-      // sum to exactly UINT32_MAX.
-      const rollToShare = (currentPromille / 100_000) * UINT32_MAX;
-      const rollFromShare =
-        ((100_000 - currentPromille) / 100_000) * UINT32_MAX;
-
-      const rollToIsLowerIndex =
-        outcome.rollToVariant < outcome.rollFromVariant;
-      const lowShare = rollToIsLowerIndex ? rollToShare : rollFromShare;
-      const lowVariant = rollToIsLowerIndex ? rollToVariant : rollFromVariant;
-      const highVariant = rollToIsLowerIndex ? rollFromVariant : rollToVariant;
-
-      if (value >= UINT32_MAX) {
-        return { ...defaultOutcome, outcomeType: OutcomeType.ROLLOUT };
+      // A rollout at promille `p` is exactly the split
+      // { rollFromVariant: SPLIT_BUCKET_COUNT - p, rollToVariant: p }, laid out
+      // with the same integer bucketing. So rollTo occupies the low buckets
+      // `[0, p)` when it is the lower-index variant (matching where the split
+      // would place it), otherwise rollFrom holds the low buckets and rollTo
+      // takes the top `[SPLIT_BUCKET_COUNT - p, SPLIT_BUCKET_COUNT)`. Because
+      // `p` is already expressed out of SPLIT_BUCKET_COUNT and the bucket space
+      // is exactly SPLIT_BUCKET_COUNT wide, every bucket is assigned and the
+      // boundary matches the split bucket-for-bucket — switching outcome type
+      // reassigns nobody.
+      if (outcome.rollToVariant < outcome.rollFromVariant) {
+        return {
+          ...(bucket < currentPromille ? rollToVariant : rollFromVariant),
+          outcomeType: OutcomeType.ROLLOUT,
+        };
       }
-      if (value < lowShare) {
-        return { ...lowVariant, outcomeType: OutcomeType.ROLLOUT };
-      }
-      if (value < rollToShare + rollFromShare) {
-        return { ...highVariant, outcomeType: OutcomeType.ROLLOUT };
-      }
-      return { ...defaultOutcome, outcomeType: OutcomeType.ROLLOUT };
+      return {
+        ...(bucket < SPLIT_BUCKET_COUNT - currentPromille
+          ? rollFromVariant
+          : rollToVariant),
+        outcomeType: OutcomeType.ROLLOUT,
+      };
     }
     default: {
       const { type } = outcome;
@@ -668,28 +667,4 @@ export function bulkEvaluate<T = unknown>(
     results[key] = evaluate<T>(params);
   }
   return results;
-}
-
-/**
- * Find the weighted index that the given value falls into.
- *
- * Takes a set of weights that add up to maxValue, and returns the index
- * that corresponds to the given value.
- *
- * @returns index or -1
- */
-export function findWeightedIndex(
-  weights: number[],
-  value: number,
-  maxValue: number,
-): number {
-  if (value < 0 || value >= maxValue) return -1;
-
-  let sum = 0;
-  for (let i = 0; i < weights.length; i++) {
-    sum += weights[i] as number;
-    if (value < sum) return i;
-  }
-
-  return -1;
 }

--- a/packages/vercel-flags-core/src/evaluate.ts
+++ b/packages/vercel-flags-core/src/evaluate.ts
@@ -14,30 +14,70 @@ type PathArray = (string | number)[];
 const MAX_REGEX_INPUT_LENGTH = 10_000;
 
 /**
- * Number of buckets that traffic-splitting hashes into.
+ * Size of the hash bucket space that all traffic splitting operates in.
  *
- * Splits, rollouts, and segment splits all fold the 32-bit hash into
- * `[0, SPLIT_BUCKET_COUNT)` with a modulo and compare against integer
- * thresholds (weights for splits, promille for rollouts and segments — promille
- * is already expressed out of 100_000). Working in this integer space — rather
- * than scaling floats over the full uint32 range — has two properties we rely
- * on: every hash lands in a bucket (there is no unassigned top value that would
- * fall through to a default), and a rollout at promille `p` is bucket-for-bucket
- * identical to the equivalent split. That identity is what lets a flag switch
- * between split and rollout without reassigning anyone.
+ * `hashInput` (xxHash32) returns an integer in `[0, 2**32 - 1]`, i.e. exactly
+ * `2**32` distinct values, so we use `2**32` directly as the bucket space and
+ * compare the raw hash against boundaries in it — no modulo. Two consequences
+ * we rely on:
+ *
+ * - **No modulo bias.** Folding the hash into a smaller range with `%` would
+ *   make the low buckets slightly heavier (since `2**32` is not divisible by
+ *   e.g. 100_000). Using the full range as-is keeps every bucket uniform.
+ * - **No unassigned value.** The final variant's boundary is exactly `2**32`
+ *   (its cumulative weight equals the total), and every hash is `< 2**32`, so
+ *   the top variant catches the whole tail. Nothing falls through to a default.
  */
-const SPLIT_BUCKET_COUNT = 100_000;
+const HASH_SPACE = 2 ** 32;
 
-/** Folds the hash of `lhs` into a bucket in `[0, SPLIT_BUCKET_COUNT)`. */
-function splitBucket(lhs: string, seed: number): number {
-  return hashInput(lhs, seed) % SPLIT_BUCKET_COUNT;
+/** Denominator for promille values (rollout slots and segment `passPromille`). */
+const PROMILLE_SCALE = 100_000;
+
+/**
+ * The single boundary function every splitting path shares.
+ *
+ * Maps the fraction `numerator / denominator` to an integer cut point in
+ * `[0, HASH_SPACE]`; a hash is "below" the fraction iff `hash < hashBoundary(…)`.
+ * Because splits, rollouts, and segments all derive their cut points from this
+ * one expression, a rollout at promille `p` produces a bit-for-bit identical cut
+ * to the split `{ rollFrom: PROMILLE_SCALE - p, rollTo: p }` — which is what lets
+ * a flag switch between split and rollout without reassigning anyone.
+ *
+ * `numerator === denominator` yields exactly `HASH_SPACE` (the final variant
+ * catches everything); `denominator === 0` yields `NaN`, so every `hash < NaN`
+ * check is false and evaluation falls through to the default.
+ */
+function hashBoundary(numerator: number, denominator: number): number {
+  return Math.floor((numerator / denominator) * HASH_SPACE);
 }
 
-// Per-object memoization cache keyed by the rhs regex objects from the datafile.
-// Using a WeakMap (instead of mutating the objects with symbol-keyed props)
-// keeps datafile objects pristine so they serialize cleanly across the RSC
-// server/client boundary. Entries are GC'd when the datafile is dropped.
+// Per-object memoization caches keyed by the outcome / rhs objects from the
+// datafile. Using WeakMaps (instead of mutating the objects with symbol-keyed
+// props) keeps datafile objects pristine so they serialize cleanly across the
+// RSC server/client boundary. Entries are GC'd when the datafile is dropped.
+//
+// Split boundaries are static per outcome (weights don't change), so the
+// cumulative cut points are computed once and reused across every evaluation.
+const splitBoundariesCache = new WeakMap<Packed.SplitOutcome, number[]>();
 const compiledRegexCache = new WeakMap<object, RegExp>();
+
+/**
+ * Cumulative hash boundaries for a split, one per variant, in variant-index
+ * order. Variant `i` is served for hashes in `[boundaries[i-1], boundaries[i])`.
+ */
+function getSplitBoundaries(outcome: Packed.SplitOutcome): number[] {
+  const cached = splitBoundariesCache.get(outcome);
+  if (cached) return cached;
+  const total = sum(outcome.weights);
+  const boundaries: number[] = [];
+  let cumulative = 0;
+  for (const weight of outcome.weights) {
+    cumulative += weight;
+    boundaries.push(hashBoundary(cumulative, total));
+  }
+  splitBoundariesCache.set(outcome, boundaries);
+  return boundaries;
+}
 
 function getCompiledRegex(rhs: { pattern: string; flags: string }): RegExp {
   const cached = compiledRegexCache.get(rhs);
@@ -357,9 +397,10 @@ function handleSegmentOutcome<T>(
 
       // bypass hashing for common values and edges
       if (outcome.passPromille <= 0) return false;
-      if (outcome.passPromille >= SPLIT_BUCKET_COUNT) return true;
+      if (outcome.passPromille >= PROMILLE_SCALE) return true;
 
-      return splitBucket(lhs, params.definition.seed) < outcome.passPromille;
+      const bucket = hashInput(lhs, params.definition.seed);
+      return bucket < hashBoundary(outcome.passPromille, PROMILLE_SCALE);
     }
     default: {
       const { type } = outcome;
@@ -422,18 +463,12 @@ function handleOutcome<T>(
         };
       }
 
-      const bucket = splitBucket(lhs, params.definition.seed);
-      const total = sum(outcome.weights);
+      const bucket = hashInput(lhs, params.definition.seed);
+      const boundaries = getSplitBoundaries(outcome);
 
-      // Walk the weights in variant-index order and return the first variant
-      // whose cumulative weight covers the bucket. The comparison is
-      // cross-multiplied to stay in integer arithmetic (no floats, no rounding):
-      //   bucket / SPLIT_BUCKET_COUNT < cumulative / total
-      //   ⟺ bucket * total < cumulative * SPLIT_BUCKET_COUNT
-      let cumulative = 0;
-      for (let index = 0; index < outcome.weights.length; index++) {
-        cumulative += outcome.weights[index] as number;
-        if (bucket * total < cumulative * SPLIT_BUCKET_COUNT) {
+      // Return the first variant whose cumulative boundary covers the bucket.
+      for (let index = 0; index < boundaries.length; index++) {
+        if (bucket < (boundaries[index] as number)) {
           return {
             ...getVariant<T>(params.definition, index),
             outcomeType: OutcomeType.SPLIT,
@@ -441,7 +476,8 @@ function handleOutcome<T>(
         }
       }
 
-      // Only reached when the weights sum to 0 (no bucket claims any traffic).
+      // Only reached when the weights sum to 0 (every boundary is NaN, so no
+      // bucket claims any traffic).
       return {
         ...defaultOutcome,
         outcomeType: OutcomeType.SPLIT,
@@ -491,7 +527,7 @@ function handleOutcome<T>(
           break;
         }
       }
-      if (exhausted) currentPromille = 100_000;
+      if (exhausted) currentPromille = PROMILLE_SCALE;
 
       // short-circuit common edges
       if (currentPromille <= 0) {
@@ -504,35 +540,36 @@ function handleOutcome<T>(
         params.definition,
         outcome.rollToVariant,
       );
-      if (currentPromille >= 100_000) {
+      if (currentPromille >= PROMILLE_SCALE) {
         return {
           ...rollToVariant,
           outcomeType: OutcomeType.ROLLOUT,
         };
       }
 
-      const bucket = splitBucket(lhs, params.definition.seed);
+      const bucket = hashInput(lhs, params.definition.seed);
 
       // A rollout at promille `p` is exactly the split
-      // { rollFromVariant: SPLIT_BUCKET_COUNT - p, rollToVariant: p }, laid out
-      // with the same integer bucketing. So rollTo occupies the low buckets
-      // `[0, p)` when it is the lower-index variant (matching where the split
-      // would place it), otherwise rollFrom holds the low buckets and rollTo
-      // takes the top `[SPLIT_BUCKET_COUNT - p, SPLIT_BUCKET_COUNT)`. Because
-      // `p` is already expressed out of SPLIT_BUCKET_COUNT and the bucket space
-      // is exactly SPLIT_BUCKET_COUNT wide, every bucket is assigned and the
-      // boundary matches the split bucket-for-bucket — switching outcome type
-      // reassigns nobody.
+      // { rollFromVariant: PROMILLE_SCALE - p, rollToVariant: p }, laid out with
+      // the same hashBoundary cut points. So rollTo occupies the low buckets
+      // `[0, boundary(p))` when it is the lower-index variant (matching where the
+      // split would place it), otherwise rollFrom holds the low buckets and
+      // rollTo takes the top. Sharing hashBoundary with the split path is what
+      // makes the two bit-for-bit identical, so switching outcome type reassigns
+      // nobody.
       if (outcome.rollToVariant < outcome.rollFromVariant) {
+        const rollToBoundary = hashBoundary(currentPromille, PROMILLE_SCALE);
         return {
-          ...(bucket < currentPromille ? rollToVariant : rollFromVariant),
+          ...(bucket < rollToBoundary ? rollToVariant : rollFromVariant),
           outcomeType: OutcomeType.ROLLOUT,
         };
       }
+      const rollFromBoundary = hashBoundary(
+        PROMILLE_SCALE - currentPromille,
+        PROMILLE_SCALE,
+      );
       return {
-        ...(bucket < SPLIT_BUCKET_COUNT - currentPromille
-          ? rollFromVariant
-          : rollToVariant),
+        ...(bucket < rollFromBoundary ? rollFromVariant : rollToVariant),
         outcomeType: OutcomeType.ROLLOUT,
       };
     }

--- a/packages/vercel-flags-core/src/integration.test.ts
+++ b/packages/vercel-flags-core/src/integration.test.ts
@@ -288,8 +288,8 @@ describe('integration evaluate', () => {
       const falseCount = results.filter((r) => !r.value).length;
 
       // both should be close to 500
-      expect(trueCount).toBe(5070);
-      expect(falseCount).toBe(4930);
+      expect(trueCount).toBe(5023);
+      expect(falseCount).toBe(4977);
     });
 
     it('should split roughly equally on a 50/50 split', () => {
@@ -323,8 +323,8 @@ describe('integration evaluate', () => {
       const falseCount = results.filter((r) => !r.value).length;
 
       // both should be close to 100 (1%)
-      expect(trueCount).toBe(102);
-      expect(falseCount).toBe(9898);
+      expect(trueCount).toBe(118);
+      expect(falseCount).toBe(9882);
     });
 
     it('should split roughly equally on a 50/50 split', () => {
@@ -358,8 +358,8 @@ describe('integration evaluate', () => {
       const falseCount = results.filter((r) => !r.value).length;
 
       // both should be close to 9900 (99%)
-      expect(trueCount).toBe(9891);
-      expect(falseCount).toBe(109);
+      expect(trueCount).toBe(9903);
+      expect(falseCount).toBe(97);
     });
   });
 });


### PR DESCRIPTION
## What & why

Splits and rollouts hashed users into buckets with **opposite conventions**, so the same user could get a different variant depending on whether a flag was expressed as a split or a rollout. Switching a flag between the two (or "locking in" a rollout as a split) reassigned users even though the effective distribution was unchanged.

## Changes

- Unified splits, rollouts, and segment splits onto a **single shared boundary function** (`boundaryFor`) over the full `2**32` hash space — a rollout at promille `p` is now bit-for-bit identical to the equivalent split, so switching outcome type reassigns nobody.
- Dropped the `% 100_000` / float-scaling approaches: no modulo bias, and no off-by-one edge where the top-of-range hash fell through to the default.
- Removed the now-dead `findWeightedIndex` / `getScaledWeights` helpers; split boundaries are precomputed once per outcome (integer, allocation-free per eval).

## Reassignment impact

- **Splits: effectively unchanged** — verified 0 differences over 12M evaluations; only a handful of exact boundary hash values differ (the top-of-range value now maps to a real variant instead of the default).
- **Rollouts & segment splits: one-time re-bucketing on release** (acceptable), after which conversions never reassign.