### PR TITLE
Make flags-sdk skill setup-first for discovery

### DIFF
--- a/skills/flags-sdk/SKILL.md
+++ b/skills/flags-sdk/SKILL.md
@@ -2,19 +2,15 @@
 name: flags-sdk
 description: >
   Set up and use feature flags and A/B tests with the Flags SDK (`flags` npm package) and Vercel Flags.
-  Use when installing or configuring the SDK, adding the first flag, wiring `vercelAdapter` /
-  FLAGS env vars, declaring flags with `flag()`, using the `vercel flags` CLI
-  (add, list, enable, disable, inspect, archive, rm, sdk-keys),
-  setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog, GrowthBook, Hypertune,
-  Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom adapters),
-  implementing precompute patterns for static pages, setting up `identify`/`dedupe`,
-  integrating Flags Explorer/Toolbar,
-  working with flags in Next.js (App Router, Pages Router, Middleware) or SvelteKit,
-  writing custom adapters, or encrypting/decrypting flag values.
+  Use when installing or configuring the SDK, adding a flag, wiring `vercelAdapter` / FLAGS env vars,
+  declaring flags with `flag()`, using `vercel flags` CLI (add, list, enable, disable, inspect,
+  archive, rm, sdk-keys), setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog,
+  GrowthBook, Hypertune, Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom),
+  precompute, `identify`/`dedupe`, Flags Explorer/Toolbar, Next.js or SvelteKit, custom adapters,
+  or encrypting/decrypting flag values.
   Triggers: set up feature flags, install Flags SDK, add a feature flag, feature flags,
-  A/B testing, experimentation, flags SDK, flag adapters, precompute,
-  Flags Explorer, feature gates, flag overrides, Vercel Flags, vercel flags CLI, vercel flags add,
-  vercel flags list, vercel flags enable, vercel flags disable,
+  A/B testing, experimentation, flags SDK, flag adapters, precompute, Flags Explorer,
+  feature gates, flag overrides, Vercel Flags, vercel flags CLI, vercel flags add/list/enable/disable,
   `flags/next`, `flags/sveltekit`, `flags/react`, `@flags-sdk/*`.
 ---
 

--- a/skills/flags-sdk/SKILL.md
+++ b/skills/flags-sdk/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Set up and use feature flags and A/B tests with the Flags SDK (`flags` npm package) and Vercel Flags.
   Use when installing or configuring the SDK, adding the first flag, wiring `vercelAdapter` /
   FLAGS env vars, using the `vercel flags` CLI (create, list, enable, disable, inspect, archive,
-  rm, sdk-keys, rules), setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog,
+  rm, sdk-keys), setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog,
   GrowthBook, Hypertune, Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom),
   integrating Flags Explorer/Toolbar, implementing precompute, `identify`/`dedupe`, or evaluating
   flags in Next.js (App Router, Pages Router, Middleware) or SvelteKit.
@@ -193,8 +193,6 @@ export const dashboardFlag = flag<boolean, Entities>({
   },
 });
 ```
-
-Timestamp entity attributes are numbers. Pass epoch milliseconds in `identify()` / evaluation context (for example `Date.now()` or a stable `Date.parse(...)` value).
 
 ### Flag with another adapter
 

--- a/skills/flags-sdk/SKILL.md
+++ b/skills/flags-sdk/SKILL.md
@@ -1,27 +1,26 @@
 ---
 name: flags-sdk
 description: >
-  Guide for feature flags and A/B tests with the Flags SDK (`flags` npm package) and Vercel Flags.
-  Use when: declaring flags with `flag()`, using `vercelAdapter` or `vercel flags` CLI
-  (add, list, enable, disable, inspect, archive, rm, sdk-keys),
-  setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog, GrowthBook, Hypertune,
-  Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom adapters),
-  implementing precompute patterns for static pages, setting up `identify`/`dedupe`,
-  integrating Flags Explorer/Toolbar,
-  working with flags in Next.js (App Router, Pages Router, Middleware) or SvelteKit,
-  writing custom adapters, or encrypting/decrypting flag values.
-  Triggers: feature flags, A/B testing, experimentation, flags SDK, flag adapters, precompute,
-  Flags Explorer, feature gates, flag overrides, Vercel Flags, vercel flags CLI, vercel flags add,
-  vercel flags list, vercel flags enable, vercel flags disable,
-  `flags/next`, `flags/sveltekit`, `flags/react`, `@flags-sdk/*`.
+  Set up and use feature flags and A/B tests with the Flags SDK (`flags` npm package) and Vercel Flags.
+  Use when installing or configuring the SDK, adding the first flag, wiring `vercelAdapter` /
+  FLAGS env vars, using the `vercel flags` CLI (create, list, enable, disable, inspect, archive,
+  rm, sdk-keys, rules), setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog,
+  GrowthBook, Hypertune, Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom),
+  integrating Flags Explorer/Toolbar, implementing precompute, `identify`/`dedupe`, or evaluating
+  flags in Next.js (App Router, Pages Router, Middleware) or SvelteKit.
+  Triggers: set up feature flags, install Flags SDK, add a feature flag, A/B testing, experimentation,
+  feature gates, flag overrides, Vercel Flags, vercel flags create/list/enable/disable,
+  Flags Explorer, `flags/next`, `flags/sveltekit`, `flags/react`, `@flags-sdk/*`.
 ---
 
-# Flags SDK
+# Set up the Flags SDK
 
 The Flags SDK (`flags` npm package) is a feature flags toolkit for Next.js and SvelteKit. It turns each feature flag into a callable function, works with any flag provider via adapters, and keeps pages static using the precompute pattern. Vercel Flags is the first-party provider, letting you manage flags from the Vercel dashboard or the `vercel flags` CLI.
 
 - Docs: https://flags-sdk.dev
 - Repo: https://github.com/vercel/flags
+
+When the user asks to install, configure, or set up feature flags, follow [Set up the SDK](#set-up-the-sdk). When they ask to create or add a flag, follow [Create a flag](#create-a-flag). Do not leave CLI steps as "next steps" for the user — execute them yourself.
 
 ## Core concepts
 
@@ -60,9 +59,9 @@ export const exampleFlag = flag({
 
 > **Version note**: The SDK is published as `flags` (renamed from `@vercel/flags`; that old name still appears in changelog history). `flags` 4.2.0+ accepts the adapter factory by reference (`adapter: vercelAdapter`) and resolves it once per declaration. Older versions require calling it (`adapter: vercelAdapter()`). The called form still works on new versions, so prefer the shorthand unless you're targeting `flags` < 4.2.0.
 
-## Agent workflow: Creating a new flag
+## Set up the SDK
 
-When a user asks you to create or add a feature flag, follow these steps in order. Do not leave CLI steps as "next steps" for the user — execute them yourself.
+One-time project setup. Run this when the Flags SDK is not installed yet, or when Toolbar / Flags Explorer are missing. Skip any step that is already done.
 
 ### Before you start
 
@@ -71,10 +70,8 @@ Check the project state to adapt commands and decide which steps you can skip:
 - Which lockfile is present (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `bun.lockb`)? → Adapt all package manager commands accordingly (`pnpm add`, `npm install`, `yarn add`, `bun add`).
 - Is `flags` in `package.json`? → Skip install (step 1)
 - Does `.vercel/` directory exist? → Project is linked, skip `vercel link` in step 2
-- Does `.env.local` contain `FLAGS=`? → Env vars already pulled, skip step 3
-- Does `flags.ts` (or `lib/flags.ts`, `src/flags.ts`) exist? → Add to it rather than creating from scratch (step 4)
-- Is `@vercel/toolbar` in `package.json`? → Skip toolbar setup (step 6)
-- Does `app/.well-known/vercel/flags/route.ts` exist? → Flags Explorer already set up, skip step 7
+- Is `@vercel/toolbar` in `package.json`? → Skip toolbar setup (step 3)
+- Does `app/.well-known/vercel/flags/route.ts` exist? → Flags Explorer already set up, skip step 4
 
 ### Steps
 
@@ -83,11 +80,38 @@ Check the project state to adapt commands and decide which steps you can skip:
    pnpm i flags @flags-sdk/vercel
    ```
 
-2. **Register the flag with Vercel**: Run `vercel flags add <flag-key> --kind boolean --description "<description>"`.
-
+2. **Link the project to Vercel** (required for `vercel flags` and env vars):
    > **Prerequisite**: The `vercel flags` commands require the Vercel CLI to be installed and authenticated. If the Vercel CLI is not installed, run `pnpm i -g vercel`. For authentication or linking issues, follow the `vercel-cli` skill if it's already available. If it isn't, suggest the user install it with `npx skills add vercel/vercel@vercel-cli` (don't auto-install it) and rely on `vercel <command> --help` in the meantime.
 
-   Before running `vercel flags add`, verify the project is linked to Vercel. Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link` first.
+   Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link`.
+
+3. **Set up the Vercel Toolbar** (if not already present):
+   - Run `pnpm i @vercel/toolbar`
+   - Wrap `next.config.ts` with the toolbar plugin
+   - Render `<VercelToolbar />` in the root layout
+   See [references/nextjs.md — Toolbar Setup](references/nextjs.md#toolbar-setup) for the full code.
+
+4. **Set up Flags Explorer** (if not already present): Create `app/.well-known/vercel/flags/route.ts` — see [Flags Explorer setup](#flags-explorer-setup).
+
+`FLAGS` and `FLAGS_SECRET` are written when you create a flag on Vercel. After the first flag, run `vercel env pull` (see [Create a flag](#create-a-flag)). For manual `FLAGS_SECRET` generation, see [FLAGS_SECRET](#flags_secret).
+
+## Create a flag
+
+When a user asks you to create or add a feature flag, follow these steps in order.
+
+### Before you start
+
+- Complete [Set up the SDK](#set-up-the-sdk) first if packages, Vercel link, Toolbar, or Flags Explorer are missing. Skip steps that are already done.
+- Does `.env.local` contain `FLAGS=`? → Env vars already pulled; still re-pull after creating a new flag if evaluation fails.
+- Does `flags.ts` (or `lib/flags.ts`, `src/flags.ts`) exist? → Add to it rather than creating from scratch.
+
+### Steps
+
+1. **Ensure the SDK is set up**: Follow [Set up the SDK](#set-up-the-sdk) if needed, then continue.
+
+2. **Register the flag with Vercel**: Run `vercel flags create <flag-key> --kind boolean --description "<description>"`.
+
+   Before running `vercel flags create`, verify the project is linked (`.vercel` directory). If missing, run `vercel link` first.
 
 3. **Pull environment variables**: Run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter` will not be able to evaluate flags. This step is **mandatory** after creating a flag.
 
@@ -112,25 +136,17 @@ Check the project state to adapt commands and decide which steps you can skip:
    }
    ```
 
-6. **Set up the Vercel Toolbar** (if not already present):
-   - Run `pnpm i @vercel/toolbar`
-   - Wrap `next.config.ts` with the toolbar plugin
-   - Render `<VercelToolbar />` in the root layout
-   See [references/nextjs.md — Toolbar Setup](references/nextjs.md#toolbar-setup) for the full code.
-
-7. **Set up Flags Explorer** (if not already present): Create `app/.well-known/vercel/flags/route.ts` — see the [Flags Explorer setup](#flags-explorer-setup) section below.
-
 ## Vercel Flags
 
 Vercel Flags is Vercel's feature flags platform. You create and manage flags from the Vercel dashboard or the `vercel flags` CLI, then connect them to your code with the `@flags-sdk/vercel` adapter. When you create a flag in Vercel, the `FLAGS` and `FLAGS_SECRET` environment variables are configured automatically.
 
-To create a flag end-to-end, follow the [Agent workflow](#agent-workflow-creating-a-new-flag) above.
+To install the SDK, follow [Set up the SDK](#set-up-the-sdk). To create a flag end-to-end, follow [Create a flag](#create-a-flag).
 
 For the full Vercel provider reference — user targeting, `vercel flags` CLI subcommands, custom adapter configuration, and Flags Explorer setup — see [references/providers.md](references/providers.md#vercel).
 
 ## Declaring flags
 
-When using Vercel Flags, declare flags with `vercelAdapter` as shown in the [Agent workflow](#agent-workflow-creating-a-new-flag). For other providers, see [references/providers.md](references/providers.md). Below are the general `flag()` patterns.
+When using Vercel Flags, declare flags with `vercelAdapter` as shown in [Create a flag](#create-a-flag). For other providers, see [references/providers.md](references/providers.md). Below are the general `flag()` patterns.
 
 ### Basic flag
 
@@ -177,6 +193,8 @@ export const dashboardFlag = flag<boolean, Entities>({
   },
 });
 ```
+
+Timestamp entity attributes are numbers. Pass epoch milliseconds in `identify()` / evaluation context (for example `Date.now()` or a stable `Date.parse(...)` value).
 
 ### Flag with another adapter
 

--- a/skills/flags-sdk/SKILL.md
+++ b/skills/flags-sdk/SKILL.md
@@ -3,13 +3,13 @@ name: flags-sdk
 description: >
   Set up and use feature flags and A/B tests with the Flags SDK (`flags` npm package) and Vercel Flags.
   Use when installing or configuring the SDK, adding the first flag, wiring `vercelAdapter` /
-  FLAGS env vars, using the `vercel flags` CLI (create, list, enable, disable, inspect, archive,
+  FLAGS env vars, using the `vercel flags` CLI (add, list, enable, disable, inspect, archive,
   rm, sdk-keys), setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog,
   GrowthBook, Hypertune, Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom),
   integrating Flags Explorer/Toolbar, implementing precompute, `identify`/`dedupe`, or evaluating
   flags in Next.js (App Router, Pages Router, Middleware) or SvelteKit.
   Triggers: set up feature flags, install Flags SDK, add a feature flag, A/B testing, experimentation,
-  feature gates, flag overrides, Vercel Flags, vercel flags create/list/enable/disable,
+  feature gates, flag overrides, Vercel Flags, vercel flags add/list/enable/disable,
   Flags Explorer, `flags/next`, `flags/sveltekit`, `flags/react`, `@flags-sdk/*`.
 ---
 
@@ -109,9 +109,9 @@ When a user asks you to create or add a feature flag, follow these steps in orde
 
 1. **Ensure the SDK is set up**: Follow [Set up the SDK](#set-up-the-sdk) if needed, then continue.
 
-2. **Register the flag with Vercel**: Run `vercel flags create <flag-key> --kind boolean --description "<description>"`.
+2. **Register the flag with Vercel**: Run `vercel flags add <flag-key> --kind boolean --description "<description>"`.
 
-   Before running `vercel flags create`, verify the project is linked (`.vercel` directory). If missing, run `vercel link` first.
+   Before running `vercel flags add`, verify the project is linked (`.vercel` directory). If missing, run `vercel link` first.
 
 3. **Pull environment variables**: Run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter` will not be able to evaluate flags. This step is **mandatory** after creating a flag.
 

--- a/skills/flags-sdk/SKILL.md
+++ b/skills/flags-sdk/SKILL.md
@@ -13,7 +13,7 @@ description: >
   Flags Explorer, `flags/next`, `flags/sveltekit`, `flags/react`, `@flags-sdk/*`.
 ---
 
-# Set up the Flags SDK
+# Set up and use the Flags SDK
 
 The Flags SDK (`flags` npm package) is a feature flags toolkit for Next.js and SvelteKit. It turns each feature flag into a callable function, works with any flag provider via adapters, and keeps pages static using the precompute pattern. Vercel Flags is the first-party provider, letting you manage flags from the Vercel dashboard or the `vercel flags` CLI.
 

--- a/skills/flags-sdk/SKILL.md
+++ b/skills/flags-sdk/SKILL.md
@@ -3,14 +3,19 @@ name: flags-sdk
 description: >
   Set up and use feature flags and A/B tests with the Flags SDK (`flags` npm package) and Vercel Flags.
   Use when installing or configuring the SDK, adding the first flag, wiring `vercelAdapter` /
-  FLAGS env vars, using the `vercel flags` CLI (add, list, enable, disable, inspect, archive,
-  rm, sdk-keys), setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog,
-  GrowthBook, Hypertune, Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom),
-  integrating Flags Explorer/Toolbar, implementing precompute, `identify`/`dedupe`, or evaluating
-  flags in Next.js (App Router, Pages Router, Middleware) or SvelteKit.
-  Triggers: set up feature flags, install Flags SDK, add a feature flag, A/B testing, experimentation,
-  feature gates, flag overrides, Vercel Flags, vercel flags add/list/enable/disable,
-  Flags Explorer, `flags/next`, `flags/sveltekit`, `flags/react`, `@flags-sdk/*`.
+  FLAGS env vars, declaring flags with `flag()`, using the `vercel flags` CLI
+  (add, list, enable, disable, inspect, archive, rm, sdk-keys),
+  setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog, GrowthBook, Hypertune,
+  Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom adapters),
+  implementing precompute patterns for static pages, setting up `identify`/`dedupe`,
+  integrating Flags Explorer/Toolbar,
+  working with flags in Next.js (App Router, Pages Router, Middleware) or SvelteKit,
+  writing custom adapters, or encrypting/decrypting flag values.
+  Triggers: set up feature flags, install Flags SDK, add a feature flag, feature flags,
+  A/B testing, experimentation, flags SDK, flag adapters, precompute,
+  Flags Explorer, feature gates, flag overrides, Vercel Flags, vercel flags CLI, vercel flags add,
+  vercel flags list, vercel flags enable, vercel flags disable,
+  `flags/next`, `flags/sveltekit`, `flags/react`, `@flags-sdk/*`.
 ---
 
 # Set up and use the Flags SDK
@@ -20,7 +25,7 @@ The Flags SDK (`flags` npm package) is a feature flags toolkit for Next.js and S
 - Docs: https://flags-sdk.dev
 - Repo: https://github.com/vercel/flags
 
-When the user asks to install, configure, or set up feature flags, follow [Set up the SDK](#set-up-the-sdk). When they ask to create or add a flag, follow [Create a flag](#create-a-flag). Do not leave CLI steps as "next steps" for the user — execute them yourself.
+When the user asks to install, configure, or set up feature flags, follow [Set up the SDK](#set-up-the-sdk) (including `vercel env pull` when `FLAGS` is missing). When they ask to create or add a flag, follow [Create a flag](#create-a-flag). Do not leave CLI steps as "next steps" for the user — execute them yourself.
 
 ## Core concepts
 
@@ -61,7 +66,7 @@ export const exampleFlag = flag({
 
 ## Set up the SDK
 
-One-time project setup. Run this when the Flags SDK is not installed yet, or when Toolbar / Flags Explorer are missing. Skip any step that is already done.
+One-time project setup. Run this when the Flags SDK is not installed yet, or when Toolbar / Flags Explorer / `FLAGS` env are missing. Skip any step that is already done.
 
 ### Before you start
 
@@ -70,8 +75,10 @@ Check the project state to adapt commands and decide which steps you can skip:
 - Which lockfile is present (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `bun.lockb`)? → Adapt all package manager commands accordingly (`pnpm add`, `npm install`, `yarn add`, `bun add`).
 - Is `flags` in `package.json`? → Skip install (step 1)
 - Does `.vercel/` directory exist? → Project is linked, skip `vercel link` in step 2
-- Is `@vercel/toolbar` in `package.json`? → Skip toolbar setup (step 3)
-- Does `app/.well-known/vercel/flags/route.ts` exist? → Flags Explorer already set up, skip step 4
+- Does `.env.local` contain `FLAGS=`? → Env vars already pulled, skip step 3
+- Is `@vercel/toolbar` in `package.json`? → Skip toolbar setup (step 4)
+- Does `flags.ts` (or `lib/flags.ts`, `src/flags.ts`) exist? → Skip creating it (step 5)
+- Does `app/.well-known/vercel/flags/route.ts` exist? → Flags Explorer already set up, skip step 6
 
 ### Steps
 
@@ -85,15 +92,17 @@ Check the project state to adapt commands and decide which steps you can skip:
 
    Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link`.
 
-3. **Set up the Vercel Toolbar** (if not already present):
+3. **Pull environment variables**: If `.env.local` lacks `FLAGS=`, run `vercel env pull`. Required for `vercelAdapter` when flags already exist on Vercel (fresh clone / configure). If no flags exist on Vercel yet, skip — vars are written when you create a flag (see [Create a flag](#create-a-flag)). For manual `FLAGS_SECRET` generation, see [FLAGS_SECRET](#flags_secret).
+
+4. **Set up the Vercel Toolbar** (if not already present):
    - Run `pnpm i @vercel/toolbar`
    - Wrap `next.config.ts` with the toolbar plugin
    - Render `<VercelToolbar />` in the root layout
    See [references/nextjs.md — Toolbar Setup](references/nextjs.md#toolbar-setup) for the full code.
 
-4. **Set up Flags Explorer** (if not already present): Create `app/.well-known/vercel/flags/route.ts` — see [Flags Explorer setup](#flags-explorer-setup).
+5. **Ensure `flags.ts` exists**: If missing, create `flags.ts` (or `lib/flags.ts` / `src/flags.ts` to match the project) as an empty module. Flags Explorer imports this file — create it before the discovery route.
 
-`FLAGS` and `FLAGS_SECRET` are written when you create a flag on Vercel. After the first flag, run `vercel env pull` (see [Create a flag](#create-a-flag)). For manual `FLAGS_SECRET` generation, see [FLAGS_SECRET](#flags_secret).
+6. **Set up Flags Explorer** (if not already present): Create `app/.well-known/vercel/flags/route.ts` — see [Flags Explorer setup](#flags-explorer-setup). Do this only after `flags.ts` exists.
 
 ## Create a flag
 
@@ -101,7 +110,7 @@ When a user asks you to create or add a feature flag, follow these steps in orde
 
 ### Before you start
 
-- Complete [Set up the SDK](#set-up-the-sdk) first if packages, Vercel link, Toolbar, or Flags Explorer are missing. Skip steps that are already done.
+- Complete [Set up the SDK](#set-up-the-sdk) first if packages, Vercel link, `FLAGS` env, Toolbar, `flags.ts`, or Flags Explorer are missing. Skip steps that are already done.
 - Does `.env.local` contain `FLAGS=`? → Env vars already pulled; still re-pull after creating a new flag if evaluation fails.
 - Does `flags.ts` (or `lib/flags.ts`, `src/flags.ts`) exist? → Add to it rather than creating from scratch.
 
@@ -110,8 +119,6 @@ When a user asks you to create or add a feature flag, follow these steps in orde
 1. **Ensure the SDK is set up**: Follow [Set up the SDK](#set-up-the-sdk) if needed, then continue.
 
 2. **Register the flag with Vercel**: Run `vercel flags add <flag-key> --kind boolean --description "<description>"`.
-
-   Before running `vercel flags add`, verify the project is linked (`.vercel` directory). If missing, run `vercel link` first.
 
 3. **Pull environment variables**: Run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter` will not be able to evaluate flags. This step is **mandatory** after creating a flag.
 

--- a/skills/flags-sdk/SKILL.md
+++ b/skills/flags-sdk/SKILL.md
@@ -5,7 +5,7 @@ description: >
   Use when installing or configuring the SDK, adding a flag, wiring `vercelAdapter` / FLAGS env vars,
   declaring flags with `flag()`, using `vercel flags` CLI (add, list, enable, disable, inspect,
   archive, rm, sdk-keys), setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog,
-  GrowthBook, Hypertune, Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom),
+  GrowthBook, Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom),
   precompute, `identify`/`dedupe`, Flags Explorer/Toolbar, Next.js or SvelteKit, custom adapters,
   or encrypting/decrypting flag values.
   Triggers: set up feature flags, install Flags SDK, add a feature flag, feature flags,
@@ -384,5 +384,5 @@ Detailed framework and provider guides are in separate files to keep context lea
 
 - **[references/nextjs.md](references/nextjs.md)**: Next.js quickstart, toolbar, App Router, Pages Router, middleware/proxy, precompute, dedupe, dashboard pages, marketing pages, suspense fallbacks
 - **[references/sveltekit.md](references/sveltekit.md)**: SvelteKit quickstart, toolbar, hooks setup, precompute with reroute + middleware, dashboard pages, marketing pages
-- **[references/providers.md](references/providers.md)**: All provider adapters — Vercel, Global Config, Statsig, LaunchDarkly, PostHog, GrowthBook, Hypertune, Flagsmith, Reflag, Split, Optimizely, OpenFeature, and custom adapters
+- **[references/providers.md](references/providers.md)**: All provider adapters — Vercel, Global Config, Statsig, LaunchDarkly, PostHog, GrowthBook, Flagsmith, Reflag, Split, Optimizely, OpenFeature, and custom adapters
 - **[references/api.md](references/api.md)**: Full API reference for `flags`, `flags/react`, `flags/next`, and `flags/sveltekit`

--- a/skills/flags-sdk/SKILL.md
+++ b/skills/flags-sdk/SKILL.md
@@ -88,7 +88,7 @@ Check the project state to adapt commands and decide which steps you can skip:
 
    Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link`.
 
-3. **Pull environment variables**: If `.env.local` lacks `FLAGS=`, run `vercel env pull`. Required for `vercelAdapter` when flags already exist on Vercel (fresh clone / configure). If no flags exist on Vercel yet, skip — vars are written when you create a flag (see [Create a flag](#create-a-flag)). For manual `FLAGS_SECRET` generation, see [FLAGS_SECRET](#flags_secret).
+3. **Pull environment variables**: If `.env.local` lacks `FLAGS=`, run `vercel env pull`. Required for `vercelAdapter` when flags already exist on Vercel (fresh clone / configure). If no flags exist on Vercel yet, skip — `FLAGS` is written when you create a flag (see [Create a flag](#create-a-flag)). Setup-only still needs `FLAGS_SECRET` for Flags Explorer / overrides — generate it per [FLAGS_SECRET](#flags_secret) if missing after pull.
 
 4. **Set up the Vercel Toolbar** (if not already present):
    - Run `pnpm i @vercel/toolbar`
@@ -96,9 +96,9 @@ Check the project state to adapt commands and decide which steps you can skip:
    - Render `<VercelToolbar />` in the root layout
    See [references/nextjs.md — Toolbar Setup](references/nextjs.md#toolbar-setup) for the full code.
 
-5. **Ensure `flags.ts` exists**: If missing, create `flags.ts` (or `lib/flags.ts` / `src/flags.ts` to match the project) as an empty module. Flags Explorer imports this file — create it before the discovery route.
+5. **Ensure `flags.ts` exists**: If missing, create `flags.ts` (or `lib/flags.ts` / `src/flags.ts` to match the project) with `export {}` so TypeScript treats it as a module. Flags Explorer imports this file — create it before the discovery route.
 
-6. **Set up Flags Explorer** (if not already present): Create `app/.well-known/vercel/flags/route.ts` — see [Flags Explorer setup](#flags-explorer-setup). Do this only after `flags.ts` exists.
+6. **Set up Flags Explorer** (if not already present): Create `app/.well-known/vercel/flags/route.ts` — see [Flags Explorer setup](#flags-explorer-setup). Do this only after `flags.ts` exists. Point the import at the real flags file path (the snippet assumes root `flags.ts`).
 
 ## Create a flag
 
@@ -283,7 +283,7 @@ Adapters can opt into batching by implementing the optional `bulkDecide` hook. T
 // app/.well-known/vercel/flags/route.ts
 import { createFlagsDiscoveryEndpoint } from 'flags/next';
 import { getProviderData } from '@flags-sdk/vercel';
-import * as flags from '../../../../flags';
+import * as flags from '../../../../flags'; // adjust if flags live under lib/ or src/
 
 export const GET = createFlagsDiscoveryEndpoint(async () => {
   return getProviderData(flags);

--- a/skills/flags-sdk/references/providers.md
+++ b/skills/flags-sdk/references/providers.md
@@ -32,7 +32,7 @@ pnpm i flags @flags-sdk/vercel
 
 Before running any `vercel flags` command, verify the project is linked to Vercel. Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link` first.
 
-1. Create a flag in the Vercel dashboard or via CLI: `vercel flags create <flag-key> --kind boolean --description "<description>"`
+1. Create a flag in the Vercel dashboard or via CLI: `vercel flags add <flag-key> --kind boolean --description "<description>"`
 2. Pull env vars: you **must** run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter` will not be able to evaluate flags.
 3. Declare the flag:
 
@@ -122,7 +122,7 @@ Manage Vercel Flags from the terminal. Requires the [Vercel CLI](https://vercel.
 | Subcommand   | Description                                           |
 | ------------ | ----------------------------------------------------- |
 | `list`       | List all flags in the project                         |
-| `create`     | Create a new flag (`add` is an alias)                 |
+| `add`        | Create a new flag                                     |
 | `inspect`    | Show details, status, and targeting rules of a flag   |
 | `enable`     | Enable a boolean flag for a specific environment      |
 | `disable`    | Disable a boolean flag for a specific environment     |
@@ -134,7 +134,7 @@ Manage Vercel Flags from the terminal. Requires the [Vercel CLI](https://vercel.
 
 ```bash
 # Create a boolean flag with a description
-vercel flags create my-feature --kind boolean --description "New onboarding flow"
+vercel flags add my-feature --kind boolean --description "New onboarding flow"
 
 # Enable in development first
 vercel flags enable my-feature --environment development

--- a/skills/flags-sdk/references/providers.md
+++ b/skills/flags-sdk/references/providers.md
@@ -32,7 +32,7 @@ pnpm i flags @flags-sdk/vercel
 
 Before running any `vercel flags` command, verify the project is linked to Vercel. Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link` first.
 
-1. Create a flag in the Vercel dashboard or via CLI: `vercel flags add <flag-key> --kind boolean --description "<description>"`
+1. Create a flag in the Vercel dashboard or via CLI: `vercel flags create <flag-key> --kind boolean --description "<description>"`
 2. Pull env vars: you **must** run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter` will not be able to evaluate flags.
 3. Declare the flag:
 
@@ -122,19 +122,22 @@ Manage Vercel Flags from the terminal. Requires the [Vercel CLI](https://vercel.
 | Subcommand   | Description                                           |
 | ------------ | ----------------------------------------------------- |
 | `list`       | List all flags in the project                         |
-| `add`        | Create a new flag                                     |
+| `create`     | Create a new flag (`add` is an alias)                 |
 | `inspect`    | Show details, status, and targeting rules of a flag   |
 | `enable`     | Enable a boolean flag for a specific environment      |
 | `disable`    | Disable a boolean flag for a specific environment     |
 | `archive`    | Archive a flag (required before deleting)              |
 | `rm`         | Delete an archived flag                               |
 | `sdk-keys`   | Manage SDK keys (subcommands: `ls`, `add`, `rm`)      |
+| `rules`      | Manage targeting rules (`ls`, `add`, `update`, `move`, `rm`) |
+
+Timestamp attributes are numbers: pass epoch milliseconds in `identify()` / evaluation context. Flag rules accept ISO 8601 date/time or epoch ms, for example `vercel flags rules add my-feature -e production --condition user.signupAt:after:2026-04-16T09:00:00Z --variant on`.
 
 #### Create and toggle a flag
 
 ```bash
 # Create a boolean flag with a description
-vercel flags add my-feature --kind boolean --description "New onboarding flow"
+vercel flags create my-feature --kind boolean --description "New onboarding flow"
 
 # Enable in development first
 vercel flags enable my-feature --environment development

--- a/skills/flags-sdk/references/providers.md
+++ b/skills/flags-sdk/references/providers.md
@@ -129,9 +129,6 @@ Manage Vercel Flags from the terminal. Requires the [Vercel CLI](https://vercel.
 | `archive`    | Archive a flag (required before deleting)              |
 | `rm`         | Delete an archived flag                               |
 | `sdk-keys`   | Manage SDK keys (subcommands: `ls`, `add`, `rm`)      |
-| `rules`      | Manage targeting rules (`ls`, `add`, `update`, `move`, `rm`) |
-
-Timestamp attributes are numbers: pass epoch milliseconds in `identify()` / evaluation context. Flag rules accept ISO 8601 date/time or epoch ms, for example `vercel flags rules add my-feature -e production --condition user.signupAt:after:2026-04-16T09:00:00Z --variant on`.
 
 #### Create and toggle a flag
 

--- a/skills/flags-sdk/references/providers.md
+++ b/skills/flags-sdk/references/providers.md
@@ -8,7 +8,6 @@
 - [LaunchDarkly](#launchdarkly)
 - [PostHog](#posthog)
 - [GrowthBook](#growthbook)
-- [Hypertune](#hypertune)
 - [Flagsmith](#flagsmith)
 - [Reflag](#reflag)
 - [OpenFeature](#openfeature)
@@ -496,32 +495,6 @@ growthbookAdapter.setTrackingCallback((experiment, result) => {
     console.log('Experiment', experiment.key, 'Variation', result.key);
   });
 });
-```
-
----
-
-## Hypertune
-
-Package: `@flags-sdk/hypertune`
-
-```bash
-pnpm i hypertune flags server-only @flags-sdk/hypertune @vercel/global-config
-```
-
-Requires code generation: `npx hypertune`
-
-```ts
-import { createHypertuneAdapter } from '@flags-sdk/hypertune';
-import { createSource, flagFallbacks, vercelFlagDefinitions, type Context, type FlagValues } from './generated/hypertune';
-
-const hypertuneAdapter = createHypertuneAdapter<FlagValues, Context>({
-  createSource,
-  flagFallbacks,
-  flagDefinitions: vercelFlagDefinitions,
-  identify,
-});
-
-export const exampleFlag = flag(hypertuneAdapter.declarations.exampleFlag);
 ```
 
 ---


### PR DESCRIPTION
## Summary
- [EXP-3402](https://linear.app/vercel/issue/EXP-3402/flags-sdk-skill-make-setup-discoverable-via-titledescription): reframe the skill description and H1 around setup and use so agents load it for install/configure, not only usage
- Split one-time [Set up the SDK] vs [Create a flag] (setup is step 1)

## Test plan
- [ ] Ask an agent to “set up feature flags” / “install the Flags SDK” and confirm this skill is selected
- [ ] Ask to “add a feature flag” on a project that already has the SDK and confirm it skips setup and goes to add → env pull → declare → use
- [ ] Ask to “add a feature flag” when packages are missing and confirm setup runs first