### PR TITLE
Prefer vercel flags create over add in the skill

### DIFF
--- a/skills/flags-sdk/SKILL.md
+++ b/skills/flags-sdk/SKILL.md
@@ -3,14 +3,14 @@ name: flags-sdk
 description: >
   Set up and use feature flags and A/B tests with the Flags SDK (`flags` npm package) and Vercel Flags.
   Use when installing or configuring the SDK, adding a flag, wiring `vercelAdapter` / FLAGS env vars,
-  declaring flags with `flag()`, using `vercel flags` CLI (add, list, enable, disable, inspect,
+  declaring flags with `flag()`, using `vercel flags` CLI (create, list, enable, disable, inspect,
   archive, rm, sdk-keys), setting up providers/adapters (Vercel, Statsig, LaunchDarkly, PostHog,
   GrowthBook, Global Config, OpenFeature, Split, Flagsmith, Reflag, Optimizely, or custom),
   precompute, `identify`/`dedupe`, Flags Explorer/Toolbar, Next.js or SvelteKit, custom adapters,
   or encrypting/decrypting flag values.
   Triggers: set up feature flags, install Flags SDK, add a feature flag, feature flags,
   A/B testing, experimentation, flags SDK, flag adapters, precompute, Flags Explorer,
-  feature gates, flag overrides, Vercel Flags, vercel flags CLI, vercel flags add/list/enable/disable,
+  feature gates, flag overrides, Vercel Flags, vercel flags CLI, vercel flags create/list/enable/disable,
   `flags/next`, `flags/sveltekit`, `flags/react`, `@flags-sdk/*`.
 ---
 
@@ -114,7 +114,9 @@ When a user asks you to create or add a feature flag, follow these steps in orde
 
 1. **Ensure the SDK is set up**: Follow [Set up the SDK](#set-up-the-sdk) if needed, then continue.
 
-2. **Register the flag with Vercel**: Run `vercel flags add <flag-key> --kind boolean --description "<description>"`.
+2. **Register the flag with Vercel**: Run `vercel flags create <flag-key> --kind boolean --description "<description>"`.
+
+   Before running `vercel flags create`, verify the project is linked (`.vercel` directory). If missing, run `vercel link` first.
 
 3. **Pull environment variables**: Run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter` will not be able to evaluate flags. This step is **mandatory** after creating a flag.
 

--- a/skills/flags-sdk/references/providers.md
+++ b/skills/flags-sdk/references/providers.md
@@ -31,7 +31,7 @@ pnpm i flags @flags-sdk/vercel
 
 Before running any `vercel flags` command, verify the project is linked to Vercel. Check for a `.vercel` directory in the project root. If it doesn't exist, run `vercel link` first.
 
-1. Create a flag in the Vercel dashboard or via CLI: `vercel flags add <flag-key> --kind boolean --description "<description>"`
+1. Create a flag in the Vercel dashboard or via CLI: `vercel flags create <flag-key> --kind boolean --description "<description>"`
 2. Pull env vars: you **must** run `vercel env pull` to write `FLAGS` and `FLAGS_SECRET` to `.env.local`. Without these environment variables, `vercelAdapter` will not be able to evaluate flags.
 3. Declare the flag:
 
@@ -121,7 +121,7 @@ Manage Vercel Flags from the terminal. Requires the [Vercel CLI](https://vercel.
 | Subcommand   | Description                                           |
 | ------------ | ----------------------------------------------------- |
 | `list`       | List all flags in the project                         |
-| `add`        | Create a new flag                                     |
+| `create`     | Create a new flag (`add` is an alias)                 |
 | `inspect`    | Show details, status, and targeting rules of a flag   |
 | `enable`     | Enable a boolean flag for a specific environment      |
 | `disable`    | Disable a boolean flag for a specific environment     |
@@ -133,7 +133,7 @@ Manage Vercel Flags from the terminal. Requires the [Vercel CLI](https://vercel.
 
 ```bash
 # Create a boolean flag with a description
-vercel flags add my-feature --kind boolean --description "New onboarding flow"
+vercel flags create my-feature --kind boolean --description "New onboarding flow"
 
 # Enable in development first
 vercel flags enable my-feature --environment development

--- a/skills/flags-sdk/references/providers.md
+++ b/skills/flags-sdk/references/providers.md
@@ -121,7 +121,7 @@ Manage Vercel Flags from the terminal. Requires the [Vercel CLI](https://vercel.
 | Subcommand   | Description                                           |
 | ------------ | ----------------------------------------------------- |
 | `list`       | List all flags in the project                         |
-| `create`     | Create a new flag (`add` is an alias)                 |
+| `create`     | Create a new flag                                     |
 | `inspect`    | Show details, status, and targeting rules of a flag   |
 | `enable`     | Enable a boolean flag for a specific environment      |
 | `disable`    | Disable a boolean flag for a specific environment     |


### PR DESCRIPTION
## Summary
- [EXP-3408](https://linear.app/vercel/issue/EXP-3408/flags-sdk-skill-prefer-vercel-flags-create-over-add): prefer `vercel flags create` in the flags-sdk skill

## Test plan
- [ ] Compare examples against `vercel flags create --help`
- [ ] Confirm `sdk-keys add` docs are unchanged