### PR TITLE
Update exports and changesets

### DIFF
--- a/.changeset/rename-global-config.md
+++ b/.changeset/rename-global-config.md
@@ -1,14 +1,16 @@
 ---
 '@flags-sdk/global-config': minor
-'@flags-sdk/growthbook': major
+'@flags-sdk/growthbook': minor
 '@flags-sdk/hypertune': patch
-'@flags-sdk/launchdarkly': major
+'@flags-sdk/launchdarkly': minor
 '@flags-sdk/posthog': patch
 '@flags-sdk/reflag': patch
-'@flags-sdk/statsig': major
-'flags': major
+'@flags-sdk/statsig': minor
+'flags': minor
 ---
 
 Replace `@vercel/edge-config` with `@vercel/global-config`.
 
 Rename the Edge Config adapter package to `@flags-sdk/global-config` and rename repository-owned Edge Config files, exports, types, options, variables, and environment variables to Global Config.
+
+The previous Edge Config names remain available as deprecated aliases, and the previous environment variables are still honored as fallbacks, so existing code keeps working without changes.

--- a/packages/adapter-growthbook/src/index.ts
+++ b/packages/adapter-growthbook/src/index.ts
@@ -64,9 +64,13 @@ export function createGrowthbookAdapter(options: {
   stickyBucketService?: StickyBucketService;
   /** Provide Global Config details to use the optional Global Config adapter */
   globalConfig?: GlobalConfig;
+  /** @deprecated Use `globalConfig` instead. */
+  edgeConfig?: GlobalConfig;
 }): AdapterResponse {
   let trackingCallback = options.trackingCallback;
   let stickyBucketService = options.stickyBucketService;
+
+  const globalConfig = options.globalConfig ?? options.edgeConfig;
 
   const growthbook = new GrowthBookClient({
     clientKey: options.clientKey,
@@ -74,10 +78,10 @@ export function createGrowthbookAdapter(options: {
     ...(options.clientOptions || {}),
   });
 
-  const globalConfigClient = options.globalConfig
-    ? createClient(options.globalConfig.connectionString)
+  const globalConfigClient = globalConfig
+    ? createClient(globalConfig.connectionString)
     : null;
-  const globalConfigKey = options.globalConfig?.itemKey || options.clientKey;
+  const globalConfigKey = globalConfig?.itemKey || options.clientKey;
 
   const store = new AsyncLocalStorage<WeakKey>();
   const cache = new WeakMap<WeakKey, Promise<FeatureApiResponse | null>>();
@@ -156,7 +160,7 @@ export function createGrowthbookAdapter(options: {
   };
 
   const refresh = async (): Promise<void> => {
-    if (options.globalConfig) {
+    if (globalConfig) {
       const payload = await getGlobalConfigPayload();
       if (payload && payload !== growthbook.getPayload()) {
         await growthbook.setPayload(payload);
@@ -250,8 +254,10 @@ export function resetDefaultGrowthbookAdapter() {
  * - `GROWTHBOOK_API_HOST` - Override the SDK API endpoint for self-hosted users
  * - `GROWTHBOOK_APP_ORIGIN` - Override the application URL for self-hosted users
  * - `GROWTHBOOK_GLOBAL_CONFIG_CONNECTION_STRING` - Global Config connection string
+ * - `GROWTHBOOK_EDGE_CONNECTION_STRING` - deprecated fallback for GROWTHBOOK_GLOBAL_CONFIG_CONNECTION_STRING
  * - `EXPERIMENTATION_CONFIG` - fallback for GROWTHBOOK_GLOBAL_CONFIG_CONNECTION_STRING
  * - `GROWTHBOOK_GLOBAL_CONFIG_ITEM_KEY` - Override the item key for Global Config (defaults to GROWTHBOOK_CLIENT_KEY)
+ * - `GROWTHBOOK_EDGE_CONFIG_ITEM_KEY` - deprecated fallback for GROWTHBOOK_GLOBAL_CONFIG_ITEM_KEY
  */
 export function getOrCreateDefaultGrowthbookAdapter(): AdapterResponse {
   if (defaultGrowthbookAdapter) {
@@ -265,8 +271,11 @@ export function getOrCreateDefaultGrowthbookAdapter(): AdapterResponse {
   const appOrigin = process.env.GROWTHBOOK_APP_ORIGIN;
   const connectionString =
     process.env.GROWTHBOOK_GLOBAL_CONFIG_CONNECTION_STRING ||
+    process.env.GROWTHBOOK_EDGE_CONNECTION_STRING ||
     process.env.EXPERIMENTATION_CONFIG;
-  const itemKey = process.env.GROWTHBOOK_GLOBAL_CONFIG_ITEM_KEY;
+  const itemKey =
+    process.env.GROWTHBOOK_GLOBAL_CONFIG_ITEM_KEY ||
+    process.env.GROWTHBOOK_EDGE_CONFIG_ITEM_KEY;
 
   let globalConfig: GlobalConfig | undefined;
   if (connectionString) {

--- a/packages/adapter-launchdarkly/src/index.ts
+++ b/packages/adapter-launchdarkly/src/index.ts
@@ -40,12 +40,22 @@ export function createLaunchDarklyAdapter({
   projectSlug,
   clientSideId,
   globalConfigConnectionString,
+  edgeConfigConnectionString,
 }: {
   projectSlug: string;
   clientSideId: string;
-  globalConfigConnectionString: string;
+  globalConfigConnectionString?: string;
+  /** @deprecated Use `globalConfigConnectionString` instead. */
+  edgeConfigConnectionString?: string;
 }): AdapterResponse {
-  const globalConfigClient = createClient(globalConfigConnectionString);
+  const connectionString =
+    globalConfigConnectionString ?? edgeConfigConnectionString;
+  if (!connectionString) {
+    throw new Error(
+      'LaunchDarkly Adapter: Missing globalConfigConnectionString',
+    );
+  }
+  const globalConfigClient = createClient(connectionString);
 
   const store = new AsyncLocalStorage<WeakKey>();
   const cache = new WeakMap<WeakKey, Promise<unknown>>();

--- a/packages/adapter-statsig/src/index.ts
+++ b/packages/adapter-statsig/src/index.ts
@@ -57,13 +57,20 @@ export function createStatsigAdapter(options: {
     connectionString: string;
     itemKey: string;
   };
+  /** @deprecated Use `globalConfig` instead. */
+  edgeConfig?: {
+    connectionString: string;
+    itemKey: string;
+  };
 }): AdapterResponse {
+  const globalConfig = options.globalConfig ?? options.edgeConfig;
+
   const initializeStatsig = async (): Promise<void> => {
     let dataAdapter: StatsigOptions['dataAdapter'] | undefined;
-    if (options.globalConfig) {
+    if (globalConfig) {
       dataAdapter = await createGlobalConfigDataAdapter({
-        globalConfigItemKey: options.globalConfig.itemKey,
-        globalConfigConnectionString: options.globalConfig.connectionString,
+        globalConfigItemKey: globalConfig.itemKey,
+        globalConfigConnectionString: globalConfig.connectionString,
       });
     }
 
@@ -101,7 +108,7 @@ export function createStatsigAdapter(options: {
     return user != null && typeof user === 'object';
   };
 
-  const minSyncDelayMs = options.globalConfig ? 1_000 : 5_000;
+  const minSyncDelayMs = globalConfig ? 1_000 : 5_000;
   const syncHandler = createSyncingHandler(minSyncDelayMs);
 
   async function predecide(user?: StatsigUser): Promise<StatsigUser> {

--- a/packages/flags/src/types.ts
+++ b/packages/flags/src/types.ts
@@ -31,6 +31,13 @@ export type Origin =
       globalConfigItemKey?: string;
       teamSlug: string;
     }
+  | {
+      /** @deprecated Use `global-config` instead. */
+      provider: 'edge-config';
+      edgeConfigId: string;
+      edgeConfigItemKey?: string;
+      teamSlug: string;
+    }
   | Record<string, unknown>;
 
 /**


### PR DESCRIPTION
Follow up to https://github.com/vercel/flags/pull/452

Avoids bumping packages as a major by re-exporting the previous types as aliases.