### PR TITLE
docs: fix Global Config links

### DIFF
--- a/apps/docs/content/docs/providers/global-config.mdx
+++ b/apps/docs/content/docs/providers/global-config.mdx
@@ -2,7 +2,7 @@
 title: 'Global Config'
 ---
 
-The `@flags-sdk/global-config` package provides a basic adapter for defining feature flags powered by [Vercel Global Config](https://vercel.com/docs/storage/global-config)
+The `@flags-sdk/global-config` package provides a basic adapter for defining feature flags powered by [Vercel Global Config](https://vercel.com/docs/global-config)
 
 <LearnMore
   icon="arrow"
@@ -41,7 +41,7 @@ export const exampleFlag = flag({
 });
 ```
 
-Your Global Config should be [managed on the dashboard](https://vercel.com/docs/storage/global-config/global-config-dashboard) as follows:
+Your Global Config should be [managed on the dashboard](https://vercel.com/docs/global-config/global-config-dashboard) as follows:
 
 ```json
 {
@@ -76,7 +76,7 @@ To customize these options you can import and call `createGlobalConfigAdapter` m
 
 | Option key | Type | Description |
 | ----------- | -------- | ----------------------- |
-| `connectionString` | `string | GlobalConfigClient` | A [connection string](https://vercel.com/docs/storage/global-config/using-global-config#using-a-connection-string) or a [client instance](https://vercel.com/docs/storage/global-config/global-config-sdk#use-connection-strings) |
+| `connectionString` | `string | GlobalConfigClient` | A [connection string](https://vercel.com/docs/global-config/using-global-config#using-a-connection-string) or a [client instance](https://vercel.com/docs/global-config/global-config-sdk#use-connection-strings) |
 | `options.globalConfigItemKey` | `string` | Defaults to `flags` |
 | `options.teamSlug` | `string` | The team slug used for your team in the Vercel dashboard, used to create links to your Global Config |
 
@@ -102,7 +102,7 @@ export const exampleFlag = flag({
 Read more about Global Config, Flags SDK, and the Global Config adapter.
 
 - [Concepts: Precompute](/principles/precompute)
-- [Global Config Docs](https://vercel.com/docs/storage/global-config)
-- [Global Config SDK Reference](https://vercel.com/docs/storage/global-config/global-config-sdk)
+- [Global Config Docs](https://vercel.com/docs/global-config)
+- [Global Config SDK Reference](https://vercel.com/docs/global-config/global-config-sdk)
 - [Global Config Examples](https://vercel.com/templates/global-config)
-- [Global Config Limits and Pricing](https://vercel.com/docs/storage/global-config/global-config-limits)
+- [Global Config Limits and Pricing](https://vercel.com/docs/global-config/global-config-limits)

--- a/apps/docs/content/docs/providers/growthbook.mdx
+++ b/apps/docs/content/docs/providers/growthbook.mdx
@@ -176,7 +176,7 @@ If you have set a sticky bucket service, you may retrieve its instance here.
 
 ## Global Config
 
-The adapter can load feature configuration from [Vercel Global Config](https://vercel.com/docs/storage/global-config) to lower the latency of feature flag evaluation.
+The adapter can load feature configuration from [Vercel Global Config](https://vercel.com/docs/global-config) to lower the latency of feature flag evaluation.
 
 - Set `GROWTHBOOK_GLOBAL_CONFIG_CONNECTION_STRING` (or `EXPERIMENTATION_CONFIG` if installed through the Vercel Marketplace) in your environment. Optionally set `GROWTHBOOK_GLOBAL_CONFIG_ITEM_KEY` to override the default key name (defaults to your client key).
 - Or pass `globalConfig` directly to the adapter.
@@ -233,6 +233,6 @@ export const GET = createFlagsDiscoveryEndpoint(async (request) => {
 
 - [GrowthBook Documentation](https://docs.growthbook.io/)
 - [GrowthBook JS SDK Reference](https://docs.growthbook.io/lib/js)
-- [Vercel Global Config](https://vercel.com/docs/storage/global-config)
+- [Vercel Global Config](https://vercel.com/docs/global-config)
 - [Flags Explorer](https://vercel.com/docs/flags/flags-explorer)
 - [Deploy the GrowthBook template](https://vercel.com/templates/next.js/growthbook-flags-sdk-example)

--- a/apps/docs/content/docs/providers/statsig.mdx
+++ b/apps/docs/content/docs/providers/statsig.mdx
@@ -358,7 +358,7 @@ Read more about initialization strategies in the [Statsig Docs](https://docs.sta
 
 The Statsig adapter can either load the experiment configuration over the network or bootstrap from [Global Config](https://vercel.com/storage/global-config).
 
-Using [Global Config](https://vercel.com/docs/storage/global-config) is optional but recommended for the best latency. Global Config is a global, ultra-low latency store which uses active replication and is specifically designed for serving feature flag configuration.
+Using [Global Config](https://vercel.com/docs/global-config) is optional but recommended for the best latency. Global Config is a global, ultra-low latency store which uses active replication and is specifically designed for serving feature flag configuration.
 
 The default Statsig adapter, exported as `statsigAdapter`, will automatically connect to Global Config if the `EXPERIMENTATION_CONFIG` and `EXPERIMENTATION_CONFIG_ITEM_KEY` environment variables are set. If you are using the [Statsig integration on Vercel marketplace](https://vercel.com/marketplace/statsig) these environment variables will be provided automatically, and the default Statsig adapter will read from Global Config automatically.
 


### PR DESCRIPTION
## Summary

- update Flags SDK provider docs to use the current Global Config paths
- fix dashboard, usage, SDK, and limits links moved out of `/docs/storage`

## Testing

- pre-commit Biome check
- `git diff --check`
- verified replacement URLs return HTTP 200 without redirects