### PR TITLE
manual 304s

### DIFF
--- a/.changeset/manual-304-etag.md
+++ b/.changeset/manual-304-etag.md
@@ -1,0 +1,5 @@
+---
+"flags": patch
+---
+
+Replace `cache-control: no-store` on the flags discovery endpoint with a self-handled conditional request (ETag / If-None-Match). This allows clients to send `304 Not Modified` requests while guaranteeing the `x-flags-sdk-version` header is always present, since the SDK generates the 304 response itself instead of relying on an upstream cache.

--- a/packages/flags/src/lib/compute-etag.ts
+++ b/packages/flags/src/lib/compute-etag.ts
@@ -1,0 +1,15 @@
+/**
+ * Computes a short, non-cryptographic ETag for a string body using FNV-1a hashing.
+ *
+ * Used to support conditional requests (If-None-Match / 304) on endpoints that
+ * must always return certain headers, since we generate the 304 ourselves
+ * instead of relying on an upstream cache to do it (which may drop headers).
+ */
+export function computeEtag(body: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < body.length; i++) {
+    hash ^= body.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `"${(hash >>> 0).toString(36)}-${body.length}"`;
+}

--- a/packages/flags/src/next/create-flags-discovery-endpoint.ts
+++ b/packages/flags/src/next/create-flags-discovery-endpoint.ts
@@ -2,6 +2,7 @@
 // the real next/server would prevent flags/next from working in Pages Router.
 import type { NextRequest } from 'next/server';
 import { version } from '..';
+import { computeEtag } from '../lib/compute-etag';
 import { verifyAccess } from '../lib/verify-access';
 import type { ApiData } from '../types';
 
@@ -27,12 +28,24 @@ export function createFlagsDiscoveryEndpoint(
     if (!access) return Response.json(null, { status: 401 });
 
     const apiData = await getApiData(request);
-    return new Response(JSON.stringify(apiData), {
-      headers: {
-        'x-flags-sdk-version': version,
-        'content-type': 'application/json',
-        'cache-control': 'no-store',
-      },
+    const body = JSON.stringify(apiData);
+    const etag = computeEtag(body);
+
+    // We handle conditional requests ourselves, rather than relying on an
+    // upstream cache to generate the 304, so we can guarantee
+    // x-flags-sdk-version is always present, even on a 304 response.
+    const headers: Record<string, string> = {
+      'x-flags-sdk-version': version,
+      'cache-control': 'no-cache',
+      etag,
+    };
+
+    if (request.headers.get('if-none-match') === etag) {
+      return new Response(null, { status: 304, headers });
+    }
+
+    return new Response(body, {
+      headers: { ...headers, 'content-type': 'application/json' },
     });
   };
 }

--- a/packages/flags/src/sveltekit/index.ts
+++ b/packages/flags/src/sveltekit/index.ts
@@ -3,7 +3,6 @@ import { RequestCookies } from '@edge-runtime/cookies';
 import {
   error,
   type Handle,
-  json,
   type RequestEvent,
   type RequestHandler,
 } from '@sveltejs/kit';
@@ -22,6 +21,7 @@ import {
   verifyAccess,
   version,
 } from '..';
+import { computeEtag } from '../lib/compute-etag';
 import { normalizeOptions } from '../lib/normalize-options';
 import {
   HeadersAdapter,
@@ -360,8 +360,24 @@ async function handleWellKnownFlagsRoute(
   );
   if (!access) return new Response(null, { status: 401 });
   const providerData = getProviderData(flags);
-  return Response.json(providerData, {
-    headers: { 'x-flags-sdk-version': version },
+  const body = JSON.stringify(providerData);
+  const etag = computeEtag(body);
+
+  // We handle conditional requests ourselves, rather than relying on an
+  // upstream cache to generate the 304, so we can guarantee
+  // x-flags-sdk-version is always present, even on a 304 response.
+  const headers: Record<string, string> = {
+    'x-flags-sdk-version': version,
+    'cache-control': 'no-cache',
+    etag,
+  };
+
+  if (event.request.headers.get('if-none-match') === etag) {
+    return new Response(null, { status: 304, headers });
+  }
+
+  return new Response(body, {
+    headers: { ...headers, 'content-type': 'application/json' },
   });
 }
 
@@ -455,7 +471,25 @@ export function createFlagsDiscoveryEndpoint(
     if (!access) error(401);
 
     const apiData = await getApiData(event);
-    return json(apiData, { headers: { 'x-flags-sdk-version': version } });
+    const body = JSON.stringify(apiData);
+    const etag = computeEtag(body);
+
+    // We handle conditional requests ourselves, rather than relying on an
+    // upstream cache to generate the 304, so we can guarantee
+    // x-flags-sdk-version is always present, even on a 304 response.
+    const headers: Record<string, string> = {
+      'x-flags-sdk-version': version,
+      'cache-control': 'no-cache',
+      etag,
+    };
+
+    if (event.request.headers.get('if-none-match') === etag) {
+      return new Response(null, { status: 304, headers });
+    }
+
+    return new Response(body, {
+      headers: { ...headers, 'content-type': 'application/json' },
+    });
   };
 
   return requestHandler;


### PR DESCRIPTION
Replace `cache-control: no-store` on the flags discovery endpoint with a self-handled conditional request (ETag / If-None-Match). This allows clients to send `304 Not Modified` requests while guaranteeing the `x-flags-sdk-version` header is always present, since the SDK generates the 304 response itself instead of relying on an upstream cache.