### PR TITLE
docs: correct the examples in the marketing pages guide

### DIFF
--- a/apps/docs/content/docs/frameworks/next/guides/marketing-pages.mdx
+++ b/apps/docs/content/docs/frameworks/next/guides/marketing-pages.mdx
@@ -46,7 +46,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 import { marketingFlags } from './flags';
 import { getOrGenerateVisitorId } from './get-or-generate-visitor-id';
 
-export async function marketingMiddleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   // assign a cookie to the visitor
   const visitorId = await getOrGenerateVisitorId(
     request.cookies,
@@ -117,17 +117,14 @@ function and both will see the exact same id, even when no cookie was
 present initially.
 
 ```tsx title="flags.tsx#next"
+import type { Identify } from 'flags';
+import { dedupe, flag } from 'flags/next';
+
 // identify who is requesting the page
-const identify = dedupe(
-  async ({
-    cookies,
-  }: {
-    cookies: ReadonlyRequestCookies;
-  }): Promise<Entities> => {
-    const visitorId = await getOrGenerateVisitorId(cookies);
-    return { visitor: visitorId ? { id: visitorId } : undefined };
-  },
-);
+const identify: Identify<Entities> = dedupe(async ({ cookies, headers }) => {
+  const visitorId = await getOrGenerateVisitorId(cookies, headers);
+  return { visitor: visitorId ? { id: visitorId } : undefined };
+});
 
 export const marketingAbTest = flag<boolean, Entities>({
   key: 'marketing-ab-test-flag',


### PR DESCRIPTION
## Summary

This change corrects two code examples in the marketing pages guide.

## The identify example

- Add two import statements. The statements show where `Identify`, `dedupe` and `flag` come from.
- Give the `identify` constant the `Identify<Entities>` type. The type gives the correct type to the `cookies` parameter and to the `headers` parameter. You do not write these types again in the example.
- Send `cookies` and `headers` to the `getOrGenerateVisitorId` function. The function needs the two parameters.
- Keep the return statement and the `marketingAbTest` block.

Before this change, the example sent only `cookies` to the `getOrGenerateVisitorId` function. The example on the same page shows that the function needs `cookies` and `headers`. If you send only `cookies`, the code does not compile.

## The proxy.ts example

Change the name of the exported function from `marketingMiddleware` to `proxy`.

Next.js reads the function with the name `proxy` from the `proxy.ts` file. The name `marketingMiddleware` is the old middleware name. The other pages of the documentation, and the example applications, use the name `proxy`.

## Test

The change is a documentation change. It changes no application code.