### PR TITLE
[flags] allow passing request when invoking flag

### DIFF
--- a/.changeset/next-request-direct.md
+++ b/.changeset/next-request-direct.md
@@ -1,0 +1,7 @@
+---
+"flags": patch
+---
+
+Allow passing a `NextRequest` / Web `Request` directly to `flag(req)` and `evaluate(flags, req)` outside App Router (e.g. in routing middleware).
+
+Previously only a Pages Router `IncomingMessage`, or a manually-flattened headers object, worked when calling a flag directly — passing a `NextRequest` produced empty headers because it wasn't recognized as already having a `Headers` instance.

--- a/packages/flags/src/next/evaluate.ts
+++ b/packages/flags/src/next/evaluate.ts
@@ -20,7 +20,7 @@ import type {
 } from '../types';
 import { isInternalNextError } from './is-internal-next-error';
 import { getOverrides } from './overrides';
-import type { Flag, PagesRouterRequest } from './types';
+import type { Flag, FlagRequest } from './types';
 
 // Internal markers stamped on the flag api by `flag()`. Read by `evaluate()`
 // to partition flags into adapter groups.
@@ -93,7 +93,11 @@ const identifyArgsMap = new WeakMap<
 /**
  * Transforms IncomingHttpHeaders to Headers
  */
-function transformToHeaders(incomingHeaders: IncomingHttpHeaders): Headers {
+function transformToHeaders(
+  incomingHeaders: IncomingHttpHeaders | Headers,
+): Headers {
+  if (incomingHeaders instanceof Headers) return incomingHeaders;
+
   const cached = transformMap.get(incomingHeaders);
   if (cached !== undefined) return cached;
 
@@ -319,9 +323,9 @@ type Run<ValueType, EntitiesType> = (options: {
     | FlagDeclaration<ValueType, EntitiesType>['identify']
     | EntitiesType;
   /**
-   * For Pages Router only
+   * For use outside App Router only, e.g. Pages Router or routing middleware
    */
-  request?: PagesRouterRequest;
+  request?: FlagRequest;
 }) => Promise<ValueType>;
 
 /**
@@ -344,7 +348,7 @@ export function getRun<ValueType, EntitiesType>(
     let overrides: Record<string, any> | null;
 
     if (options.request) {
-      // pages router
+      // pages router, or a NextRequest / Web Request (e.g. routing middleware)
       const headers = transformToHeaders(options.request.headers);
       readonlyHeaders = sealHeaders(headers);
       readonlyCookies = sealCookies(headers);
@@ -416,7 +420,7 @@ export function getRun<ValueType, EntitiesType>(
 // naked type parameter — hence the helper.
 type BulkValue<F> = F extends Flag<infer V, any> ? V : never;
 
-type EvaluateRequest = PagesRouterRequest | Request;
+type EvaluateRequest = FlagRequest;
 
 /**
  * Resolves a set of flags in a single call.

--- a/packages/flags/src/next/index.test.ts
+++ b/packages/flags/src/next/index.test.ts
@@ -1243,6 +1243,19 @@ describe('evaluate', () => {
       expect(decideMock).toHaveBeenCalledTimes(1);
       socket.destroy();
     });
+
+    it('accepts a web Request (NextRequest) passed directly to flag(req)', async () => {
+      const decideMock = vi.fn(({ cookies }) => cookies.get('flag')?.value);
+      const a = flag<string | undefined>({ key: 'a', decide: decideMock });
+
+      mocks.headers.mockClear();
+      const webRequest = new Request('http://example.com/', {
+        headers: { cookie: 'flag=on' },
+      });
+
+      await expect(a(webRequest)).resolves.toEqual('on');
+      expect(mocks.headers).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/flags/src/next/index.ts
+++ b/packages/flags/src/next/index.ts
@@ -142,12 +142,14 @@ export function flag<
         }
       }
 
-      // check if we're using the flag in pages router
+      // check if we're being called with a request (Pages Router
+      // IncomingMessage, or a NextRequest / Web Request from routing
+      // middleware)
       //
       // ideally we'd check args[0] instanceof IncomingMessage, but that leads
       // to build time errors in the host application due to Edge Runtime,
-      // so we check for headers on the first arg instead, which indicates an
-      // IncomingMessage
+      // so we check for headers on the first arg instead, which indicates a
+      // request object
       if (args[0] && typeof args[0] === 'object' && 'headers' in args[0]) {
         const [request] = args as Parameters<
           PagesRouterFlag<ValueType, EntitiesType>

--- a/packages/flags/src/next/types.ts
+++ b/packages/flags/src/next/types.ts
@@ -14,6 +14,13 @@ export type PagesRouterRequest = IncomingMessage & {
 };
 
 /**
+ * The request shapes accepted by `flag(req)` and `evaluate(flags, req)` outside
+ * of App Router: a Pages Router `IncomingMessage`, or a `NextRequest` / Web
+ * `Request` (e.g. from routing middleware).
+ */
+export type FlagRequest = PagesRouterRequest | Request;
+
+/**
  * Metadata on a feature flag function
  */
 type FlagMeta<ValueType, EntitiesType> = {
@@ -75,7 +82,7 @@ type FlagMeta<ValueType, EntitiesType> = {
     identify:
       | FlagDeclaration<ValueType, EntitiesType>['identify']
       | EntitiesType;
-    request?: PagesRouterRequest;
+    request?: FlagRequest;
   }) => Promise<ValueType>;
 };
 
@@ -84,7 +91,7 @@ export type AppRouterFlag<ValueType, EntitiesType> =
 
 export type PagesRouterFlag<ValueType, EntitiesType> = {
   (): never;
-  (request: PagesRouterRequest): Promise<ValueType>;
+  (request: FlagRequest): Promise<ValueType>;
 } & FlagMeta<ValueType, EntitiesType>;
 
 export type PrecomputedFlag<ValueType, EntitiesType> = {


### PR DESCRIPTION
Allow passing a `NextRequest` / Web Request directly to `flag(req)` and `evaluate(flags, req)` outside App Router (e.g. in routing middleware).

Previously only a Pages Router `IncomingMessage`, or a manually-flattened headers object, worked when calling a flag directly — passing a `NextRequest` produced empty headers because it wasn't recognized as already having a `Headers` instance.



Previously it would only work if the request was not passed at all, as it would call `headers()` behind the scenes

```
export async function proxy() {
  const flagValue = await testFlag()
}
```

Now the SDK also supports passing the request directly:

```
export async function proxy(req: NextRequest) {
  const flagValue = await testFlag(req)
}
```