### PR TITLE
Verify flags/next needs no explicit `await connection()`

### DIFF
--- a/apps/docs/content/docs/api-reference/frameworks/next.mdx
+++ b/apps/docs/content/docs/api-reference/frameworks/next.mdx
@@ -41,6 +41,25 @@ export const showSummerSale = flag<boolean>({
 });
 ```
 
+#### Dynamic rendering
+
+You do not need to call [`connection()`](https://nextjs.org/docs/app/api-reference/functions/connection) before evaluating a flag.
+
+Every App Router evaluation awaits `headers()` and `cookies()` before calling `decide`, and those are Request-time APIs, so awaiting a flag already excludes the caller from the prerender. This holds no matter what `decide` does — a value coming from a provider, from `Math.random()`, or from a constant is treated the same way, because the SDK reads the request before `decide` runs. It also holds for repeated evaluations within a request, which are served from a per-request cache keyed by the request itself.
+
+```tsx title="app/page.tsx"
+import { exampleFlag } from '../flags';
+
+export default async function Page() {
+  // no `await connection()` needed, the flag reads the request for you
+  const example = await exampleFlag();
+
+  return <div>{example ? 'Flag is on' : 'Flag is off'}</div>;
+}
+```
+
+Reading a [precomputed](/principles/precompute) value is the deliberate exception. `exampleFlag(code, precomputedFlags)` decodes the value from the signed code instead of reading the request, which is what keeps pages rendering precomputed flags prerenderable.
+
 
 ### `createFlagsDiscoveryEndpoint`
 

--- a/packages/flags/src/next/dynamic-rendering.test.ts
+++ b/packages/flags/src/next/dynamic-rendering.test.ts
@@ -1,0 +1,184 @@
+import { IncomingMessage } from 'node:http';
+import type { Socket } from 'node:net';
+import { Readable } from 'node:stream';
+import type { NextApiRequestCookies } from 'next/dist/server/api-utils';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { encryptOverrides } from '..';
+import { evaluate, flag, precompute } from '.';
+
+/**
+ * These tests pin down *when* the SDK reaches for Next.js' Request-time APIs.
+ *
+ * Awaiting `headers()` / `cookies()` is what opts a caller out of the
+ * prerender, so it is also the reason `flags/next` never needs to call
+ * `await connection()` itself. See
+ * https://nextjs.org/docs/app/api-reference/functions/connection.
+ *
+ * Two invariants are worth keeping:
+ *
+ * - Every App Router evaluation reads the request, including cache hits and
+ *   overrides, so the surrounding render can never stay static by accident.
+ * - Reading a precomputed value reads nothing, so precomputed pages stay
+ *   prerenderable.
+ */
+
+const mocks = vi.hoisted(() => {
+  return {
+    headers: vi.fn(() => new Headers()),
+    cookies: vi.fn(() => ({
+      get: vi.fn(),
+    })),
+  };
+});
+
+vi.mock('next/headers', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('next/headers')>();
+  return {
+    ...mod,
+    headers: mocks.headers,
+    cookies: mocks.cookies,
+  };
+});
+
+function createRequest(cookies: Record<string, string> = {}) {
+  const socket = new Readable();
+  const request = new IncomingMessage(
+    socket as unknown as Socket,
+  ) as IncomingMessage & { cookies: NextApiRequestCookies };
+  request.cookies = cookies;
+  request.headers.cookie = Object.entries(cookies)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('; ');
+  return request;
+}
+
+describe('dynamic rendering', () => {
+  beforeAll(() => {
+    // a random secret for testing purposes
+    process.env.FLAGS_SECRET = 'yuhyxaVI0Zue85SguKlMIUQojvJyBPzm95fFYvOa4Rc';
+  });
+
+  beforeEach(() => {
+    // A fresh headers instance per test, but a stable one within a test, so
+    // repeated evaluations hit the per-request evaluation cache.
+    const requestHeaders = new Headers();
+    mocks.headers.mockReset();
+    mocks.headers.mockImplementation(() => requestHeaders);
+    mocks.cookies.mockReset();
+    mocks.cookies.mockImplementation(() => ({ get: vi.fn() }));
+  });
+
+  describe('app router', () => {
+    it('reads headers and cookies when evaluating a flag', async () => {
+      const f = flag<boolean>({ key: 'read-request', decide: () => true });
+
+      await expect(f()).resolves.toBe(true);
+
+      expect(mocks.headers).toHaveBeenCalledTimes(1);
+      expect(mocks.cookies).toHaveBeenCalledTimes(1);
+    });
+
+    it('reads headers and cookies even when the decision is not request-dependent', async () => {
+      // The guarantee comes from the SDK, not from the decide function, so a
+      // flag which ignores the request must still opt the caller out of the
+      // prerender.
+      const f = flag<number>({ key: 'no-request-usage', decide: () => 42 });
+
+      await expect(f()).resolves.toBe(42);
+
+      expect(mocks.headers).toHaveBeenCalledTimes(1);
+      expect(mocks.cookies).toHaveBeenCalledTimes(1);
+    });
+
+    it('reads headers and cookies again when serving a cached value', async () => {
+      const decide = vi.fn(() => true);
+      const f = flag<boolean>({ key: 'cached', decide });
+
+      await expect(f()).resolves.toBe(true);
+      await expect(f()).resolves.toBe(true);
+
+      // second call was served from the per-request cache …
+      expect(decide).toHaveBeenCalledTimes(1);
+      // … and still went through the Request-time APIs to get there
+      expect(mocks.headers).toHaveBeenCalledTimes(2);
+      expect(mocks.cookies).toHaveBeenCalledTimes(2);
+    });
+
+    it('reads headers and cookies when an override short-circuits the decision', async () => {
+      const override = await encryptOverrides({ overridden: true });
+      mocks.cookies.mockImplementation(() => ({
+        get: vi.fn((cookieName: string) =>
+          cookieName === 'vercel-flag-overrides'
+            ? { name: 'vercel-flag-overrides', value: override }
+            : undefined,
+        ),
+      }));
+      const decide = vi.fn(() => false);
+      const f = flag<boolean>({ key: 'overridden', decide });
+
+      await expect(f()).resolves.toBe(true);
+
+      expect(decide).not.toHaveBeenCalled();
+      expect(mocks.headers).toHaveBeenCalledTimes(1);
+      expect(mocks.cookies).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('evaluate', () => {
+    it('reads headers and cookies once for the whole batch', async () => {
+      const a = flag<boolean>({ key: 'batch-a', decide: () => true });
+      const b = flag<boolean>({ key: 'batch-b', decide: () => false });
+
+      await expect(evaluate([a, b])).resolves.toEqual([true, false]);
+
+      expect(mocks.headers).toHaveBeenCalledTimes(1);
+      expect(mocks.cookies).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not read headers or cookies for an empty batch', async () => {
+      // `precompute([])` must keep working outside of a request scope, so an
+      // empty batch must not force dynamic rendering either.
+      await expect(evaluate([])).resolves.toEqual([]);
+
+      expect(mocks.headers).not.toHaveBeenCalled();
+      expect(mocks.cookies).not.toHaveBeenCalled();
+    });
+
+    it('does not read headers or cookies when a request is passed', async () => {
+      const f = flag<boolean>({ key: 'batch-request', decide: () => true });
+
+      await expect(evaluate([f], createRequest())).resolves.toEqual([true]);
+
+      expect(mocks.headers).not.toHaveBeenCalled();
+      expect(mocks.cookies).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('precomputed values', () => {
+    it('does not read headers or cookies', async () => {
+      const f = flag<boolean>({ key: 'precomputed', decide: () => true });
+      const code = await precompute([f]);
+
+      mocks.headers.mockClear();
+      mocks.cookies.mockClear();
+
+      await expect(f(code, [f])).resolves.toBe(true);
+
+      // Reading a precomputed value must stay prerenderable — that is the
+      // point of the precompute pattern.
+      expect(mocks.headers).not.toHaveBeenCalled();
+      expect(mocks.cookies).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pages router', () => {
+    it('does not read from next/headers', async () => {
+      const f = flag<boolean>({ key: 'pages-router', decide: () => true });
+
+      await expect(f(createRequest())).resolves.toBe(true);
+
+      expect(mocks.headers).not.toHaveBeenCalled();
+      expect(mocks.cookies).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/flags/src/next/evaluate.ts
+++ b/packages/flags/src/next/evaluate.ts
@@ -222,6 +222,12 @@ function shouldReportValue(definition: FlagInfo<any>): boolean {
  * → cache write → reportValue. Override and cache writes write to the same
  * `evaluationCache` either path uses, so a subsequent `flagFn()` in the same
  * request hits cache regardless of which path populated it.
+ *
+ * Note on dynamic rendering: the per-request cache is keyed by the sealed
+ * headers object, so reaching a cache hit requires having read `headers()`
+ * (App Router) or having been handed a request. A cache read can therefore
+ * never be the thing that keeps a render static, and needs no separate
+ * `connection()` call of its own.
  */
 async function applyResult<ValueType>(args: {
   definition: FlagInfo<ValueType>;
@@ -331,6 +337,19 @@ type Run<ValueType, EntitiesType> = (options: {
 /**
  * Builds the runtime function used by a single flag. Handles Pages Router,
  * App Router, and reuse of pre-read data when called from inside `evaluate()`.
+ *
+ * Dynamic rendering: every branch below reaches request-scoped data before it
+ * decides, either through `next/headers` or through a request handed in by the
+ * caller. `headers()` and `cookies()` are Request-time APIs, so awaiting them
+ * already excludes the caller from the prerender — exactly what an explicit
+ * `await connection()` would do. Adding `connection()` on top would mean
+ * importing `next/server` (which `flags/next` deliberately avoids at the top
+ * level so it keeps working in Pages Router) and awaiting one more promise per
+ * evaluation, with no change in behavior.
+ *
+ * See https://nextjs.org/docs/app/api-reference/functions/connection: the
+ * function "is only necessary when dynamic rendering is required and common
+ * Request-time APIs are not used".
  */
 export function getRun<ValueType, EntitiesType>(
   definition: ResolvedFlagDeclaration<ValueType, EntitiesType>,
@@ -349,6 +368,11 @@ export function getRun<ValueType, EntitiesType>(
 
     if (options.request) {
       // pages router, or a NextRequest / Web Request (e.g. routing middleware)
+      //
+      // No `connection()` here: the caller already holds a request, so the
+      // surrounding context is request-scoped by definition, and `connection()`
+      // is an App Router API that has no meaning in Pages Router or routing
+      // middleware.
       const headers = transformToHeaders(options.request.headers);
       readonlyHeaders = sealHeaders(headers);
       readonlyCookies = sealCookies(headers);
@@ -357,6 +381,9 @@ export function getRun<ValueType, EntitiesType>(
       overrides = await readOverrides(readonlyCookies);
     } else if (bulkData) {
       // app router — evaluate() mode, everything pre-read
+      //
+      // `evaluate()` performed the request-time read (or was handed a request)
+      // before entering the store, so this branch inherits its dynamic opt-in.
       readonlyHeaders = bulkData.headers;
       readonlyCookies = bulkData.cookies;
       dedupeCacheKey = bulkData.dedupeCacheKey;
@@ -373,6 +400,8 @@ export function getRun<ValueType, EntitiesType>(
       if (!headersModule) headersModule = await headersModulePromise;
       const { headers, cookies } = headersModule;
 
+      // Awaiting these two Request-time APIs is what opts the caller out of
+      // the prerender, so no explicit `await connection()` is needed here.
       const [headersStore, cookiesStore] = await Promise.all([
         headers(),
         cookies(),
@@ -478,7 +507,8 @@ async function evaluateImpl(
   // Skip the `next/headers` read when there's nothing to evaluate. This also
   // lets `precompute([])` return `__no_flags__` outside a request scope (e.g.
   // during static generation), which is the documented behavior of an empty
-  // precompute group.
+  // precompute group. For the same reason this must not call `connection()`:
+  // an empty batch reads nothing from the request and must stay prerenderable.
   if (
     Array.isArray(flags) ? flags.length === 0 : Object.keys(flags).length === 0
   ) {
@@ -507,6 +537,9 @@ async function evaluateImpl(
     if (!headersModule) headersModule = await headersModulePromise;
     const { headers, cookies } = headersModule;
 
+    // One request-time read for the whole batch. As in `getRun`, awaiting
+    // these Request-time APIs opts the caller out of the prerender, so an
+    // extra `await connection()` here would only add a promise per batch.
     const [headersStore, cookiesStore] = await Promise.all([
       headers(),
       cookies(),

--- a/packages/flags/src/next/index.ts
+++ b/packages/flags/src/next/index.ts
@@ -126,6 +126,13 @@ export function flag<
       setSpanAttribute('method', 'decided');
 
       // the flag was precomputed, works for both App Router and Pages Router
+      //
+      // This branch reads nothing from the request — the value is decoded from
+      // the signed code the caller passes in. It must therefore stay free of
+      // Request-time APIs and of `await connection()`, as keeping the page
+      // prerenderable is the entire point of the precompute pattern. See
+      // `tests/next-16/app/app-router-precomputed`, whose page Next.js reports
+      // as prerendered in the build output.
       if (typeof args[0] === 'string' && Array.isArray(args[1])) {
         const [precomputedCode, precomputedGroup, secret] = args as Parameters<
           PrecomputedFlag<ValueType, EntitiesType>
@@ -159,6 +166,10 @@ export function flag<
       }
 
       // the flag is being used in app router
+      //
+      // `run` awaits `headers()` and `cookies()` here, which is what makes the
+      // caller dynamic. No `await connection()` is needed on top of that — see
+      // the note on `getRun` in `./evaluate.ts`.
       return run({ identify, request: undefined });
     },
     {

--- a/skills/flags-sdk/references/nextjs.md
+++ b/skills/flags-sdk/references/nextjs.md
@@ -93,6 +93,13 @@ export default async function Page() {
 }
 ```
 
+Do not add `await connection()` before evaluating a flag. Every App Router
+evaluation awaits `headers()` and `cookies()` before calling `decide`, so
+awaiting a flag already excludes the caller from the prerender. Reading a
+precomputed value (`exampleFlag(code, precomputedFlags)`) is the exception: it
+decodes the value from the code rather than reading the request, which is what
+keeps precomputed pages prerenderable.
+
 ## Pages Router
 
 Pass `req` to the flag in `getServerSideProps`:

--- a/tests/next-15/app/app-router-dynamic/page.spec.tsx
+++ b/tests/next-15/app/app-router-dynamic/page.spec.tsx
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+import { port } from '../../port';
+
+/**
+ * `requestScopedFlag` ignores headers and cookies and returns a new value on
+ * every evaluation, so this page can only produce a fresh value per request if
+ * the SDK opted it out of static generation. That is the counterpart to the
+ * "keeps page static" assertion for precomputed pages: reading the request
+ * inside the SDK has the same effect as `await connection()`, so users do not
+ * need to call it themselves.
+ */
+test('evaluates flags per request without an explicit connection()', async ({
+  page,
+}) => {
+  await page.goto(`http://localhost:${port}/app-router-dynamic`);
+  const first = await page
+    .getByTestId('request-scoped-flag')
+    .textContent({ timeout: 10_000 });
+
+  await page.goto(`http://localhost:${port}/app-router-dynamic?cache-bust=1`);
+  const second = await page
+    .getByTestId('request-scoped-flag')
+    .textContent({ timeout: 10_000 });
+
+  expect(first).toMatch(/^Request scoped: .+/);
+  expect(second).not.toBe(first);
+});

--- a/tests/next-15/app/app-router-dynamic/page.tsx
+++ b/tests/next-15/app/app-router-dynamic/page.tsx
@@ -1,0 +1,12 @@
+import { requestScopedFlag } from '../../flags';
+
+/**
+ * Nothing in this page reads the request except the flag itself, yet
+ * `next build` reports the route as `ƒ (Dynamic)`. That is the SDK awaiting
+ * `headers()` and `cookies()` before calling `decide` — no `await connection()`
+ * needed here.
+ */
+export default async function Page() {
+  const value = await requestScopedFlag();
+  return <p data-testid="request-scoped-flag">Request scoped: {value}</p>;
+}

--- a/tests/next-15/flags.tsx
+++ b/tests/next-15/flags.tsx
@@ -19,4 +19,18 @@ export const cookieFlag = flag<string>({
   options: ['no cookie'],
 });
 
+/**
+ * Deliberately does not read `headers` or `cookies`, and resolves to a
+ * different value on every evaluation.
+ *
+ * A page rendering this flag may therefore never be statically generated. The
+ * SDK is what guarantees that: it awaits `headers()` and `cookies()` before
+ * calling `decide`, which is why no `await connection()` is needed in user
+ * land.
+ */
+export const requestScopedFlag = flag<string>({
+  key: 'request-scoped',
+  decide: () => Math.random().toString(36).slice(2),
+});
+
 export const precomputedFlags = [exampleFlag, hostFlag, cookieFlag];

--- a/tests/next-16/app/app-router-dynamic/page.spec.tsx
+++ b/tests/next-16/app/app-router-dynamic/page.spec.tsx
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+import { port } from '../../port';
+
+/**
+ * `requestScopedFlag` ignores headers and cookies and returns a new value on
+ * every evaluation, so this page can only produce a fresh value per request if
+ * the SDK excluded it from the prerender. That is the counterpart to the
+ * "keeps page static" assertion for precomputed pages: reading the request
+ * inside the SDK has the same effect as `await connection()`, so users do not
+ * need to call it themselves.
+ */
+test('evaluates flags per request without an explicit connection()', async ({
+  page,
+}) => {
+  await page.goto(`http://localhost:${port}/app-router-dynamic`);
+  const first = await page
+    .getByTestId('request-scoped-flag')
+    .textContent({ timeout: 10_000 });
+
+  await page.goto(`http://localhost:${port}/app-router-dynamic?cache-bust=1`);
+  const second = await page
+    .getByTestId('request-scoped-flag')
+    .textContent({ timeout: 10_000 });
+
+  expect(first).toMatch(/^Request scoped: .+/);
+  expect(second).not.toBe(first);
+});

--- a/tests/next-16/app/app-router-dynamic/page.tsx
+++ b/tests/next-16/app/app-router-dynamic/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from 'react';
+import { requestScopedFlag } from '../../flags';
+
+/**
+ * With Cache Components enabled, `next build` fails this page with
+ * `next-prerender-random` if the `Math.random()` inside the flag's `decide`
+ * runs before any Request data (`cookies()`, `headers()`, `connection()`, …)
+ * was accessed. The build succeeding is therefore itself an assertion that the
+ * SDK reads the request before deciding — no `await connection()` needed here.
+ */
+async function RequestScoped() {
+  const value = await requestScopedFlag();
+  return <p data-testid="request-scoped-flag">Request scoped: {value}</p>;
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<p>Loading…</p>}>
+      <RequestScoped />
+    </Suspense>
+  );
+}

--- a/tests/next-16/flags.tsx
+++ b/tests/next-16/flags.tsx
@@ -19,4 +19,18 @@ export const cookieFlag = flag<string>({
   options: ['no cookie'],
 });
 
+/**
+ * Deliberately does not read `headers` or `cookies`, and resolves to a
+ * different value on every evaluation.
+ *
+ * A page rendering this flag may therefore never be served from the prerender.
+ * The SDK is what guarantees that: it awaits `headers()` and `cookies()`
+ * before calling `decide`, which is why no `await connection()` is needed in
+ * user land.
+ */
+export const requestScopedFlag = flag<string>({
+  key: 'request-scoped',
+  decide: () => Math.random().toString(36).slice(2),
+});
+
 export const precomputedFlags = [exampleFlag, hostFlag, cookieFlag];


### PR DESCRIPTION
Follow-up to the review request on `vercel/front#80221`: check whether the function returned by `flag()` should `await connection()` anywhere, and add it where it is missing.

**Result: nothing was missing.** Every path that needs request data already reads it, and the paths that do not read it must stay prerenderable. So this PR contains no behavior change — it documents the guarantee and locks it in with tests, since it is the kind of thing a future refactor can silently drop.

## The audit

`connection()` is ["only necessary when dynamic rendering is required and common Request-time APIs are not used"](https://nextjs.org/docs/app/api-reference/functions/connection). Path by path:

| Path | Reads the request? | Verdict |
| --- | --- | --- |
| App Router `flagFn()` | `await Promise.all([headers(), cookies()])` before `decide` | already dynamic |
| `evaluate(flags)` in App Router | same read, once per batch | already dynamic |
| Per-request cache hit / override | cache is keyed by the sealed headers object, so it is only reachable *after* that read | already dynamic |
| Pages Router / routing middleware | caller hands in the request | request-scoped by definition; `connection()` is App Router-only |
| `flagFn(code, precomputeFlags)` | no — value is decoded from the signed code | **must stay static**, that is the point of precompute |
| `evaluate([])` | no — deliberately skips the `next/headers` read so `precompute([])` works during prerender | **must stay static** |

Adding `connection()` to the App Router paths would also mean importing `next/server`, which `flags/next` deliberately avoids at the top level so it keeps working in Pages Router, plus one more awaited promise per evaluation — for no change in behavior.

## What is in the PR

**Comments** at each branch in `getRun`, `evaluateImpl`, `applyResult`, and the precomputed branch of `flag()`, recording why `connection()` is or is not appropriate there.

**Unit tests** (`packages/flags/src/next/dynamic-rendering.test.ts`) asserting which paths touch `headers()`/`cookies()` and which must not — including cache hits, overrides, bulk evaluation, precomputed reads, and Pages Router.

**e2e coverage** in `tests/next-15` and `tests/next-16`: a new `/app-router-dynamic` route rendering `requestScopedFlag`, a flag whose `decide` ignores the request and returns a new value on every evaluation. If the SDK were not reading the request, the page would be baked at build time.

- Next 15 build reports the route as `ƒ (Dynamic)`, while `/app-router-precomputed/[code]` stays `● (SSG)`.
- Next 16 (Cache Components) reports it as `◐ (Partial Prerender)` and streams the flag outside the static shell.
- Both suites assert two requests return different values.

The Next 16 build is the sharpest check of the three. Replacing the flag with a bare `Math.random()` in the same component fails the build with:

> Route "/tmp-counterfactual" used `Math.random()` before accessing either uncached data (e.g. `fetch()`) or Request data (e.g. `cookies()`, `headers()`, `connection()`, and `searchParams`).

With the flag, the build passes — Next.js itself confirms the SDK read Request data before `decide` ran. So if this guarantee ever regresses, `tests/next-16` stops building.

**Docs**: a "Dynamic rendering" section under `flag` in the `flags/next` API reference, and the same note in the flags-sdk skill, so nobody adds `await connection()` in front of a flag evaluation.

## Verification

- `packages/flags`: 126 unit tests pass, `tsc --noEmit` clean.
- `tests/next-15` e2e: 7/7 pass.
- `tests/next-16` e2e: the new test passes. One pre-existing failure, `keeps page static`, expects `x-nextjs-cache: HIT`, which Next 16.2.12 does not emit for that route — reproduced on a pristine `main` checkout, so it is unrelated to this change.
- `biome check` clean on all touched files.

No changeset: no published package changes behavior.
