### PR TITLE
docs: navbar/OSS dropdown update + hero-text select flicker fix

### DIFF
--- a/apps/docs/app/[lang]/home/[code]/toggles.tsx
+++ b/apps/docs/app/[lang]/home/[code]/toggles.tsx
@@ -150,7 +150,12 @@ export const FlagSelect = ({
           }}
         >
           <SelectTrigger id={flagKey} className="mt-1.5 w-full">
-            <SelectValue placeholder="Select an option" />
+            {/* Render the label as children so it is present in the
+                server-rendered HTML. Radix otherwise injects the selected
+                label via a client-only portal, which flickers on reload. */}
+            <SelectValue placeholder="Select an option">
+              {override === null ? value : override}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             {options?.map((option) => (

--- a/apps/docs/lib/geistdocs/config.tsx
+++ b/apps/docs/lib/geistdocs/config.tsx
@@ -22,7 +22,7 @@ import {
 
 // geistdocs' default OSS products, minus Flags SDK (this site).
 const navbarOssProducts: GeistdocsNavbarOssProduct[] = [
-  { href: "https://eve.dev/", logo: <LogoEve height={12} /> },
+  { href: "https://eve.dev/docs", logo: <LogoEve height={12} /> },
   { href: "https://ai-sdk.dev/", logo: <LogoAiSdk height={12} /> },
   { href: "https://chat-sdk.dev/", logo: <LogoChatSdk height={20} /> },
   { href: "https://workflow-sdk.dev/", logo: <LogoWorkflowSdk height={12} /> },

--- a/apps/docs/lib/geistdocs/config.tsx
+++ b/apps/docs/lib/geistdocs/config.tsx
@@ -1,4 +1,12 @@
-import { defineConfig } from "@vercel/geistdocs/config";
+import { LogoAiElements } from "@vercel/geistdocs/assets/logos/logo-ai-elements";
+import { LogoAiSdk } from "@vercel/geistdocs/assets/logos/logo-ai-sdk";
+import { LogoChatSdk } from "@vercel/geistdocs/assets/logos/logo-chat-sdk";
+import { LogoEve } from "@vercel/geistdocs/assets/logos/logo-eve";
+import { LogoWorkflowSdk } from "@vercel/geistdocs/assets/logos/logo-workflow-sdk";
+import {
+  defineConfig,
+  type GeistdocsNavbarOssProduct,
+} from "@vercel/geistdocs/config";
 import {
   agent,
   basePath,
@@ -12,6 +20,15 @@ import {
   translations,
 } from "@/geistdocs";
 
+// geistdocs' default OSS products, minus Flags SDK (this site).
+const navbarOssProducts: GeistdocsNavbarOssProduct[] = [
+  { href: "https://eve.dev/", logo: <LogoEve height={12} /> },
+  { href: "https://ai-sdk.dev/", logo: <LogoAiSdk height={12} /> },
+  { href: "https://chat-sdk.dev/", logo: <LogoChatSdk height={20} /> },
+  { href: "https://workflow-sdk.dev/", logo: <LogoWorkflowSdk height={12} /> },
+  { href: "https://elements.ai-sdk.dev/", logo: <LogoAiElements height={12} /> },
+];
+
 export const config = defineConfig({
   title,
   agent,
@@ -19,6 +36,7 @@ export const config = defineConfig({
   logo: <Logo />,
   github,
   nav,
+  navbarOssProducts,
   basePath,
   siteId,
   translations,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^1.6.1",
-    "@vercel/geistdocs": "1.7.3",
+    "@vercel/geistdocs": "1.8.0",
     "@vercel/speed-insights": "^1.3.1",
     "@vercel/toolbar": "0.1.36",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^1.6.1
         version: 1.6.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.41.3)(vite@6.4.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1)))(svelte@5.41.3)(typescript@5.9.3)(vite@6.4.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1)))(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(svelte@5.41.3)
       '@vercel/geistdocs':
-        specifier: 1.7.3
-        version: 1.7.3(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)(unified@11.0.5)(vite@6.4.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))
+        specifier: 1.8.0
+        version: 1.8.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)(unified@11.0.5)(vite@6.4.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))
       '@vercel/speed-insights':
         specifier: ^1.3.1
         version: 1.3.1(@sveltejs/kit@2.53.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.41.3)(vite@6.4.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1)))(svelte@5.41.3)(typescript@5.9.3)(vite@6.4.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1)))(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(svelte@5.41.3)
@@ -5310,8 +5310,8 @@ packages:
       '@aws-sdk/credential-provider-web-identity':
         optional: true
 
-  '@vercel/geistdocs@1.7.3':
-    resolution: {integrity: sha512-8KwaEseESWmlwNS5M/Bv7vt6g+Oz2o2Rz501156inkOBKoubZxWLxEKkPbEYTkBXblYUDahK0WW4N64loDnulA==}
+  '@vercel/geistdocs@1.8.0':
+    resolution: {integrity: sha512-BjVEO73sZ1iYgAYj8T4lGb9nfw27sx2MVzjLPq519Hr3r6S50NFGLdrPFFOZiK4c19AOlM7clpDPn1Ys82d6kw==}
     hasBin: true
     peerDependencies:
       next: 16.2.6
@@ -14050,7 +14050,7 @@ snapshots:
     dependencies:
       '@vercel/oidc': 3.2.0
 
-  '@vercel/geistdocs@1.7.3(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)(unified@11.0.5)(vite@6.4.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))':
+  '@vercel/geistdocs@1.8.0(@svta/cml-cta@1.0.1(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1))(@svta/cml-structured-field-values@1.0.1(@svta/cml-utils@1.0.1))(@svta/cml-utils@1.0.1)(@types/mdast@4.0.4)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(micromark-util-types@2.0.2)(micromark@4.0.2)(next@16.2.6(@opentelemetry/api@1.9.0)(@playwright/test@1.58.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)(unified@11.0.5)(vite@6.4.1(@types/node@24.10.13)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))':
     dependencies:
       '@ai-sdk/react': 3.0.208(react@19.2.4)(zod@4.3.6)
       '@clack/prompts': 0.11.0


### PR DESCRIPTION
## Summary
- Update docs to `@vercel/geistdocs` 1.8.0 and drop Flags from the OSS dropdown
- Link eve to `/docs` in the OSS dropdown
- Fix hero-text `Select` label flickering on reload on the homepage

## Hero-text flicker fix
Radix `Select` injects the selected option's label into the trigger via a client-only portal, so the statically prerendered homepage shipped an **empty** trigger and the label popped in only after hydration — a visible flicker on every reload. The label is now rendered as `SelectValue` children so it is present in the server HTML (which also disables the portal path via `valueNodeHasChildren`). The optimistic override is preserved.

## Test plan
- [ ] Hard-reload a homepage `[code]` with a non-default hero text selected; the switcher label is present in view-source and no longer flickers
- [ ] Toggling the select still updates the headline and persists across reloads