### PR TITLE
add date support, with explicit now

### DIFF
--- a/.changeset/exp-3256-now-accessor.md
+++ b/.changeset/exp-3256-now-accessor.md
@@ -1,0 +1,9 @@
+---
+'flags': minor
+'@flags-sdk/vercel': minor
+'@vercel/flags-core': minor
+---
+
+Add a system `now` accessor and lock evaluation time per request/batch.
+
+Flag conditions can compare against the current time with BEFORE/AFTER (ISO or epoch ms) or numeric GT/GTE/LT/LTE. Rollouts and bulk evaluation share one locked `now` so results stay consistent within a request.

--- a/packages/adapter-global-config/src/index.test.ts
+++ b/packages/adapter-global-config/src/index.test.ts
@@ -56,6 +56,7 @@ describe('createGlobalConfigAdapter', () => {
         entities: {},
         headers,
         cookies: {} as ReadonlyRequestCookies,
+        now: 1700000000000,
       });
 
       expect(result).toEqual({ 'flag-a': true, 'flag-b': false });
@@ -74,6 +75,7 @@ describe('createGlobalConfigAdapter', () => {
         entities: {},
         headers,
         cookies: {} as ReadonlyRequestCookies,
+        now: 1700000000000,
       });
 
       expect(result).toEqual({ 'flag-a': true });
@@ -91,6 +93,7 @@ describe('createGlobalConfigAdapter', () => {
         entities: {},
         headers,
         cookies: {} as ReadonlyRequestCookies,
+        now: 1700000000000,
       });
 
       await adapter().bulkDecide!({
@@ -98,6 +101,7 @@ describe('createGlobalConfigAdapter', () => {
         entities: {},
         headers,
         cookies: {} as ReadonlyRequestCookies,
+        now: 1700000000000,
       });
 
       expect(fakeGlobalConfigClient.get).toHaveBeenCalledOnce();
@@ -122,6 +126,7 @@ describe('createGlobalConfigAdapter', () => {
         entities: {},
         headers: new Headers(),
         cookies: {} as ReadonlyRequestCookies,
+        now: 1700000000000,
       }),
     ).resolves.toEqual(true);
     expect(fakeGlobalConfigClient.get).toHaveBeenCalledWith('flags');
@@ -143,6 +148,7 @@ describe('createGlobalConfigAdapter', () => {
           entities: {},
           headers,
           cookies: {} as ReadonlyRequestCookies,
+          now: 1700000000000,
         }),
       ).resolves.toEqual(true);
 
@@ -154,6 +160,7 @@ describe('createGlobalConfigAdapter', () => {
           entities: {},
           headers,
           cookies: {} as ReadonlyRequestCookies,
+          now: 1700000000000,
         }),
       ).resolves.toEqual(true);
       expect(fakeGlobalConfigClient.get).toHaveBeenCalledWith('flags');
@@ -172,6 +179,7 @@ describe('createGlobalConfigAdapter', () => {
           entities: {},
           headers: new Headers(),
           cookies: {} as ReadonlyRequestCookies,
+          now: 1700000000000,
         }),
       ).resolves.toEqual(true);
 
@@ -183,6 +191,7 @@ describe('createGlobalConfigAdapter', () => {
           entities: {},
           headers: new Headers(),
           cookies: {} as ReadonlyRequestCookies,
+          now: 1700000000000,
         }),
       ).resolves.toEqual(true);
 

--- a/packages/adapter-launchdarkly/src/index.test.ts
+++ b/packages/adapter-launchdarkly/src/index.test.ts
@@ -62,6 +62,7 @@ describe('ldAdapter', () => {
           cookies: {} as ReadonlyRequestCookies,
           entities: {} as LDContext,
           defaultValue: false,
+          now: 1700000000000,
         });
 
         await expect(valuePromise).resolves.toEqual(true);

--- a/packages/adapter-openfeature/src/index.test.ts
+++ b/packages/adapter-openfeature/src/index.test.ts
@@ -37,6 +37,7 @@ describe('OpenFeature Adapter', () => {
           entities,
           headers: mockHeaders as ReadonlyHeaders,
           cookies: mockCookies as ReadonlyRequestCookies,
+          now: 1700000000000,
         });
 
         expect(mockClient.getBooleanValue).toHaveBeenCalledWith(
@@ -65,6 +66,7 @@ describe('OpenFeature Adapter', () => {
           entities,
           headers: mockHeaders as ReadonlyHeaders,
           cookies: mockCookies as ReadonlyRequestCookies,
+          now: 1700000000000,
         });
 
         expect(mockClient.getStringValue).toHaveBeenCalledWith(
@@ -93,6 +95,7 @@ describe('OpenFeature Adapter', () => {
           entities,
           headers: mockHeaders as ReadonlyHeaders,
           cookies: mockCookies as ReadonlyRequestCookies,
+          now: 1700000000000,
         });
 
         expect(mockClient.getNumberValue).toHaveBeenCalledWith(
@@ -121,6 +124,7 @@ describe('OpenFeature Adapter', () => {
           entities,
           headers: mockHeaders as ReadonlyHeaders,
           cookies: mockCookies as ReadonlyRequestCookies,
+          now: 1700000000000,
         });
 
         expect(mockClient.getObjectValue).toHaveBeenCalledWith(
@@ -158,6 +162,7 @@ describe('OpenFeature Adapter', () => {
           entities,
           headers: mockHeaders as ReadonlyHeaders,
           cookies: mockCookies as ReadonlyRequestCookies,
+          now: 1700000000000,
         });
 
         expect(mockClient.getBooleanValue).toHaveBeenCalledWith(
@@ -186,6 +191,7 @@ describe('OpenFeature Adapter', () => {
           entities,
           headers: mockHeaders as ReadonlyHeaders,
           cookies: mockCookies as ReadonlyRequestCookies,
+          now: 1700000000000,
         });
 
         expect(mockClient.getStringValue).toHaveBeenCalledWith(
@@ -214,6 +220,7 @@ describe('OpenFeature Adapter', () => {
           entities,
           headers: mockHeaders as ReadonlyHeaders,
           cookies: mockCookies as ReadonlyRequestCookies,
+          now: 1700000000000,
         });
 
         expect(mockClient.getNumberValue).toHaveBeenCalledWith(
@@ -242,6 +249,7 @@ describe('OpenFeature Adapter', () => {
           entities,
           headers: mockHeaders as ReadonlyHeaders,
           cookies: mockCookies as ReadonlyRequestCookies,
+          now: 1700000000000,
         });
 
         expect(mockClient.getObjectValue).toHaveBeenCalledWith(

--- a/packages/adapter-vercel/src/index.test.ts
+++ b/packages/adapter-vercel/src/index.test.ts
@@ -151,6 +151,7 @@ describe('createVercelAdapter', () => {
         entities: { user: { id: 'u1' } } as any,
         headers: undefined as any,
         cookies: undefined as any,
+        now: 1700000000000,
       });
 
       expect(bulkEvaluateMock).toHaveBeenCalledTimes(1);
@@ -160,6 +161,7 @@ describe('createVercelAdapter', () => {
           { key: 'b', defaultValue: undefined },
         ],
         { user: { id: 'u1' } },
+        { now: 1700000000000 },
       );
       expect(result).toEqual({ a: 'x', b: 'y' });
     });
@@ -178,6 +180,7 @@ describe('createVercelAdapter', () => {
         flags: [{ key: 'a' }, { key: 'b' }],
         headers: undefined as any,
         cookies: undefined as any,
+        now: 1700000000000,
       });
       expect(result).toEqual({ a: 'ok' });
       expect('b' in result).toBe(false);

--- a/packages/adapter-vercel/src/index.ts
+++ b/packages/adapter-vercel/src/index.ts
@@ -40,11 +40,12 @@ export function createVercelAdapter(
     adapterId,
     origin: flagsClient.origin,
     config: { reportValue: false },
-    async decide({ key, entities }) {
+    async decide({ key, entities, now }) {
       const evaluationResult = await flagsClient.evaluate<unknown, unknown>(
         key,
         undefined,
         entities,
+        { now },
       );
 
       if (evaluationResult.value === undefined) {
@@ -61,7 +62,7 @@ export function createVercelAdapter(
       // when there was an error but the defaultValue was set
       return evaluationResult.value;
     },
-    async bulkDecide({ flags, entities }) {
+    async bulkDecide({ flags, entities, now }) {
       // `flags` is typed `{ key: string; defaultValue?: unknown }[]` on
       // `Adapter.bulkDecide` (to keep `ValueType` covariant). The client
       // here narrows it back to `ValueType`; `defaultValue` is shuttled
@@ -69,6 +70,7 @@ export function createVercelAdapter(
       const results = await flagsClient.bulkEvaluate<unknown, unknown>(
         flags as { key: string; defaultValue?: unknown }[],
         entities,
+        { now },
       );
       const out: Record<string, unknown> = {};
       for (const key in results) {

--- a/packages/flags/src/next/evaluate.ts
+++ b/packages/flags/src/next/evaluate.ts
@@ -180,6 +180,12 @@ interface BulkStoreData {
   cookies: ReadonlyRequestCookies;
   dedupeCacheKey: Headers | IncomingHttpHeaders;
   overrides: Record<string, any> | null;
+  /**
+   * The current time (epoch ms), locked once for the whole `evaluate()`
+   * batch so every flag in it — bulk-grouped or standalone — agrees on
+   * "now", regardless of how long evaluation takes.
+   */
+  now: number;
 }
 
 const bulkStore = new AsyncLocalStorage<BulkStoreData>();
@@ -344,6 +350,10 @@ export function getRun<ValueType, EntitiesType>(
 
     // Check if running inside evaluate() — reuse pre-read headers/cookies/overrides
     const bulkData = bulkStore.getStore();
+    // Reuse the batch's locked time when running inside evaluate(); a
+    // standalone flag() call has nothing to stay consistent with, so it
+    // reads a fresh value.
+    const now = bulkData ? bulkData.now : Date.now();
 
     let overrides: Record<string, any> | null;
 
@@ -409,6 +419,7 @@ export function getRun<ValueType, EntitiesType>(
           headers: readonlyHeaders,
           cookies: readonlyCookies,
           entities,
+          now,
         }),
     });
   };
@@ -520,11 +531,16 @@ async function evaluateImpl(
   // Read overrides once
   const overrides = await readOverrides(readonlyCookies);
 
+  // Lock "now" once for the whole batch so every flag agrees on the current
+  // time, regardless of how long evaluation takes.
+  const now = Date.now();
+
   const storeData: BulkStoreData = {
     headers: readonlyHeaders,
     cookies: readonlyCookies,
     dedupeCacheKey,
     overrides,
+    now,
   };
 
   return bulkStore.run(storeData, async () => {
@@ -629,6 +645,7 @@ async function evaluateImpl(
                     entities,
                     headers: readonlyHeaders,
                     cookies: readonlyCookies,
+                    now,
                   });
                 } catch (err) {
                   bulkError = err;

--- a/packages/flags/src/next/evaluate.ts
+++ b/packages/flags/src/next/evaluate.ts
@@ -181,14 +181,31 @@ interface BulkStoreData {
   dedupeCacheKey: Headers | IncomingHttpHeaders;
   overrides: Record<string, any> | null;
   /**
-   * The current time (epoch ms), locked once for the whole `evaluate()`
-   * batch so every flag in it — bulk-grouped or standalone — agrees on
-   * "now", regardless of how long evaluation takes.
+   * The current time (epoch ms) for this `evaluate()` batch. Seeded from
+   * `nowByRequest` so standalone `flag()` calls in the same request agree.
    */
   now: number;
 }
 
 const bulkStore = new AsyncLocalStorage<BulkStoreData>();
+
+/**
+ * Locks evaluation time once per request, keyed by the same object
+ * `identifyArgsMap` uses (`headers()` store or `request.headers`).
+ * Get-or-set only — never overwrite an existing lock.
+ */
+const nowByRequest = new WeakMap<Headers | IncomingHttpHeaders, number>();
+
+function getRequestNow(
+  key: Headers | IncomingHttpHeaders,
+  preferred?: number,
+): number {
+  const existing = nowByRequest.get(key);
+  if (existing !== undefined) return existing;
+  const now = preferred ?? Date.now();
+  nowByRequest.set(key, now);
+  return now;
+}
 
 let headersModulePromise: Promise<typeof import('next/headers')> | undefined;
 let headersModule: typeof import('next/headers') | undefined;
@@ -350,10 +367,6 @@ export function getRun<ValueType, EntitiesType>(
 
     // Check if running inside evaluate() — reuse pre-read headers/cookies/overrides
     const bulkData = bulkStore.getStore();
-    // Reuse the batch's locked time when running inside evaluate(); a
-    // standalone flag() call has nothing to stay consistent with, so it
-    // reads a fresh value.
-    const now = bulkData ? bulkData.now : Date.now();
 
     let overrides: Record<string, any> | null;
 
@@ -393,6 +406,11 @@ export function getRun<ValueType, EntitiesType>(
 
       overrides = await readOverrides(readonlyCookies);
     }
+
+    // Lock after the request key is known. Prefer the evaluate() batch's
+    // now when present, but never overwrite a lock already set by an
+    // earlier flag() in this request.
+    const now = getRequestNow(dedupeCacheKey, bulkData?.now);
 
     // the flag is being used in app router
     // skip microtask if identify does not exist
@@ -531,9 +549,9 @@ async function evaluateImpl(
   // Read overrides once
   const overrides = await readOverrides(readonlyCookies);
 
-  // Lock "now" once for the whole batch so every flag agrees on the current
-  // time, regardless of how long evaluation takes.
-  const now = Date.now();
+  // Lock "now" for this request (shared with standalone flag() calls that
+  // use the same dedupeCacheKey). Get-or-set so a prior flag() wins.
+  const now = getRequestNow(dedupeCacheKey);
 
   const storeData: BulkStoreData = {
     headers: readonlyHeaders,

--- a/packages/flags/src/next/index.test.ts
+++ b/packages/flags/src/next/index.test.ts
@@ -189,6 +189,88 @@ describe('flag on app router', () => {
     expect(mockDecide).toHaveBeenCalledTimes(1);
   });
 
+  it('locks now across standalone flag() calls in the same request', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2000-01-01T00:00:00.000Z'));
+    const t0 = Date.parse('2000-01-01T00:00:00.000Z');
+
+    const seen: number[] = [];
+    const a = flag<number>({
+      key: 'now-a',
+      decide: ({ now }) => {
+        seen.push(now!);
+        return now!;
+      },
+    });
+    const b = flag<number>({
+      key: 'now-b',
+      decide: ({ now }) => {
+        seen.push(now!);
+        return now!;
+      },
+    });
+
+    const headers = new Headers();
+    mocks.headers.mockReturnValueOnce(headers);
+    mocks.headers.mockReturnValueOnce(headers);
+
+    await expect(a()).resolves.toEqual(t0);
+    vi.setSystemTime(new Date('2000-01-01T00:00:01.000Z'));
+    await expect(b()).resolves.toEqual(t0);
+    expect(seen).toEqual([t0, t0]);
+
+    // Different request identity gets a fresh lock at the advanced wall clock.
+    const t1 = Date.parse('2000-01-01T00:00:01.000Z');
+    mocks.headers.mockReturnValueOnce(new Headers());
+    await expect(a()).resolves.toEqual(t1);
+    expect(seen).toEqual([t0, t0, t1]);
+
+    vi.useRealTimers();
+  });
+
+  it('shares locked now between flag() and evaluate() in either order', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2000-01-01T00:00:00.000Z'));
+    const t0 = Date.parse('2000-01-01T00:00:00.000Z');
+
+    const seen: number[] = [];
+    const make = (key: string) =>
+      flag<string>({
+        key,
+        decide: ({ now }) => {
+          seen.push(now!);
+          return key;
+        },
+      });
+
+    // flag() first, then evaluate() after wall clock advances
+    const a = make('now-share-a');
+    const b = make('now-share-b');
+    const headers1 = new Headers();
+    mocks.headers.mockReturnValueOnce(headers1);
+    mocks.headers.mockReturnValueOnce(headers1);
+    await a();
+    vi.setSystemTime(new Date('2000-01-01T00:00:01.000Z'));
+    await evaluate({ b });
+    expect(seen).toEqual([t0, t0]);
+
+    // evaluate() first, then flag() after wall clock advances further
+    seen.length = 0;
+    vi.setSystemTime(new Date('2000-01-01T00:00:02.000Z'));
+    const t2 = Date.parse('2000-01-01T00:00:02.000Z');
+    const c = make('now-share-c');
+    const d = make('now-share-d');
+    const headers2 = new Headers();
+    mocks.headers.mockReturnValueOnce(headers2);
+    mocks.headers.mockReturnValueOnce(headers2);
+    await evaluate({ c });
+    vi.setSystemTime(new Date('2000-01-01T00:00:03.000Z'));
+    await d();
+    expect(seen).toEqual([t2, t2]);
+
+    vi.useRealTimers();
+  });
+
   it('respects overrides', async () => {
     const decide = vi.fn(() => false);
     const f = flag<boolean>({ key: 'first-flag', decide });
@@ -1242,6 +1324,43 @@ describe('evaluate', () => {
       expect(bulkDecideMock).toHaveBeenCalledTimes(1);
       expect(decideMock).toHaveBeenCalledTimes(1);
       socket.destroy();
+    });
+
+    it('locks now across evaluate(req) and flag(req) in the same request', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2000-01-01T00:00:00.000Z'));
+      const t0 = Date.parse('2000-01-01T00:00:00.000Z');
+
+      const seen: number[] = [];
+      const a = flag<string>({
+        key: 'now-pages-a',
+        decide: ({ now }) => {
+          seen.push(now!);
+          return 'a';
+        },
+      });
+      const b = flag<string>({
+        key: 'now-pages-b',
+        decide: ({ now }) => {
+          seen.push(now!);
+          return 'b';
+        },
+      });
+
+      const [request, socket] = createRequest();
+      await expect(evaluate({ a }, request)).resolves.toEqual({ a: 'a' });
+      vi.setSystemTime(new Date('2000-01-01T00:00:01.000Z'));
+      await expect(b(request)).resolves.toEqual('b');
+      expect(seen).toEqual([t0, t0]);
+
+      // A different request object gets a fresh lock.
+      const [request2, socket2] = createRequest();
+      await expect(a(request2)).resolves.toEqual('a');
+      expect(seen).toEqual([t0, t0, Date.parse('2000-01-01T00:00:01.000Z')]);
+
+      socket.destroy();
+      socket2.destroy();
+      vi.useRealTimers();
     });
 
     it('accepts a web Request (NextRequest) passed directly to flag(req)', async () => {

--- a/packages/flags/src/sveltekit/index.ts
+++ b/packages/flags/src/sveltekit/index.ts
@@ -223,6 +223,7 @@ export function flag<
       headers,
       cookies,
       entities,
+      now: store.now,
     });
     store.usedFlags[definition.key] = valuePromise as Promise<JsonValue>;
 
@@ -264,6 +265,11 @@ interface AsyncLocalContext {
   params: Record<string, string>;
   usedFlags: Record<string, Promise<JsonValue>>;
   identifiers: Map<Identify<unknown>, ReturnType<Identify<unknown>>>;
+  /**
+   * The current time (epoch ms), locked once per request so every flag
+   * evaluated for it agrees on "now".
+   */
+  now: number;
 }
 
 function createContext(
@@ -277,6 +283,7 @@ function createContext(
     params: params ?? {},
     usedFlags: {},
     identifiers: new Map(),
+    now: Date.now(),
   };
 }
 

--- a/packages/flags/src/types.ts
+++ b/packages/flags/src/types.ts
@@ -138,6 +138,12 @@ export type GenerousOption<T> = boolean extends T
 export type Decide<ValueType, EntitiesType> = (
   params: FlagParamsType & {
     entities?: EntitiesType;
+    /**
+     * The current time (epoch ms), locked once per request/batch so every
+     * flag decided together agrees on "now" — use this instead of calling
+     * `Date.now()` directly for time-based decisions.
+     */
+    now: number;
   },
 ) => Promise<ValueType> | ValueType;
 
@@ -174,6 +180,12 @@ export interface Adapter<ValueType, EntitiesType> {
     // output positions only. Keeping it covariant lets `Adapter<boolean>` and
     // `Flag<boolean>` remain assignable to `Adapter<unknown>` / `Flag<unknown>`.
     defaultValue?: unknown;
+    /**
+     * The current time (epoch ms), locked once per request/batch so every
+     * flag decided together agrees on "now" — use this instead of calling
+     * `Date.now()` directly for time-based decisions.
+     */
+    now: number;
   }) => Promise<ValueType> | ValueType;
   /**
    * Optional batch hook used by `evaluate()` to resolve many flags that
@@ -193,6 +205,12 @@ export interface Adapter<ValueType, EntitiesType> {
     entities?: EntitiesType;
     headers: ReadonlyHeaders;
     cookies: ReadonlyRequestCookies;
+    /**
+     * The current time (epoch ms), locked once per request/batch so every
+     * flag decided together agrees on "now" — use this instead of calling
+     * `Date.now()` directly for time-based decisions.
+     */
+    now: number;
   }) => Promise<Record<string, ValueType>> | Record<string, ValueType>;
 }
 

--- a/packages/flags/src/types.ts
+++ b/packages/flags/src/types.ts
@@ -143,7 +143,7 @@ export type Decide<ValueType, EntitiesType> = (
      * flag decided together agrees on "now" — use this instead of calling
      * `Date.now()` directly for time-based decisions.
      */
-    now: number;
+    now?: number;
   },
 ) => Promise<ValueType> | ValueType;
 
@@ -185,7 +185,7 @@ export interface Adapter<ValueType, EntitiesType> {
      * flag decided together agrees on "now" — use this instead of calling
      * `Date.now()` directly for time-based decisions.
      */
-    now: number;
+    now?: number;
   }) => Promise<ValueType> | ValueType;
   /**
    * Optional batch hook used by `evaluate()` to resolve many flags that
@@ -210,7 +210,7 @@ export interface Adapter<ValueType, EntitiesType> {
      * flag decided together agrees on "now" — use this instead of calling
      * `Date.now()` directly for time-based decisions.
      */
-    now: number;
+    now?: number;
   }) => Promise<Record<string, ValueType>> | Record<string, ValueType>;
 }
 

--- a/packages/vercel-flags-core/src/controller-fns.ts
+++ b/packages/vercel-flags-core/src/controller-fns.ts
@@ -9,6 +9,7 @@ import type {
   BundledDefinitions,
   ControllerInterface,
   Datafile,
+  EvaluationOptions,
   EvaluationResult,
   Metrics,
   Packed,
@@ -68,6 +69,7 @@ export async function evaluate<T, E = Record<string, unknown>>(
   flagKey: string,
   defaultValue?: T,
   entities?: E,
+  options?: EvaluationOptions,
 ): Promise<EvaluationResult<T>> {
   const controller = getInstance(id).controller as EvaluationTrackingController;
 
@@ -137,6 +139,7 @@ export async function evaluate<T, E = Record<string, unknown>>(
     environment: datafile.environment,
     entities: entities ?? {},
     segments: datafile.segments,
+    now: options?.now ?? evalStartTime,
   });
   const evaluationDurationMs = Date.now() - evalStartTime;
 
@@ -174,6 +177,7 @@ export async function bulkEvaluate<T, E = Record<string, unknown>>(
   id: number,
   flags: BulkEvaluateInput<T>[],
   entities?: E,
+  options?: EvaluationOptions,
 ): Promise<Record<string, EvaluationResult<T>>> {
   const controller = getInstance(id).controller as EvaluationTrackingController;
 
@@ -249,6 +253,7 @@ export async function bulkEvaluate<T, E = Record<string, unknown>>(
     entities: (entities ?? {}) as Record<string, unknown>,
     environment: datafile.environment,
     segments: datafile.segments,
+    now: options?.now ?? evalStartTime,
   });
   const evaluationDurationMs = Date.now() - evalStartTime;
 

--- a/packages/vercel-flags-core/src/create-raw-client.ts
+++ b/packages/vercel-flags-core/src/create-raw-client.ts
@@ -14,6 +14,7 @@ import type {
   BulkEvaluateInput,
   BundledDefinitions,
   ControllerInterface,
+  EvaluationOptions,
   EvaluationResult,
   FlagsClient,
   Value,
@@ -99,6 +100,7 @@ export function createCreateRawClient(fns: {
         flagKey: string,
         defaultValue?: T,
         entities?: E,
+        options?: EvaluationOptions,
       ): Promise<EvaluationResult<T>> => {
         const instance = controllerInstanceMap.get(id);
         if (!instance?.initialized) {
@@ -109,11 +111,12 @@ export function createCreateRawClient(fns: {
             // chain (last known value → datafile → bundled → defaultValue → throw)
           }
         }
-        return fns.evaluate<T, E>(id, flagKey, defaultValue, entities);
+        return fns.evaluate<T, E>(id, flagKey, defaultValue, entities, options);
       },
       bulkEvaluate: async <T = Value, E = Entities>(
         flags: BulkEvaluateInput<T>[],
         entities?: E,
+        options?: EvaluationOptions,
       ): Promise<Record<string, EvaluationResult<T>>> => {
         const instance = controllerInstanceMap.get(id);
         if (!instance?.initialized) {
@@ -124,7 +127,7 @@ export function createCreateRawClient(fns: {
             // chain (last known value → datafile → bundled → defaultValue → throw)
           }
         }
-        return fns.bulkEvaluate<T, E>(id, flags, entities);
+        return fns.bulkEvaluate<T, E>(id, flags, entities, options);
       },
     };
     return api;

--- a/packages/vercel-flags-core/src/evaluate.test.ts
+++ b/packages/vercel-flags-core/src/evaluate.test.ts
@@ -19,6 +19,7 @@ describe('evaluate', () => {
           variants: [false, true],
         } satisfies Packed.FlagDefinition,
         environment: 'production',
+        now: Date.now(),
         entities: {},
       }),
     ).toEqual({
@@ -37,6 +38,7 @@ describe('evaluate', () => {
           variants: [false, true],
         } satisfies Packed.FlagDefinition,
         environment: 'production',
+        now: Date.now(),
         entities: {},
       }),
     ).toEqual({
@@ -57,6 +59,7 @@ describe('evaluate', () => {
             variants: [false, true],
           } satisfies Packed.FlagDefinition,
           environment: 'this-env-does-not-exist-and-will-cause-an-error',
+          now: Date.now(),
           entities: {},
         }),
       ).toEqual({
@@ -87,6 +90,7 @@ describe('evaluate', () => {
           variants: [false, true],
         } satisfies Packed.FlagDefinition,
         environment: 'production',
+        now: Date.now(),
         entities: { user: { name: 'Joe' } },
       }),
     ).toEqual({
@@ -115,6 +119,7 @@ describe('evaluate', () => {
           variants: [false, true],
         } satisfies Packed.FlagDefinition,
         environment: 'production',
+        now: Date.now(),
         entities: { user: {} },
       }),
     ).toEqual({
@@ -141,6 +146,7 @@ describe('evaluate', () => {
           variants: [false, true],
         } satisfies Packed.FlagDefinition,
         environment: 'production',
+        now: Date.now(),
         entities: {},
       }),
     ).toEqual({
@@ -169,6 +175,7 @@ describe('evaluate', () => {
           variants: [false, true],
         } satisfies Packed.FlagDefinition,
         environment: 'production',
+        now: Date.now(),
         entities: { user: { name: 'Joe' } },
       }),
     ).toEqual({
@@ -187,6 +194,7 @@ describe('evaluate', () => {
           variants: [false, true],
         } satisfies Packed.FlagDefinition,
         environment: 'production',
+        now: Date.now(),
       }),
     ).toEqual({
       value: false,
@@ -204,6 +212,7 @@ describe('evaluate', () => {
           variants: [false, true],
         } satisfies Packed.FlagDefinition,
         environment: 'preview',
+        now: Date.now(),
       }),
     ).toEqual({
       value: true,
@@ -232,6 +241,7 @@ describe('evaluate', () => {
           variants: [false, true],
         } satisfies Packed.FlagDefinition,
         environment: 'preview',
+        now: Date.now(),
         entities: { user: { name: 'Joe' } },
         segments: {
           segment1: {
@@ -263,6 +273,7 @@ describe('evaluate', () => {
           variants: [false, true],
         } satisfies Packed.FlagDefinition,
         environment: 'preview',
+        now: Date.now(),
         entities: { user: { name: 'Joe' } },
         segments: {},
       }),
@@ -288,6 +299,7 @@ describe('evaluate', () => {
             variants: [false, true],
           } satisfies Packed.FlagDefinition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { name: 'Joe' } },
         }),
       ).toEqual({
@@ -333,6 +345,7 @@ describe('evaluate', () => {
             variants: [false, true],
           } satisfies Packed.FlagDefinition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { name: 'Joe' } },
           segments: {
             segment1: {
@@ -358,6 +371,7 @@ describe('evaluate', () => {
         evaluate({
           definition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: 'uid1' } },
           segments: {
             segment1: { rules: [], include: {}, exclude: {} },
@@ -376,6 +390,7 @@ describe('evaluate', () => {
         evaluate({
           definition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { name: 'Joe' } },
           segments: {
             segment1: {
@@ -399,6 +414,7 @@ describe('evaluate', () => {
         evaluate({
           definition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { name: 'Jim' } },
           segments: {
             segment1: {
@@ -424,6 +440,7 @@ describe('evaluate', () => {
         evaluate({
           definition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: 'uid1' } },
           segments: {
             segment1: {
@@ -444,6 +461,7 @@ describe('evaluate', () => {
         evaluate({
           definition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: 'uid1' } },
           segments: {
             segment1: {
@@ -468,6 +486,7 @@ describe('evaluate', () => {
         evaluate({
           definition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { name: 'Jim' } },
           segments: {
             segment1: {
@@ -493,6 +512,7 @@ describe('evaluate', () => {
         evaluate({
           definition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: 'uid1' } },
           segments: {
             segment1: {
@@ -514,6 +534,7 @@ describe('evaluate', () => {
         evaluate({
           definition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { name: 'Joe' } },
           segments: {
             segment1: {
@@ -541,6 +562,7 @@ describe('evaluate', () => {
         evaluate({
           definition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { name: 'Joe' } },
           segments: {
             segment1: {
@@ -573,6 +595,7 @@ describe('evaluate', () => {
           evaluate({
             definition,
             environment: 'production',
+            now: Date.now(),
             entities: { user: { name: `name${i}` } },
             segments: {
               segment1: {
@@ -608,6 +631,7 @@ describe('evaluate', () => {
           evaluate({
             definition,
             environment: 'production',
+            now: Date.now(),
             entities: { user: { name: `name${i}` } },
             segments: {
               segment1: {
@@ -643,6 +667,7 @@ describe('evaluate', () => {
           evaluate({
             definition,
             environment: 'production',
+            now: Date.now(),
             entities: { user: { name: `name${i}` } },
             segments: {
               segment1: {
@@ -1971,6 +1996,7 @@ describe('evaluate', () => {
           variants: [false, true],
         } satisfies Packed.FlagDefinition,
         environment: 'production',
+        now: Date.now(),
         entities,
         segments,
       }),
@@ -2011,6 +2037,7 @@ describe('evaluate', () => {
             variants: [false, true],
           } satisfies Packed.FlagDefinition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: longString } },
         }),
       ).toEqual({
@@ -2047,6 +2074,7 @@ describe('evaluate', () => {
             variants: [false, true],
           } satisfies Packed.FlagDefinition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: longString } },
         }),
       ).toEqual({
@@ -2083,12 +2111,14 @@ describe('evaluate', () => {
       const first = evaluate({
         definition,
         environment: 'production',
+        now: Date.now(),
         entities: { user: { id: 'uid1' } },
       });
 
       const second = evaluate({
         definition,
         environment: 'production',
+        now: Date.now(),
         entities: { user: { id: 'uid2' } },
       });
 
@@ -2133,6 +2163,7 @@ describe('evaluate', () => {
             variants: [false, true],
           } satisfies Packed.FlagDefinition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: okString } },
         }),
       ).toEqual({
@@ -2240,6 +2271,7 @@ describe('evaluate', () => {
             variants,
           } satisfies Packed.FlagDefinition,
           environment: 'production',
+          now: Date.now(),
           entities,
         }),
       ).toEqual({
@@ -2270,6 +2302,7 @@ describe('evaluate', () => {
               seed,
             } satisfies Packed.FlagDefinition,
             environment: 'production',
+            now: Date.now(),
             entities: { user: { id: `uid${i}` } },
           }).value as 'a' | 'b' | 'c' | 'd';
           totals[result]++;
@@ -2318,6 +2351,7 @@ describe('evaluate', () => {
             seed: 7,
           } satisfies Packed.FlagDefinition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: `uid${i}` } },
         }).value as string;
         counts[variants.indexOf(result)]!++;
@@ -2376,6 +2410,7 @@ describe('evaluate', () => {
             variants: [false, true],
           },
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: 'uid1' } },
         }),
       ).toEqual({
@@ -2396,6 +2431,7 @@ describe('evaluate', () => {
             variants: [false, true],
           },
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: 'uid1' } },
         }),
       ).toEqual({
@@ -2416,6 +2452,7 @@ describe('evaluate', () => {
             variants: [false, true],
           },
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: 'uid1' } },
         }),
       ).toEqual({
@@ -2436,6 +2473,7 @@ describe('evaluate', () => {
             variants: [false, true],
           },
           environment: 'production',
+          now: Date.now(),
           entities: {},
         }),
       ).toEqual({
@@ -2459,6 +2497,7 @@ describe('evaluate', () => {
             variants: [false, true],
           },
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: `uid${i}` } },
         });
         if (result.value === true) trueCount++;
@@ -2489,6 +2528,7 @@ describe('evaluate', () => {
               variants: [false, true],
             },
             environment: 'production',
+            now: Date.now(),
             entities: { user: { id: uid } },
           });
           if (evalResult.value === true) result.add(uid);
@@ -2533,6 +2573,7 @@ describe('evaluate', () => {
             variants: [false, true],
           },
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: `uid${i}` } },
         });
         if (result.value === true) trueCount++;
@@ -2560,6 +2601,7 @@ describe('evaluate', () => {
             variants: [false, true],
           },
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: `uid${i}` } },
         });
         if (result.value === true) rollToCount++;
@@ -2596,6 +2638,7 @@ describe('evaluate', () => {
             variants: [false, true],
           },
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: 'uid1', plan: 'pro' } },
         }),
       ).toEqual({
@@ -2635,6 +2678,7 @@ describe('evaluate', () => {
             variants: [...VARIANTS],
           },
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: uid } },
         }).value;
       };
@@ -2666,6 +2710,7 @@ describe('evaluate', () => {
             variants: [...VARIANTS],
           },
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: uid } },
         }).value;
       };
@@ -2734,6 +2779,7 @@ describe('bulkEvaluate', () => {
         },
         {
           environment: 'production',
+          now: Date.now(),
           entities: { user: { name: 'Joe' } },
         },
       ),
@@ -2770,7 +2816,7 @@ describe('bulkEvaluate', () => {
         a: { definition, defaultValue: true },
         b: { definition, defaultValue: false },
       },
-      { environment: 'this-env-does-not-exist', entities: {} },
+      { environment: 'this-env-does-not-exist', entities: {}, now: Date.now() },
     );
 
     expect(results.a).toEqual({
@@ -2810,6 +2856,7 @@ describe('bulkEvaluate', () => {
       },
       {
         environment: 'production',
+        now: Date.now(),
         entities: { user: { name: 'Joe' } },
         segments: {
           segment1: {
@@ -2835,6 +2882,8 @@ describe('bulkEvaluate', () => {
   });
 
   it('returns an empty object when no flags are provided', () => {
-    expect(bulkEvaluate({}, { environment: 'production' })).toEqual({});
+    expect(
+      bulkEvaluate({}, { environment: 'production', now: Date.now() }),
+    ).toEqual({});
   });
 });

--- a/packages/vercel-flags-core/src/evaluate.test.ts
+++ b/packages/vercel-flags-core/src/evaluate.test.ts
@@ -701,6 +701,7 @@ describe('evaluate', () => {
     condition: Packed.Condition;
     entities: Record<string, unknown> | undefined;
     segments?: Record<string, Packed.Segment>;
+    now?: number;
     result: boolean;
   }>([
     // EQ (string)
@@ -1507,6 +1508,111 @@ describe('evaluate', () => {
       result: false,
     },
 
+    // BEFORE / AFTER with epoch ms (entity or now)
+    {
+      name: `${Comparator.BEFORE} epoch lhs vs ISO rhs match`,
+      condition: [
+        ['user', 'createdAt'],
+        Comparator.BEFORE,
+        '2000-01-01T00:00:00.000Z',
+      ],
+      entities: { user: { createdAt: Date.parse('1970-01-01T00:00:00.000Z') } },
+      result: true,
+    },
+    {
+      name: `${Comparator.AFTER} epoch lhs vs epoch rhs match`,
+      condition: [
+        ['user', 'createdAt'],
+        Comparator.AFTER,
+        Date.parse('1970-01-01T00:00:00.000Z'),
+      ],
+      entities: { user: { createdAt: Date.parse('2000-01-01T00:00:00.000Z') } },
+      result: true,
+    },
+    {
+      name: `${Comparator.BEFORE} invalid date string miss`,
+      condition: [['user', 'createdAt'], Comparator.BEFORE, 'not-a-date'],
+      entities: { user: { createdAt: '2000-01-01T00:00:00.000Z' } },
+      result: false,
+    },
+
+    // now accessor
+    {
+      name: `now ${Comparator.BEFORE} ISO match`,
+      condition: ['now', Comparator.BEFORE, '2000-01-01T00:00:00.000Z'],
+      entities: {},
+      now: Date.parse('1970-01-01T00:00:00.000Z'),
+      result: true,
+    },
+    {
+      name: `now ${Comparator.BEFORE} ISO miss`,
+      condition: ['now', Comparator.BEFORE, '1970-01-01T00:00:00.000Z'],
+      entities: {},
+      now: Date.parse('2000-01-01T00:00:00.000Z'),
+      result: false,
+    },
+    {
+      name: `now ${Comparator.AFTER} ISO match`,
+      condition: ['now', Comparator.AFTER, '1970-01-01T00:00:00.000Z'],
+      entities: {},
+      now: Date.parse('2000-01-01T00:00:00.000Z'),
+      result: true,
+    },
+    {
+      name: `now ${Comparator.AFTER} ISO miss`,
+      condition: ['now', Comparator.AFTER, '2000-01-01T00:00:00.000Z'],
+      entities: {},
+      now: Date.parse('1970-01-01T00:00:00.000Z'),
+      result: false,
+    },
+    {
+      name: `now ${Comparator.BEFORE} epoch rhs match`,
+      condition: [
+        'now',
+        Comparator.BEFORE,
+        Date.parse('2000-01-01T00:00:00.000Z'),
+      ],
+      entities: {},
+      now: Date.parse('1970-01-01T00:00:00.000Z'),
+      result: true,
+    },
+    {
+      name: `now ${Comparator.AFTER} epoch rhs match`,
+      condition: [
+        'now',
+        Comparator.AFTER,
+        Date.parse('1970-01-01T00:00:00.000Z'),
+      ],
+      entities: {},
+      now: Date.parse('2000-01-01T00:00:00.000Z'),
+      result: true,
+    },
+    {
+      name: `now ${Comparator.LT} epoch match`,
+      condition: ['now', Comparator.LT, Date.parse('2000-01-01T00:00:00.000Z')],
+      entities: {},
+      now: Date.parse('1970-01-01T00:00:00.000Z'),
+      result: true,
+    },
+    {
+      name: `now ${Comparator.GTE} epoch match`,
+      condition: [
+        'now',
+        Comparator.GTE,
+        Date.parse('2000-01-01T00:00:00.000Z'),
+      ],
+      entities: {},
+      now: Date.parse('2000-01-01T00:00:00.000Z'),
+      result: true,
+    },
+    {
+      name: `now ${Comparator.LT} ISO rhs does not coerce`,
+      condition: ['now', Comparator.LT, '2000-01-01T00:00:00.000Z'],
+      entities: {},
+      now: Date.parse('1970-01-01T00:00:00.000Z'),
+      result: false,
+    },
+
     // ---- Case-insensitive via string shorthand: 'i' ----
 
     // EQ 'i'
@@ -1981,6 +2087,7 @@ describe('evaluate', () => {
     condition,
     entities,
     segments,
+    now,
     result,
   }) => {
     expect(
@@ -1996,7 +2103,7 @@ describe('evaluate', () => {
           variants: [false, true],
         } satisfies Packed.FlagDefinition,
         environment: 'production',
-        now: Date.now(),
+        now: now ?? Date.now(),
         entities,
         segments,
       }),
@@ -2411,6 +2518,29 @@ describe('evaluate', () => {
           },
           environment: 'production',
           now: Date.now(),
+          entities: { user: { id: 'uid1' } },
+        }),
+      ).toEqual({
+        value: false,
+        variantId: null,
+        reason: ResolutionReason.FALLTHROUGH,
+        outcomeType: OutcomeType.ROLLOUT,
+      });
+    });
+
+    it('uses params.now instead of the wall clock', () => {
+      // Wall clock is after the rollout finishes (100%), but params.now is
+      // before start — evaluation must follow the locked now.
+      vi.setSystemTime(startTimestamp + 100 * HOUR);
+      expect(
+        evaluate({
+          definition: {
+            environments: { production: { fallthrough: makeRollout() } },
+            seed: 7,
+            variants: [false, true],
+          },
+          environment: 'production',
+          now: startTimestamp - 1,
           entities: { user: { id: 'uid1' } },
         }),
       ).toEqual({
@@ -2879,6 +3009,63 @@ describe('bulkEvaluate', () => {
     };
     expect(results.a).toEqual(expected);
     expect(results.b).toEqual(expected);
+  });
+
+  it('shares a locked now across flags with date conditions', () => {
+    const boundary = Date.parse('2000-01-01T00:00:00.000Z');
+    const beforeFlag: Packed.FlagDefinition = {
+      environments: {
+        production: {
+          rules: [
+            {
+              conditions: [['now', Comparator.BEFORE, boundary]],
+              outcome: 1,
+            },
+          ],
+          fallthrough: 0,
+        },
+      },
+      variants: [false, true],
+    };
+    const afterFlag: Packed.FlagDefinition = {
+      environments: {
+        production: {
+          rules: [
+            {
+              conditions: [['now', Comparator.AFTER, boundary]],
+              outcome: 1,
+            },
+          ],
+          fallthrough: 0,
+        },
+      },
+      variants: [false, true],
+    };
+
+    const results = bulkEvaluate(
+      {
+        before: { definition: beforeFlag },
+        after: { definition: afterFlag },
+      },
+      {
+        environment: 'production',
+        now: Date.parse('1999-12-31T00:00:00.000Z'),
+        entities: {},
+      },
+    );
+
+    expect(results.before).toEqual({
+      value: true,
+      variantId: null,
+      reason: ResolutionReason.RULE_MATCH,
+      outcomeType: OutcomeType.VALUE,
+    });
+    expect(results.after).toEqual({
+      value: false,
+      variantId: null,
+      reason: ResolutionReason.FALLTHROUGH,
+      outcomeType: OutcomeType.VALUE,
+    });
   });
 
   it('returns an empty object when no flags are provided', () => {

--- a/packages/vercel-flags-core/src/evaluate.ts
+++ b/packages/vercel-flags-core/src/evaluate.ts
@@ -220,9 +220,12 @@ function matchConditions<T>(
       return rawRhs && matchSegmentCondition(cmpKey, rawRhs, params);
     }
 
-    const lhs = ignoreCase
-      ? lower(access(lhsAccessor, params))
-      : access(lhsAccessor, params);
+    // "now" is the locked current time, not an entity attribute
+    const rawLhs =
+      lhsAccessor === Packed.AccessorType.NOW
+        ? params.now
+        : access(lhsAccessor, params);
+    const lhs = ignoreCase ? lower(rawLhs) : rawLhs;
     const rhs = ignoreCase ? lower(rawRhs) : rawRhs;
 
     try {
@@ -477,8 +480,7 @@ function handleOutcome<T>(
       }
 
       // Determine active slot based on elapsed time
-      const now = Date.now();
-      const elapsed = now - outcome.startTimestamp;
+      const elapsed = params.now - outcome.startTimestamp;
 
       const rollFromVariant = getVariant<T>(
         params.definition,
@@ -663,12 +665,14 @@ export function bulkEvaluate<T = unknown>(
     entities?: Record<string, unknown>;
     environment: string;
     segments?: EvaluationParams<T>['segments'];
+    now: number;
   },
 ): Record<string, EvaluationResult<T>> {
   const params: EvaluationParams<T> = {
     entities: shared.entities,
     environment: shared.environment,
     segments: shared.segments,
+    now: shared.now,
     definition: undefined as unknown as Packed.FlagDefinition,
     defaultValue: undefined,
   };

--- a/packages/vercel-flags-core/src/evaluate.ts
+++ b/packages/vercel-flags-core/src/evaluate.ts
@@ -112,6 +112,19 @@ function isArray(input: unknown): input is unknown[] {
   return Array.isArray(input);
 }
 
+/**
+ * Normalize a date-like value to epoch milliseconds.
+ * Accepts finite numbers (epoch ms) and parseable date strings.
+ */
+function toEpochMs(value: unknown): number | null {
+  if (isNumber(value) && Number.isFinite(value)) return value;
+  if (isString(value)) {
+    const time = new Date(value).getTime();
+    return Number.isNaN(time) ? null : time;
+  }
+  return null;
+}
+
 function lower<T>(input: T): T {
   if (typeof input === 'string') return input.toLowerCase() as T;
   if (Array.isArray(input)) return input.map(lower) as T;
@@ -337,18 +350,17 @@ function matchConditions<T>(
           }
           return false;
         case Comparator.BEFORE: {
-          if (!isString(lhs) || !isString(rhs)) return false;
-          const a = new Date(lhs);
-          const b = new Date(rhs);
-          // if any date fails to parse getTime will return NaN, which will cause
-          // comparisons to fail.
-          return a.getTime() < b.getTime();
+          const a = toEpochMs(lhs);
+          const b = toEpochMs(rhs);
+          // Unparseable values (including NaN from bad date strings) do not match.
+          if (a === null || b === null) return false;
+          return a < b;
         }
         case Comparator.AFTER: {
-          if (!isString(lhs) || !isString(rhs)) return false;
-          const a = new Date(lhs);
-          const b = new Date(rhs);
-          return a.getTime() > b.getTime();
+          const a = toEpochMs(lhs);
+          const b = toEpochMs(rhs);
+          if (a === null || b === null) return false;
+          return a > b;
         }
         default: {
           const _x: never = cmpKey; // exhaustive check

--- a/packages/vercel-flags-core/src/integration.test.ts
+++ b/packages/vercel-flags-core/src/integration.test.ts
@@ -136,6 +136,7 @@ describe('integration evaluate', () => {
         evaluate({
           definition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: 'uid1' } },
           segments: {
             segment1: {
@@ -160,6 +161,7 @@ describe('integration evaluate', () => {
         evaluate({
           definition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { name: 'Jim' } },
           segments: {
             segment1: {
@@ -185,6 +187,7 @@ describe('integration evaluate', () => {
         evaluate({
           definition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { id: 'uid1' } },
           segments: {
             segment1: {
@@ -206,6 +209,7 @@ describe('integration evaluate', () => {
         evaluate({
           definition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { name: 'Joe' } },
           segments: {
             segment1: {
@@ -233,6 +237,7 @@ describe('integration evaluate', () => {
         evaluate({
           definition,
           environment: 'production',
+          now: Date.now(),
           entities: { user: { name: 'Joe' } },
           segments: {
             segment1: {
@@ -265,6 +270,7 @@ describe('integration evaluate', () => {
           evaluate({
             definition,
             environment: 'production',
+            now: Date.now(),
             entities: { user: { name: `name${i}` } },
             segments: {
               segment1: {
@@ -300,6 +306,7 @@ describe('integration evaluate', () => {
           evaluate({
             definition,
             environment: 'production',
+            now: Date.now(),
             entities: { user: { name: `name${i}` } },
             segments: {
               segment1: {
@@ -335,6 +342,7 @@ describe('integration evaluate', () => {
           evaluate({
             definition,
             environment: 'production',
+            now: Date.now(),
             entities: { user: { name: `name${i}` } },
             segments: {
               segment1: {

--- a/packages/vercel-flags-core/src/types.ts
+++ b/packages/vercel-flags-core/src/types.ts
@@ -123,6 +123,16 @@ export type BulkEvaluateInput<T = Value> = {
   defaultValue?: T;
 };
 
+export type EvaluationOptions = {
+  /**
+   * The current time (epoch ms) to use for time-based conditions and
+   * rollouts. Defaults to `Date.now()`. Callers evaluating several flags
+   * together (e.g. a request-scoped batch) should pass the same `now` to
+   * every call so they all agree on "now".
+   */
+  now?: number;
+};
+
 /**
  * A client for Vercel Flags
  */
@@ -149,6 +159,7 @@ export type FlagsClient<Entities = Record<string, unknown>> = {
     flagKey: string,
     defaultValue?: T,
     entities?: E,
+    options?: EvaluationOptions,
   ) => Promise<EvaluationResult<T>>;
   /**
    * Evaluate multiple feature flags against the same entities in a single call.
@@ -165,6 +176,7 @@ export type FlagsClient<Entities = Record<string, unknown>> = {
   bulkEvaluate: <T = Value, E = Entities>(
     flags: BulkEvaluateInput<T>[],
     entities?: E,
+    options?: EvaluationOptions,
   ) => Promise<Record<string, EvaluationResult<T>>>;
   /**
    * Retrieve the latest datafile during startup, and set up subscriptions if needed.
@@ -192,6 +204,12 @@ export type EvaluationParams<T> = {
   segments?: Record<SegmentId, Packed.Segment>;
   definition: Packed.FlagDefinition;
   defaultValue?: T;
+  /**
+   * The current time (epoch ms), locked once per evaluation/batch by the
+   * caller so all conditions and rollout calculations within it agree on
+   * "now", regardless of how long evaluation takes.
+   */
+  now: number;
 };
 
 // Copied from the OpenFeature ErrorCode and commented out unused types
@@ -483,6 +501,7 @@ export namespace Original {
   export enum AccessorType {
     SEGMENT = 'segment',
     ENTITY = 'entity',
+    NOW = 'now',
   }
 
   export type SegmentOutcome = SegmentAllOutcome | SegmentSplitOutcome;
@@ -569,6 +588,11 @@ export namespace Original {
     attribute: string;
   };
   export type SegmentAccessor = { type: AccessorType.SEGMENT };
+  /**
+   * References the current time (epoch ms), as locked for the duration of
+   * this evaluation. Packs to the `'now'` literal in `Packed.LHS`.
+   */
+  export type NowAccessor = { type: AccessorType.NOW };
 
   export type List = {
     // backwards compatibility, we should only use "list" going forward
@@ -577,7 +601,7 @@ export namespace Original {
     id?: never;
   };
 
-  export type LHS = SegmentAccessor | EntityAccessor;
+  export type LHS = SegmentAccessor | EntityAccessor | NowAccessor;
   export type RHS =
     | string
     | number
@@ -707,6 +731,7 @@ export namespace Packed {
   export enum AccessorType {
     SEGMENT = 'segment',
     ENTITY = 'entity',
+    NOW = 'now',
   }
 
   export type SplitOutcome = {
@@ -784,14 +809,18 @@ export namespace Packed {
 
   export type Outcome = VariantIndex | SplitOutcome | RolloutOutcome;
 
-  // an array means it's an entity, the string "segment" means a segment
+  // an array means it's an entity, the string "segment" means a segment,
+  // the string "now" means the current time (epoch ms) as locked for this
+  // evaluation, letting conditions compare "now" against a UI-authored
+  // timestamp with the existing GT/GTE/LT/LTE comparators.
   export type EntityAccessor = (string | number)[];
   export type SegmentAccessor = 'segment';
+  export type NowAccessor = 'now';
 
   /**
    * An array means an entity
    */
-  export type LHS = EntityAccessor | SegmentAccessor;
+  export type LHS = EntityAccessor | SegmentAccessor | NowAccessor;
 
   /**
    * undefined when the rhs is not used by the comparator

--- a/packages/vercel-flags-core/src/types.ts
+++ b/packages/vercel-flags-core/src/types.ts
@@ -473,15 +473,15 @@ export enum Comparator {
    */
   NOT_REGEX = '!regex',
   /**
-   * lhs must be date string
-   * rhs must be date string
+   * lhs/rhs must be a date string or epoch milliseconds (number).
+   * Used with entity date attributes or the `now` accessor.
    *
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format
    */
   BEFORE = 'before',
   /**
-   * lhs must be date string
-   * rhs must be date string
+   * lhs/rhs must be a date string or epoch milliseconds (number).
+   * Used with entity date attributes or the `now` accessor.
    *
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format
    */
@@ -811,8 +811,8 @@ export namespace Packed {
 
   // an array means it's an entity, the string "segment" means a segment,
   // the string "now" means the current time (epoch ms) as locked for this
-  // evaluation, letting conditions compare "now" against a UI-authored
-  // timestamp with the existing GT/GTE/LT/LTE comparators.
+  // evaluation. Prefer BEFORE/AFTER (ISO string or epoch ms RHS); GT/GTE/LT/LTE
+  // also work when the RHS is epoch milliseconds.
   export type EntityAccessor = (string | number)[];
   export type SegmentAccessor = 'segment';
   export type NowAccessor = 'now';


### PR DESCRIPTION
## What this PR does

This PR adds explicit time support to flag evaluation. It adds a `now` value. The `now` value is the current time in epoch milliseconds.

## Why we need this

Some flags use time-based conditions. Some flags use time-based rollouts. Before this PR, the code read the time with `Date.now()` at each check. Different flags in the same request could read different times. This PR fixes that problem.

## How it works

- Each request locks one `now` value at the start.
- All flags in the same request use this same `now` value.
- All flags in the same batch use this same `now` value.
- The system passes `now` through `decide()` and `bulkDecide()`.
- The system passes `now` through `evaluate()` and `bulkEvaluate()`.
- Adapters receive `now` as a parameter. Adapters do not need to call `Date.now()` themselves.

## New condition type

- This PR adds a `now` accessor for conditions.
- Rule authors can compare the current time against a fixed timestamp.
- The comparison uses the existing operators: greater-than, greater-than-or-equal, less-than, less-than-or-equal.

## Changed files

- `packages/flags/src/types.ts`: Adds `now` to the `Decide` and `Adapter` types.
- `packages/flags/src/next/evaluate.ts`: Locks `now` once per batch. Passes `now` to each flag.
- `packages/flags/src/sveltekit/index.ts`: Locks `now` once per request context. Passes `now` to each flag.
- `packages/adapter-vercel/src/index.ts`: Passes `now` to `evaluate()` and `bulkEvaluate()`.
- `packages/vercel-flags-core/src/types.ts`: Adds the `now` field to `EvaluationParams`. Adds the `NOW` accessor type.
- `packages/vercel-flags-core/src/evaluate.ts`: Reads `now` from `EvaluationParams` instead of calling `Date.now()`. Uses `now` for rollout timing and for the new `now` accessor.
- `packages/vercel-flags-core/src/controller-fns.ts` and `create-raw-client.ts`: Add an `options` parameter with `now`. Default to the evaluation start time when the caller does not pass `now`.
- Test files: Update existing tests to pass a fixed `now` value.

## Backward compatibility

- The `now` option is optional at the client API level.
- When a caller does not pass `now`, the code falls back to the evaluation start time.
