### PR TITLE
fix(docs): prevent hero-text Select label flicker on reload

### DIFF
--- a/apps/docs/app/[lang]/home/[code]/toggles.tsx
+++ b/apps/docs/app/[lang]/home/[code]/toggles.tsx
@@ -148,7 +148,9 @@ export const FlagSelect = ({
           }}
         >
           <SelectTrigger id={flagKey} className="mt-1.5 w-full">
-            <SelectValue placeholder="Select an option" />
+            <SelectValue placeholder="Select an option">
+              {override === null ? value : override}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             {options?.map((option) => (


### PR DESCRIPTION
## Summary
Fixes the homepage hero-text switcher flickering on reload.

| **Before**  | **After** |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/581a711f-ea28-43fd-85e6-58e9d5a35ada" />  | <video src="https://github.com/user-attachments/assets/9585e3cc-0354-4c1a-9b7c-0d1eae0da4b4" />  |
