### PR TITLE
[EXP-3419] flags-core: forward minimum config freshness requirement

### DIFF
--- a/.changeset/quiet-configs-catch-up.md
+++ b/.changeset/quiet-configs-catch-up.md
@@ -1,0 +1,9 @@
+---
+'@vercel/flags-core': patch
+---
+
+Forward a minimum config freshness requirement when the Vercel Edge Network advertises a newer flag configuration than the one held in memory.
+
+The `x-vercel-edge-config-versions` request header carries the last known update timestamp of a project's flag configuration under the `flags_<projectId>` key. When that timestamp is newer than the in-memory data, the client now sends `X-Config-Min-Updated-At` on datafile fetches and stream connections, and reports its current `configUpdatedAt` as `X-Config-Updated-At` on stream connections. `X-Revision` is unchanged.
+
+A response that does not meet the minimum no longer resolves initialization as fresh: `initialize()` keeps waiting for satisfying data and then falls back to the existing data, which is reported with `cacheStatus: 'STALE'`. The requirement is re-read per `initialize()`/`read()`/`getDatafile()` call so long-lived clients pick up newer requirements on later requests, is monotonic (an older header never downgrades it), and triggers at most one deduplicated background refresh per client per requirement. Build-step and non-Vercel behavior is unchanged.

--- a/packages/vercel-flags-core/CLAUDE.md
+++ b/packages/vercel-flags-core/CLAUDE.md
@@ -31,6 +31,8 @@ src/
 │   ├── usage-tracker.ts
 │   ├── sdk-keys.ts
 │   ├── sleep.ts
+│   ├── request-context.ts
+│   ├── edge-config-versions.ts  # x-vercel-edge-config-versions parsing
 │   └── read-bundled-definitions.ts
 └── lib/
     └── report-value.ts   # Flag evaluation reporting to Vercel request context
@@ -232,6 +234,8 @@ When updating tests for new behavior, preserve the strength of existing assertio
 - Uses fetch with streaming body (NDJSON format)
 - Callbacks: `onDatafile` (new data), `onPrimed` (server confirmed revision is current), `onDisconnect`
 - Sends `X-Revision` header with the current revision number on every connection (including reconnects), allowing the server to respond with a lightweight `primed` message instead of a full datafile when the revision is current
+- Also sends `X-Config-Updated-At` (the `configUpdatedAt` currently held in memory) and, when a minimum is required, `X-Config-Min-Updated-At` — see "Minimum Config Freshness". All three getters are re-read per connection attempt, so reconnects reflect the latest state
+- `canResolveInit` lets the owner reject a `datafile`/`primed` message for init purposes: the message is still delivered to the callbacks, but the init promise keeps waiting for one that satisfies the freshness requirement
 - The `primed` message confirms the client's data is up-to-date; it resolves the init promise (like `datafile`) but does not update data — only transitions state to `streaming`
 - Reconnects with exponential backoff (base: 1s, max: 60s, max retries: 15)
 - Retries on transient errors both before and after initial data is received. Before initial data, retries continue until max retries are exhausted or the abort controller is aborted (e.g., by the Controller's init timeout). The init promise rejects when the loop exits without data.
@@ -250,6 +254,7 @@ When updating tests for new behavior, preserve the strength of existing assertio
 - Stops automatically when stream reconnects
 - `PollingSource` passes its abort signal to `fetchDatafile`, so calling `stop()` aborts in-flight HTTP requests
 - `fetchDatafile` accepts an optional `signal` parameter; when provided, it aborts the internal fetch controller when the external signal fires
+- `fetchDatafile` accepts an optional `minUpdatedAt` parameter, sent as `X-Config-Min-Updated-At` — see "Minimum Config Freshness"
 
 ### Data Origin Tagging
 
@@ -281,6 +286,46 @@ The Controller tags all data with its origin using `tagData(data, origin)` from 
 ### configUpdatedAt Guard
 
 The Controller rejects incoming data (from stream or poll) if its `configUpdatedAt` is older than or equal to the current in-memory data. This prevents stale updates from overwriting newer data. Accepts the update if either side lacks a `configUpdatedAt`.
+
+### Minimum Config Freshness
+
+The Vercel Edge Network attaches `x-vercel-edge-config-versions` to incoming
+requests: semicolon-separated `<id>=<updatedAt>` pairs, where the entry keyed
+`flags_<projectId>` is the last known update timestamp of that project's flag
+configuration (see `utils/edge-config-versions.ts`). When it is newer than the
+data held in memory, the Controller treats it as a minimum the next response
+must satisfy:
+
+- `X-Config-Min-Updated-At` is forwarded on datafile fetches (poll, one-time
+  fetch, refresh) and on stream connections
+- A response below the minimum **does not resolve initialization as fresh** —
+  `canResolveInit` withholds the stream init promise and `completePollingInit`
+  reports failure, so `initialize()` keeps waiting up to `initTimeoutMs` and
+  then falls back to the existing data
+- Data below the minimum is reported with `cacheStatus: 'STALE'` even while the
+  stream is connected
+
+Because controllers are module-scoped and outlive individual requests, the
+header is re-read on every `initialize()`, `read()`, and `getDatafile()` call.
+Only the resulting timestamp is retained — never the request context or its
+headers.
+
+The requirement is monotonic and deduplicated:
+
+- A later request advertising an older version never lowers it
+- A raised requirement triggers at most **one** background refresh per
+  controller per target (`refreshedMinUpdatedAt`), so repeating the same header
+  on every warm request causes no extra work
+- A requirement already forwarded on a stream connection or poll
+  (`requestedMinUpdatedAt`) is left to that request instead of also spawning a
+  refresh
+- The refresh never blocks the caller and is best effort: on failure the
+  existing data keeps being served and reported as stale
+
+No-op during build steps and wherever no request context is available, so build
+and non-Vercel behavior is unchanged. The header is only emitted for
+deployments where the Edge Network enables it, so the feature is inert until
+both that and the server-side support (EXP-3414) are in place.
 
 ### Evaluation Reporting
 

--- a/packages/vercel-flags-core/src/black-box.test.ts
+++ b/packages/vercel-flags-core/src/black-box.test.ts
@@ -851,6 +851,7 @@ describe('Controller (black-box)', () => {
           headers: {
             ...streamRequestHeaders,
             'X-Revision': '1',
+            'X-Config-Updated-At': '1',
           },
           signal: expect.any(AbortSignal),
         },
@@ -862,7 +863,11 @@ describe('Controller (black-box)', () => {
       expect(fetchMock).toHaveBeenLastCalledWith(
         'https://flags.vercel.com/v1/stream',
         {
-          headers: { ...streamRequestHeaders, 'X-Revision': '1' },
+          headers: {
+            ...streamRequestHeaders,
+            'X-Revision': '1',
+            'X-Config-Updated-At': '1',
+          },
           signal: expect.any(AbortSignal),
         },
       );
@@ -2928,6 +2933,559 @@ describe('Controller (black-box)', () => {
 
       const result = await client.evaluate('flagA');
       expect(result.value).toBe(true); // variant 1 = newer
+
+      stream.close();
+      await client.shutdown();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Minimum config freshness (x-vercel-edge-config-versions)
+  // ---------------------------------------------------------------------------
+  describe('minimum config freshness', () => {
+    /** Request context advertising a flags config version for `prj_123`. */
+    function advertise(version: number | string) {
+      return setRequestContext({
+        host: 'example.com',
+        'x-vercel-edge-config-versions': `ecfg_other=1;flags_prj_123=${version}`,
+      });
+    }
+
+    function callsTo(path: string) {
+      return fetchMock.mock.calls.filter((call) => {
+        const url = typeof call[0] === 'string' ? call[0] : call[0]!.toString();
+        return url.includes(path);
+      });
+    }
+
+    function headersOf(call: Parameters<typeof fetch>) {
+      return call[1]!.headers as Record<string, string>;
+    }
+
+    /** Responds to /v1/stream with `stream`, /v1/datafile with `datafile`. */
+    function mockNetwork(options: {
+      stream?: { response: Promise<Response> };
+      datafile?: () => Promise<Response>;
+    }) {
+      fetchMock.mockImplementation((input) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.includes('/v1/stream') && options.stream) {
+          return options.stream.response;
+        }
+        if (url.includes('/v1/datafile') && options.datafile) {
+          return options.datafile();
+        }
+        if (url.includes('/v1/ingest')) return Promise.resolve(new Response());
+        return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+      });
+    }
+
+    it('should forward the requirement and current configUpdatedAt on the stream', async () => {
+      const stream = createMockStream();
+      const cleanupCtx = advertise(2000);
+      mockNetwork({ stream });
+
+      const client = createClient(sdkKey, {
+        fetch: fetchMock,
+        polling: false,
+        datafile: makeBundled({ configUpdatedAt: 1000, revision: 7 }),
+      });
+
+      const initPromise = client.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      stream.push({
+        type: 'datafile',
+        data: makeBundled({ configUpdatedAt: 2000 }),
+      });
+      await vi.advanceTimersByTimeAsync(10);
+      await initPromise;
+
+      const streamCalls = callsTo('/v1/stream');
+      expect(streamCalls).toHaveLength(1);
+      expect(headersOf(streamCalls[0]!)).toEqual({
+        ...streamRequestHeaders,
+        'X-Revision': '7',
+        'X-Config-Updated-At': '1000',
+        'X-Config-Min-Updated-At': '2000',
+      });
+
+      stream.close();
+      await client.shutdown();
+      cleanupCtx();
+    });
+
+    it('should not send the requirement when the header advertises another project', async () => {
+      const stream = createMockStream();
+      const cleanupCtx = setRequestContext({
+        host: 'example.com',
+        'x-vercel-edge-config-versions': 'flags_prj_other=2000',
+      });
+      mockNetwork({ stream });
+
+      const client = createClient(sdkKey, {
+        fetch: fetchMock,
+        polling: false,
+        datafile: makeBundled({ configUpdatedAt: 1000, revision: 7 }),
+      });
+
+      const initPromise = client.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      stream.push({
+        type: 'primed',
+        revision: 7,
+        projectId: 'prj_123',
+        environment: 'production',
+      });
+      await vi.advanceTimersByTimeAsync(10);
+      await initPromise;
+
+      const headers = headersOf(callsTo('/v1/stream')[0]!);
+      expect(headers['X-Config-Min-Updated-At']).toBeUndefined();
+      expect(headers['X-Config-Updated-At']).toBe('1000');
+
+      // Nothing was below a minimum, so the read is a plain HIT.
+      const datafile = await client.getDatafile();
+      expect(datafile.metrics.cacheStatus).toBe('HIT');
+      expect(callsTo('/v1/datafile')).toHaveLength(0);
+
+      stream.close();
+      await client.shutdown();
+      cleanupCtx();
+    });
+
+    it('should not resolve initialization as fresh when primed below the minimum', async () => {
+      const stream = createMockStream();
+      const cleanupCtx = advertise(2000);
+      mockNetwork({ stream });
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const client = createClient(sdkKey, {
+        fetch: fetchMock,
+        polling: false,
+        datafile: makeBundled({ configUpdatedAt: 1000 }),
+      });
+
+      let initResolved = false;
+      const initPromise = Promise.resolve(client.initialize()).then(() => {
+        initResolved = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      stream.push({
+        type: 'primed',
+        revision: 1,
+        projectId: 'prj_123',
+        environment: 'production',
+      });
+      await vi.advanceTimersByTimeAsync(10);
+
+      // The server confirmed our (stale) revision, which cannot satisfy the
+      // advertised minimum — initialization must keep waiting.
+      expect(initResolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(3_000);
+      await initPromise;
+      expect(initResolved).toBe(true);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '@vercel/flags-core: Stream initialization timeout, falling back while continuing to connect in the background',
+      );
+
+      // Existing data is preserved and reported as stale, not fresh.
+      const datafile = await client.getDatafile();
+      expect(datafile.configUpdatedAt).toBe(1000);
+      expect(datafile.metrics.cacheStatus).toBe('STALE');
+      expect(datafile.metrics.source).toBe('in-memory');
+
+      // The stream request already carried the requirement, so no extra
+      // datafile fetch is made for it.
+      expect(callsTo('/v1/datafile')).toHaveLength(0);
+
+      stream.close();
+      await client.shutdown();
+      warnSpy.mockRestore();
+      cleanupCtx();
+    });
+
+    it('should resolve initialization as fresh once a message meets the minimum', async () => {
+      const stream = createMockStream();
+      const cleanupCtx = advertise(2000);
+      mockNetwork({ stream });
+
+      const client = createClient(sdkKey, {
+        fetch: fetchMock,
+        polling: false,
+        datafile: makeBundled({ configUpdatedAt: 1000 }),
+      });
+
+      let initResolved = false;
+      const initPromise = Promise.resolve(client.initialize()).then(() => {
+        initResolved = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      // First message is still below the minimum.
+      stream.push({
+        type: 'datafile',
+        data: makeBundled({ configUpdatedAt: 1500 }),
+      });
+      await vi.advanceTimersByTimeAsync(10);
+      expect(initResolved).toBe(false);
+
+      // Second message satisfies it.
+      stream.push({
+        type: 'datafile',
+        data: makeBundled({ configUpdatedAt: 2000 }),
+      });
+      await vi.advanceTimersByTimeAsync(10);
+      await initPromise;
+      expect(initResolved).toBe(true);
+
+      const datafile = await client.getDatafile();
+      expect(datafile.configUpdatedAt).toBe(2000);
+      expect(datafile.metrics.cacheStatus).toBe('HIT');
+
+      stream.close();
+      await client.shutdown();
+      cleanupCtx();
+    });
+
+    it('should trigger one deduplicated refresh when a warm request advertises newer config', async () => {
+      const stream = createMockStream();
+      let cleanupCtx = setRequestContext({ host: 'example.com' });
+      mockNetwork({
+        stream,
+        datafile: () =>
+          Promise.resolve(
+            Response.json(makeBundled({ configUpdatedAt: 5000, revision: 9 })),
+          ),
+      });
+
+      const client = createClient(sdkKey, {
+        fetch: fetchMock,
+        polling: false,
+        datafile: makeBundled({ configUpdatedAt: 1000 }),
+      });
+
+      // Cold request: no version advertised, stream primes our revision.
+      const initPromise = client.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      stream.push({
+        type: 'primed',
+        revision: 1,
+        projectId: 'prj_123',
+        environment: 'production',
+      });
+      await vi.advanceTimersByTimeAsync(10);
+      await initPromise;
+
+      expect(
+        headersOf(callsTo('/v1/stream')[0]!)['X-Config-Min-Updated-At'],
+      ).toBeUndefined();
+      expect(callsTo('/v1/datafile')).toHaveLength(0);
+
+      // Warm request #1: the Edge Network now advertises newer config.
+      cleanupCtx();
+      cleanupCtx = advertise(4000);
+
+      const staleResult = await client.evaluate('flagA');
+      // The refresh runs in the background — this read still serves the data
+      // already in memory, reported as stale.
+      expect(staleResult.metrics?.cacheStatus).toBe('STALE');
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      const datafileCalls = callsTo('/v1/datafile');
+      expect(datafileCalls).toHaveLength(1);
+      expect(headersOf(datafileCalls[0]!)).toEqual({
+        ...datafileRequestHeaders,
+        'X-Config-Min-Updated-At': '4000',
+      });
+
+      // Warm request #2: same requirement, already satisfied — no extra work.
+      const freshResult = await client.evaluate('flagA');
+      expect(freshResult.metrics?.cacheStatus).toBe('HIT');
+      await vi.advanceTimersByTimeAsync(0);
+      expect(callsTo('/v1/datafile')).toHaveLength(1);
+
+      // Warm request #3: repeating the header again changes nothing.
+      cleanupCtx();
+      cleanupCtx = advertise(4000);
+      await client.evaluate('flagA');
+      await vi.advanceTimersByTimeAsync(0);
+      expect(callsTo('/v1/datafile')).toHaveLength(1);
+
+      stream.close();
+      await client.shutdown();
+      cleanupCtx();
+    });
+
+    it('should not refresh again for a repeated requirement the server cannot satisfy', async () => {
+      const stream = createMockStream();
+      let cleanupCtx = setRequestContext({ host: 'example.com' });
+      mockNetwork({
+        stream,
+        // Server is behind: it never returns data meeting the minimum.
+        datafile: () =>
+          Promise.resolve(
+            Response.json(makeBundled({ configUpdatedAt: 1200 })),
+          ),
+      });
+
+      const client = createClient(sdkKey, {
+        fetch: fetchMock,
+        polling: false,
+        datafile: makeBundled({ configUpdatedAt: 1000 }),
+      });
+
+      const initPromise = client.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      stream.push({
+        type: 'primed',
+        revision: 1,
+        projectId: 'prj_123',
+        environment: 'production',
+      });
+      await vi.advanceTimersByTimeAsync(10);
+      await initPromise;
+
+      cleanupCtx();
+      cleanupCtx = advertise(4000);
+      await client.evaluate('flagA');
+      await vi.advanceTimersByTimeAsync(0);
+      expect(callsTo('/v1/datafile')).toHaveLength(1);
+
+      // Still below the minimum, so still stale — but no repeated fetches.
+      for (let i = 0; i < 3; i++) {
+        const result = await client.evaluate('flagA');
+        expect(result.metrics?.cacheStatus).toBe('STALE');
+        await vi.advanceTimersByTimeAsync(0);
+      }
+      expect(callsTo('/v1/datafile')).toHaveLength(1);
+
+      stream.close();
+      await client.shutdown();
+      cleanupCtx();
+    });
+
+    it('should keep serving stale data when the refresh fails', async () => {
+      const stream = createMockStream();
+      let cleanupCtx = setRequestContext({ host: 'example.com' });
+      mockNetwork({
+        stream,
+        datafile: () => Promise.reject(new Error('network down')),
+      });
+
+      const client = createClient(sdkKey, {
+        fetch: fetchMock,
+        polling: false,
+        datafile: makeBundled({ configUpdatedAt: 1000 }),
+      });
+
+      const initPromise = client.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      stream.push({
+        type: 'primed',
+        revision: 1,
+        projectId: 'prj_123',
+        environment: 'production',
+      });
+      await vi.advanceTimersByTimeAsync(10);
+      await initPromise;
+
+      cleanupCtx();
+      cleanupCtx = advertise(4000);
+
+      const result = await client.evaluate('flagA');
+      expect(result.reason).toBe('paused');
+      expect(result.value).toBe(true);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(callsTo('/v1/datafile')).toHaveLength(1);
+
+      // Stale-if-error: the last known data is still served and reported stale.
+      const datafile = await client.getDatafile();
+      expect(datafile.configUpdatedAt).toBe(1000);
+      expect(datafile.metrics.cacheStatus).toBe('STALE');
+
+      stream.close();
+      await client.shutdown();
+      cleanupCtx();
+    });
+
+    it('should not let a later older header downgrade the requirement', async () => {
+      const stream = createMockStream();
+      let cleanupCtx = setRequestContext({ host: 'example.com' });
+      mockNetwork({
+        stream,
+        datafile: () =>
+          Promise.resolve(
+            Response.json(makeBundled({ configUpdatedAt: 1800 })),
+          ),
+      });
+
+      const client = createClient(sdkKey, {
+        fetch: fetchMock,
+        polling: false,
+        datafile: makeBundled({ configUpdatedAt: 1000 }),
+      });
+
+      const initPromise = client.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      stream.push({
+        type: 'primed',
+        revision: 1,
+        projectId: 'prj_123',
+        environment: 'production',
+      });
+      await vi.advanceTimersByTimeAsync(10);
+      await initPromise;
+
+      // Warm request raises the requirement to 4000; the refresh only gets 1800.
+      cleanupCtx();
+      cleanupCtx = advertise(4000);
+      await client.evaluate('flagA');
+      await vi.advanceTimersByTimeAsync(0);
+      expect(callsTo('/v1/datafile')).toHaveLength(1);
+
+      // A later request advertising an older version must not lower the
+      // requirement: 1800 still does not satisfy 4000, so this stays stale.
+      cleanupCtx();
+      cleanupCtx = advertise(1500);
+      const datafile = await client.getDatafile();
+      expect(datafile.configUpdatedAt).toBe(1800);
+      expect(datafile.metrics.cacheStatus).toBe('STALE');
+
+      // ...and causes no additional work.
+      await vi.advanceTimersByTimeAsync(0);
+      expect(callsTo('/v1/datafile')).toHaveLength(1);
+
+      stream.close();
+      await client.shutdown();
+      cleanupCtx();
+    });
+
+    it('should forward the requirement on polls', async () => {
+      const cleanupCtx = advertise(2000);
+      mockNetwork({
+        datafile: () =>
+          Promise.resolve(
+            Response.json(makeBundled({ configUpdatedAt: 2000 })),
+          ),
+      });
+
+      const client = createClient(sdkKey, {
+        fetch: fetchMock,
+        stream: false,
+        datafile: makeBundled({ configUpdatedAt: 1000 }),
+      });
+
+      await client.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+
+      const datafileCalls = callsTo('/v1/datafile');
+      expect(datafileCalls).toHaveLength(1);
+      expect(headersOf(datafileCalls[0]!)).toEqual({
+        ...datafileRequestHeaders,
+        'X-Config-Min-Updated-At': '2000',
+      });
+
+      const datafile = await client.getDatafile();
+      expect(datafile.configUpdatedAt).toBe(2000);
+
+      await client.shutdown();
+      cleanupCtx();
+    });
+
+    it('should ignore a malformed header value', async () => {
+      const stream = createMockStream();
+      const cleanupCtx = setRequestContext({
+        host: 'example.com',
+        'x-vercel-edge-config-versions': 'flags_prj_123=nil',
+      });
+      mockNetwork({ stream });
+
+      const client = createClient(sdkKey, {
+        fetch: fetchMock,
+        polling: false,
+        datafile: makeBundled({ configUpdatedAt: 1000 }),
+      });
+
+      const initPromise = client.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      stream.push({
+        type: 'primed',
+        revision: 1,
+        projectId: 'prj_123',
+        environment: 'production',
+      });
+      await vi.advanceTimersByTimeAsync(10);
+      await initPromise;
+
+      const headers = headersOf(callsTo('/v1/stream')[0]!);
+      expect(headers['X-Config-Min-Updated-At']).toBeUndefined();
+
+      const datafile = await client.getDatafile();
+      expect(datafile.metrics.cacheStatus).toBe('HIT');
+      expect(callsTo('/v1/datafile')).toHaveLength(0);
+
+      stream.close();
+      await client.shutdown();
+      cleanupCtx();
+    });
+
+    it('should not read the header during build steps', async () => {
+      const cleanupCtx = advertise(9000);
+      vi.mocked(readBundledDefinitions).mockResolvedValue({
+        state: 'ok',
+        definitions: makeBundled({ configUpdatedAt: 1000 }),
+      });
+
+      const client = createClient(sdkKey, {
+        fetch: fetchMock,
+        buildStep: true,
+      });
+
+      const datafile = await client.getDatafile();
+      expect(datafile.configUpdatedAt).toBe(1000);
+      expect(datafile.metrics.cacheStatus).toBe('MISS');
+      expect(datafile.metrics.mode).toBe('build');
+
+      // No network calls at all — build behavior is unchanged.
+      expect(fetchMock).not.toHaveBeenCalled();
+
+      await client.shutdown();
+      cleanupCtx();
+    });
+
+    it('should be inert without a request context', async () => {
+      const stream = createMockStream();
+      mockNetwork({ stream });
+
+      const client = createClient(sdkKey, {
+        fetch: fetchMock,
+        polling: false,
+        datafile: makeBundled({ configUpdatedAt: 1000, revision: 7 }),
+      });
+
+      const initPromise = client.initialize();
+      await vi.advanceTimersByTimeAsync(0);
+      stream.push({
+        type: 'primed',
+        revision: 7,
+        projectId: 'prj_123',
+        environment: 'production',
+      });
+      await vi.advanceTimersByTimeAsync(10);
+      await initPromise;
+
+      expect(headersOf(callsTo('/v1/stream')[0]!)).toEqual({
+        ...streamRequestHeaders,
+        'X-Revision': '7',
+        'X-Config-Updated-At': '1000',
+      });
+
+      const datafile = await client.getDatafile();
+      expect(datafile.metrics.cacheStatus).toBe('HIT');
+      expect(callsTo('/v1/datafile')).toHaveLength(0);
 
       stream.close();
       await client.shutdown();

--- a/packages/vercel-flags-core/src/controller/fetch-datafile.ts
+++ b/packages/vercel-flags-core/src/controller/fetch-datafile.ts
@@ -12,6 +12,12 @@ export async function fetchDatafile(options: {
   auth: Auth;
   fetch: typeof globalThis.fetch;
   signal?: AbortSignal;
+  /**
+   * Minimum `configUpdatedAt` the response must satisfy, forwarded as
+   * `X-Config-Min-Updated-At`. Set when the Edge Network advertises a newer
+   * configuration than the one held in memory.
+   */
+  minUpdatedAt?: number;
 }): Promise<BundledDefinitions> {
   const token = await options.auth.resolveToken();
 
@@ -38,6 +44,9 @@ export async function fetchDatafile(options: {
         'User-Agent': `VercelFlagsCore/${version}`,
         ...(process.env.VERCEL_ENV
           ? { 'X-Vercel-Env': process.env.VERCEL_ENV }
+          : null),
+        ...(options.minUpdatedAt !== undefined
+          ? { 'X-Config-Min-Updated-At': String(options.minUpdatedAt) }
           : null),
       },
       signal: controller.signal,

--- a/packages/vercel-flags-core/src/controller/index.ts
+++ b/packages/vercel-flags-core/src/controller/index.ts
@@ -5,6 +5,7 @@ import type {
   DatafileInput,
   Metrics,
 } from '../types';
+import { readFlagsConfigVersion } from '../utils/edge-config-versions';
 import { readBundledDefinitions } from '../utils/read-bundled-definitions';
 import type { TrackReadOptions } from '../utils/usage/flags-config-read';
 import type { TrackEvaluationOptions } from '../utils/usage/flags-evaluation';
@@ -117,6 +118,28 @@ export class Controller implements ControllerInterface {
   private buildDataPromise: Promise<TaggedData> | null = null;
   private buildReadTracked = false;
 
+  // Minimum configUpdatedAt the Edge Network advertises for this project, read
+  // from the request context of every initialize/read call. Monotonic: a later
+  // request carrying an older value never lowers it.
+  //
+  // Only this number is retained. The request context object and its headers
+  // are never stored, so a module-scoped controller cannot keep a request
+  // alive across invocations.
+  private minUpdatedAt: number | undefined;
+
+  // Highest minimum already forwarded on a source request (stream connect,
+  // poll, or one-time fetch). That request is responsible for delivering data
+  // which satisfies it, so no extra refresh is needed for it.
+  private requestedMinUpdatedAt: number | undefined;
+
+  // Highest minimum a refresh has already been attempted for, so a repeated
+  // requirement never causes redundant work.
+  private refreshedMinUpdatedAt: number | undefined;
+
+  // Minimum targeted by the refresh currently in flight, if any.
+  private refreshTarget: number | undefined;
+  private refreshAbortController: AbortController | undefined;
+
   // Suppresses usage tracking when the SDK key is unauthorized
   private unauthorized = false;
 
@@ -124,12 +147,17 @@ export class Controller implements ControllerInterface {
     this.options = normalizeOptions(options);
 
     // Create source modules
-    this.streamSource = new StreamSource(
-      this.options,
-      () => this.data?.revision,
-    );
+    this.streamSource = new StreamSource(this.options, {
+      revision: () => this.data?.revision,
+      configUpdatedAt: () => parseConfigUpdatedAt(this.data?.configUpdatedAt),
+      minUpdatedAt: this.minUpdatedAtForRequest,
+      canResolveInit: () => !this.isBelowMinUpdatedAt,
+    });
 
-    this.pollingSource = new PollingSource(this.options);
+    this.pollingSource = new PollingSource(
+      this.options,
+      this.minUpdatedAtForRequest,
+    );
 
     this.bundledSource = new BundledSource({
       auth: this.options.auth,
@@ -213,6 +241,159 @@ export class Controller implements ControllerInterface {
     return this.state === 'streaming';
   }
 
+  // ---------------------------------------------------------------------------
+  // Minimum freshness requirement
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Re-reads the flag configuration version the Edge Network advertises for
+   * this project and raises the minimum freshness requirement accordingly.
+   *
+   * Controllers are module-scoped and outlive individual requests, so this runs
+   * on every initialize()/read()/getDatafile() call rather than once at
+   * construction. The requirement only ever moves forward: a later warm request
+   * carrying an older header cannot downgrade it.
+   *
+   * No-op during build steps and wherever no request context is available, so
+   * build and non-Vercel behavior is unchanged.
+   */
+  private syncMinUpdatedAt(): void {
+    if (this.options.buildStep) return;
+
+    const projectId = this.data?.projectId ?? this.options.datafile?.projectId;
+    if (!projectId) return;
+
+    const advertised = readFlagsConfigVersion(projectId);
+    if (advertised === undefined) return;
+
+    if (this.minUpdatedAt === undefined || advertised > this.minUpdatedAt) {
+      this.minUpdatedAt = advertised;
+    }
+  }
+
+  /**
+   * Returns the current requirement for an outgoing request and records that it
+   * is being forwarded, so `scheduleRefresh()` knows the request in question is
+   * already responsible for satisfying it.
+   */
+  private minUpdatedAtForRequest = (): number | undefined => {
+    const required = this.minUpdatedAt;
+    if (
+      required !== undefined &&
+      (this.requestedMinUpdatedAt === undefined ||
+        required > this.requestedMinUpdatedAt)
+    ) {
+      this.requestedMinUpdatedAt = required;
+    }
+    return required;
+  };
+
+  /**
+   * Whether the data currently held in memory is known to be older than the
+   * minimum the Edge Network advertises. Data without a `configUpdatedAt`
+   * cannot be proven fresh, so it counts as below the minimum.
+   */
+  private get isBelowMinUpdatedAt(): boolean {
+    if (this.minUpdatedAt === undefined) return false;
+    if (!this.data) return true;
+
+    const currentTs = parseConfigUpdatedAt(this.data.configUpdatedAt);
+    return currentTs === undefined || currentTs < this.minUpdatedAt;
+  }
+
+  /**
+   * Cache status for the data currently held in memory. Data that is below the
+   * advertised minimum is reported as STALE even while connected, so a response
+   * that did not meet the minimum never looks fresh.
+   */
+  private get cacheStatusForCurrentData(): Metrics['cacheStatus'] {
+    return this.isConnected && !this.isBelowMinUpdatedAt ? 'HIT' : 'STALE';
+  }
+
+  /**
+   * Starts a single background refresh when the in-memory data is older than
+   * the advertised minimum.
+   *
+   * Deduplicated per controller and target: a given requirement triggers at
+   * most one refresh, whether it is observed once or on every warm request,
+   * and a lower requirement seen later never triggers another. A requirement
+   * already forwarded on a stream connection or poll is left to that request.
+   *
+   * The refresh runs in the background — callers keep serving the data they
+   * already have, which read() reports as STALE.
+   */
+  private scheduleRefresh(): void {
+    if (this.options.buildStep) return;
+    if (this.state === 'shutdown') return;
+
+    const target = this.minUpdatedAt;
+    if (target === undefined) return;
+
+    // Without data there is nothing to refresh: initialization applies the
+    // requirement to the stream/poll request instead.
+    if (!this.data) return;
+    if (!this.isBelowMinUpdatedAt) return;
+
+    // Already forwarded on a source request, which owns delivering data that
+    // satisfies it.
+    if (
+      this.requestedMinUpdatedAt !== undefined &&
+      this.requestedMinUpdatedAt >= target
+    ) {
+      return;
+    }
+
+    // Already attempted, or already covered by a refresh in flight.
+    if (
+      this.refreshedMinUpdatedAt !== undefined &&
+      this.refreshedMinUpdatedAt >= target
+    ) {
+      return;
+    }
+    if (this.refreshTarget !== undefined && this.refreshTarget >= target) {
+      return;
+    }
+
+    this.refreshTarget = target;
+    void this.refresh(target);
+  }
+
+  /**
+   * Fetches a datafile that satisfies `target`. Best effort: on failure the
+   * existing data keeps being served, preserving the stale fallback.
+   */
+  private async refresh(target: number): Promise<void> {
+    const abortController = new AbortController();
+    this.refreshAbortController = abortController;
+
+    try {
+      const fetched = await fetchDatafile({
+        host: this.options.host,
+        auth: this.options.auth,
+        fetch: this.options.fetch,
+        signal: abortController.signal,
+        minUpdatedAt: target,
+      });
+
+      if (this.state !== 'shutdown' && this.isNewerData(fetched)) {
+        this.data = tagData(fetched, 'fetched');
+      }
+    } catch {
+      // Keep the existing data — the refresh is best effort.
+    } finally {
+      this.refreshedMinUpdatedAt =
+        this.refreshedMinUpdatedAt === undefined
+          ? target
+          : Math.max(this.refreshedMinUpdatedAt, target);
+      if (this.refreshTarget === target) {
+        this.refreshTarget = undefined;
+      }
+      if (this.refreshAbortController === abortController) {
+        this.refreshAbortController = undefined;
+      }
+    }
+  }
+
   private get mode(): Metrics['mode'] {
     if (this.options.buildStep) return 'build';
     switch (this.state) {
@@ -245,6 +426,20 @@ export class Controller implements ControllerInterface {
       return;
     }
 
+    try {
+      await this.initializeAtRuntime();
+    } finally {
+      // Initialization could not reach the advertised minimum: start the single
+      // deduplicated refresh now instead of waiting for the next read.
+      this.scheduleRefresh();
+    }
+  }
+
+  private async initializeAtRuntime(): Promise<void> {
+    // Pick up the requirement advertised for this request before opening any
+    // connection, so it can be forwarded on the very first attempt.
+    this.syncMinUpdatedAt();
+
     // Hydrate from provided datafile if not already set (e.g., after shutdown)
     if (!this.data && this.options.datafile) {
       this.data = tagData(this.options.datafile, 'provided');
@@ -262,6 +457,9 @@ export class Controller implements ControllerInterface {
       } catch {
         // Bundled definitions not available — proceed without revision
       }
+
+      // Bundled definitions may be the first thing to reveal the project id.
+      this.syncMinUpdatedAt();
     }
 
     // If we already have data (from provided datafile or bundled definitions),
@@ -311,6 +509,11 @@ export class Controller implements ControllerInterface {
     const isFirstRead = this.isFirstGetData;
     this.isFirstGetData = false;
 
+    // Re-read per request: a warm request may advertise a newer configuration
+    // than the one this long-lived controller holds.
+    this.syncMinUpdatedAt();
+    this.scheduleRefresh();
+
     const [result, cacheStatus] = await this.resolveData();
 
     const readMs = Date.now() - startTime;
@@ -344,6 +547,8 @@ export class Controller implements ControllerInterface {
     this.unwireSourceEvents();
     this.streamSource.stop();
     this.pollingSource.stop();
+    this.refreshAbortController?.abort();
+    this.refreshAbortController = undefined;
     this.data = this.options.datafile
       ? tagData(this.options.datafile, 'provided')
       : undefined;
@@ -360,13 +565,18 @@ export class Controller implements ControllerInterface {
     const startTime = Date.now();
     this.isFirstGetData = false;
 
+    // Re-read per request: a warm request may advertise a newer configuration
+    // than the one this long-lived controller holds.
+    this.syncMinUpdatedAt();
+    this.scheduleRefresh();
+
     let result: TaggedData;
     let cacheStatus: Metrics['cacheStatus'];
 
     if (this.options.buildStep) {
       [result, cacheStatus] = await this.resolveDataForBuildStep();
     } else if (this.data) {
-      cacheStatus = this.isConnected ? 'HIT' : 'STALE';
+      cacheStatus = this.cacheStatusForCurrentData;
       result = this.data;
     } else {
       // No in-memory data — try bundled, then one-time fetch
@@ -382,6 +592,7 @@ export class Controller implements ControllerInterface {
             host: this.options.host,
             auth: this.options.auth,
             fetch: this.options.fetch,
+            minUpdatedAt: this.minUpdatedAtForRequest(),
           });
           this.data = tagData(fetched, 'fetched');
           result = this.data;
@@ -442,8 +653,7 @@ export class Controller implements ControllerInterface {
     }
 
     if (this.data) {
-      const cacheStatus = this.isConnected ? 'HIT' : 'STALE';
-      return [this.data, cacheStatus];
+      return [this.data, this.cacheStatusForCurrentData];
     }
 
     return this.resolveDataWithFallbacks();
@@ -523,11 +733,7 @@ export class Controller implements ControllerInterface {
     if (this.options.polling.initTimeoutMs <= 0) {
       try {
         await pollPromise;
-        if (this.data) {
-          this.pollingSource.startInterval();
-          return true;
-        }
-        return false;
+        return this.completePollingInit();
       } catch {
         return false;
       }
@@ -553,15 +759,24 @@ export class Controller implements ControllerInterface {
         return false;
       }
 
-      if (this.data) {
-        this.pollingSource.startInterval();
-        return true;
-      }
-      return false;
+      return this.completePollingInit();
     } catch {
       clearTimeout(timeoutId!);
       return false;
     }
+  }
+
+  /**
+   * Starts the polling interval once the first poll produced data.
+   *
+   * Reports success only when that data meets the advertised minimum: a
+   * response below the minimum keeps polling running in the background but
+   * must not resolve initialization as fresh.
+   */
+  private completePollingInit(): boolean {
+    if (!this.data) return false;
+    this.pollingSource.startInterval();
+    return !this.isBelowMinUpdatedAt;
   }
 
   // ---------------------------------------------------------------------------
@@ -659,6 +874,7 @@ export class Controller implements ControllerInterface {
           host: this.options.host,
           auth: this.options.auth,
           fetch: this.options.fetch,
+          minUpdatedAt: this.minUpdatedAtForRequest(),
         });
         this.data = tagData(fetched, 'fetched');
         this.transition('degraded');
@@ -724,6 +940,7 @@ export class Controller implements ControllerInterface {
           host: this.options.host,
           auth: this.options.auth,
           fetch: this.options.fetch,
+          minUpdatedAt: this.minUpdatedAtForRequest(),
         });
         this.data = tagData(fetched, 'fetched');
         this.transition('degraded');

--- a/packages/vercel-flags-core/src/controller/polling-source.ts
+++ b/packages/vercel-flags-core/src/controller/polling-source.ts
@@ -23,12 +23,22 @@ export type PollingSourceEvents = {
  */
 export class PollingSource extends TypedEmitter<PollingSourceEvents> {
   private config: PollingSourceConfig;
+  private minUpdatedAt: () => number | undefined;
   private intervalId: ReturnType<typeof setInterval> | undefined;
   private abortController: AbortController | undefined;
 
-  constructor(config: PollingSourceConfig) {
+  constructor(
+    config: PollingSourceConfig,
+    /**
+     * Returns the minimum `configUpdatedAt` a poll response must satisfy, sent
+     * as `X-Config-Min-Updated-At`. Read per request so later polls pick up a
+     * raised requirement.
+     */
+    minUpdatedAt: () => number | undefined = () => undefined,
+  ) {
     super();
     this.config = config;
+    this.minUpdatedAt = minUpdatedAt;
   }
 
   /**
@@ -42,6 +52,7 @@ export class PollingSource extends TypedEmitter<PollingSourceEvents> {
       const data = await fetchDatafile({
         ...this.config,
         signal: this.abortController?.signal,
+        minUpdatedAt: this.minUpdatedAt(),
       });
       this.emit('data', data);
     } catch (error) {

--- a/packages/vercel-flags-core/src/controller/stream-connection.test.ts
+++ b/packages/vercel-flags-core/src/controller/stream-connection.test.ts
@@ -1001,6 +1001,242 @@ describe('connectStream', () => {
     });
   });
 
+  describe('X-Config-Updated-At / X-Config-Min-Updated-At headers', () => {
+    beforeEach(() => {
+      fetchMock.mockImplementation(() => ndjsonResponse([datafileMsg()]));
+    });
+
+    it('should send both config headers alongside X-Revision', async () => {
+      const abortController = new AbortController();
+      await connectStream(
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+          revision: () => 42,
+          configUpdatedAt: () => 1726434395818,
+          minUpdatedAt: () => 1726434400000,
+        },
+        { onDatafile: vi.fn() },
+      );
+
+      const headers = fetchMock.mock.calls[0]![1]!.headers as Record<
+        string,
+        string
+      >;
+      expect(headers['X-Revision']).toBe('42');
+      expect(headers['X-Config-Updated-At']).toBe('1726434395818');
+      expect(headers['X-Config-Min-Updated-At']).toBe('1726434400000');
+      abortController.abort();
+    });
+
+    it('should omit the config headers when the getters return undefined', async () => {
+      const abortController = new AbortController();
+      await connectStream(
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+          revision: () => 42,
+          configUpdatedAt: () => undefined,
+          minUpdatedAt: () => undefined,
+        },
+        { onDatafile: vi.fn() },
+      );
+
+      const headers = fetchMock.mock.calls[0]![1]!.headers as Record<
+        string,
+        string
+      >;
+      expect(headers['X-Revision']).toBe('42');
+      expect(headers['X-Config-Updated-At']).toBeUndefined();
+      expect(headers['X-Config-Min-Updated-At']).toBeUndefined();
+      abortController.abort();
+    });
+
+    it('should omit the config headers when the getters are not provided', async () => {
+      const abortController = new AbortController();
+      await connectStream(
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
+        { onDatafile: vi.fn() },
+      );
+
+      const headers = fetchMock.mock.calls[0]![1]!.headers as Record<
+        string,
+        string
+      >;
+      expect(headers['X-Config-Updated-At']).toBeUndefined();
+      expect(headers['X-Config-Min-Updated-At']).toBeUndefined();
+      abortController.abort();
+    });
+
+    it('should re-read the config getters on each reconnect', async () => {
+      vi.useFakeTimers();
+      let requestCount = 0;
+      let currentUpdatedAt = 100;
+      let minUpdatedAt = 100;
+
+      fetchMock.mockImplementation(() => {
+        requestCount++;
+        return ndjsonResponse([datafileMsg()], { keepOpen: requestCount >= 2 });
+      });
+
+      const abortController = new AbortController();
+
+      await connectStream(
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+          configUpdatedAt: () => currentUpdatedAt,
+          minUpdatedAt: () => minUpdatedAt,
+        },
+        {
+          onDatafile: () => {
+            // Simulate a warm request raising the requirement mid-connection.
+            currentUpdatedAt = 200;
+            minUpdatedAt = 300;
+          },
+        },
+      );
+
+      const h0 = fetchMock.mock.calls[0]![1]!.headers as Record<string, string>;
+      expect(h0['X-Config-Updated-At']).toBe('100');
+      expect(h0['X-Config-Min-Updated-At']).toBe('100');
+
+      // Advance past reconnection backoff
+      await vi.advanceTimersByTimeAsync(1000);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const h1 = fetchMock.mock.calls[1]![1]!.headers as Record<string, string>;
+      expect(h1['X-Config-Updated-At']).toBe('200');
+      expect(h1['X-Config-Min-Updated-At']).toBe('300');
+
+      abortController.abort();
+      vi.useRealTimers();
+    });
+  });
+
+  describe('canResolveInit', () => {
+    it('should not resolve init for a datafile message that is rejected', async () => {
+      const first = { projectId: 'test', definitions: {}, configUpdatedAt: 1 };
+      const second = { projectId: 'test', definitions: {}, configUpdatedAt: 9 };
+
+      // Delivered in separate chunks so init could resolve after either one.
+      fetchMock.mockImplementation(() =>
+        streamResponse(
+          createNdjsonStream(
+            [
+              { type: 'datafile', data: first },
+              { type: 'datafile', data: second },
+            ],
+            { delayMs: 5, keepOpen: true },
+          ),
+        ),
+      );
+
+      const abortController = new AbortController();
+      const received: unknown[] = [];
+      let messagesWhenResolved = -1;
+
+      const initPromise = connectStream(
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+          // Only data at or beyond configUpdatedAt 9 may resolve init.
+          canResolveInit: () => {
+            const last = received[received.length - 1] as
+              | { configUpdatedAt: number }
+              | undefined;
+            return last !== undefined && last.configUpdatedAt >= 9;
+          },
+        },
+        { onDatafile: (data) => received.push(data) },
+      );
+      void initPromise.then(() => {
+        messagesWhenResolved = received.length;
+      });
+
+      await initPromise;
+
+      // Both messages were delivered, but only the second resolved init.
+      expect(received).toEqual([first, second]);
+      expect(messagesWhenResolved).toBe(2);
+
+      abortController.abort();
+    });
+
+    it('should not resolve init for a primed message that is rejected', async () => {
+      fetchMock.mockImplementation(() =>
+        ndjsonResponse(
+          [
+            {
+              type: 'primed',
+              revision: 1,
+              projectId: 'prj_test',
+              environment: 'production',
+            },
+          ],
+          { keepOpen: true },
+        ),
+      );
+
+      const abortController = new AbortController();
+      const onPrimed = vi.fn();
+      let resolved = false;
+
+      let signalPrimed: () => void;
+      const primedDelivered = new Promise<void>((resolve) => {
+        signalPrimed = resolve;
+      });
+
+      void connectStream(
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+          canResolveInit: () => false,
+        },
+        {
+          onDatafile: vi.fn(),
+          onPrimed: (message) => {
+            onPrimed(message);
+            signalPrimed();
+          },
+        },
+      ).then(
+        () => {
+          resolved = true;
+        },
+        () => {
+          // aborted below — expected
+        },
+      );
+
+      await primedDelivered;
+      // Flush microtasks so a resolved init promise would have settled.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The primed message was delivered but did not resolve init.
+      expect(onPrimed).toHaveBeenCalledTimes(1);
+      expect(resolved).toBe(false);
+
+      abortController.abort();
+    });
+  });
+
   describe('primed message', () => {
     it('should resolve init promise when primed message is received', async () => {
       const primedMsg = {

--- a/packages/vercel-flags-core/src/controller/stream-connection.ts
+++ b/packages/vercel-flags-core/src/controller/stream-connection.ts
@@ -54,6 +54,26 @@ export type StreamConfig = {
   fetch?: typeof globalThis.fetch;
   /** Returns the current revision number to send as X-Revision header */
   revision?: () => number | undefined;
+  /**
+   * Returns the `configUpdatedAt` of the data currently held in memory, sent
+   * as the X-Config-Updated-At header.
+   */
+  configUpdatedAt?: () => number | undefined;
+  /**
+   * Returns the minimum `configUpdatedAt` this connection must be served with,
+   * sent as the X-Config-Min-Updated-At header. Read per connection attempt so
+   * reconnects pick up a raised requirement.
+   */
+  minUpdatedAt?: () => number | undefined;
+  /**
+   * Decides whether a `datafile` or `primed` message may resolve the init
+   * promise. Called after the message has been handed to the callbacks, so it
+   * can inspect the state they produced.
+   *
+   * Return false to keep waiting for a message that satisfies the caller's
+   * freshness requirement. Defaults to accepting the first message.
+   */
+  canResolveInit?: () => boolean;
   resolveToken: () => Promise<string>;
 };
 
@@ -132,9 +152,19 @@ export async function connectStream(
         if (vercelEnv) {
           headers['X-Vercel-Env'] = vercelEnv;
         }
+        // X-Revision is kept alongside the X-Config-*-Updated-At headers for
+        // the duration of the server-side migration.
         const revision = config.revision?.();
         if (revision !== undefined) {
           headers['X-Revision'] = String(revision);
+        }
+        const configUpdatedAt = config.configUpdatedAt?.();
+        if (configUpdatedAt !== undefined) {
+          headers['X-Config-Updated-At'] = String(configUpdatedAt);
+        }
+        const minUpdatedAt = config.minUpdatedAt?.();
+        if (minUpdatedAt !== undefined) {
+          headers['X-Config-Min-Updated-At'] = String(minUpdatedAt);
         }
         const response = await fetchFn(`${host}/v1/stream`, {
           headers,
@@ -198,7 +228,12 @@ export async function connectStream(
               if (message.type === 'datafile') {
                 onDatafile(message.data);
                 retryCount = 0;
-                if (!initialDataReceived) {
+                // The message may leave us below the caller's minimum required
+                // freshness, in which case it must not resolve init.
+                if (
+                  !initialDataReceived &&
+                  (config.canResolveInit?.() ?? true)
+                ) {
                   initialDataReceived = true;
                   resolveInit!();
                 }
@@ -211,7 +246,10 @@ export async function connectStream(
               if (message.type === 'primed') {
                 onPrimed?.(message);
                 retryCount = 0;
-                if (!initialDataReceived) {
+                if (
+                  !initialDataReceived &&
+                  (config.canResolveInit?.() ?? true)
+                ) {
                   initialDataReceived = true;
                   resolveInit!();
                 }

--- a/packages/vercel-flags-core/src/controller/stream-source.ts
+++ b/packages/vercel-flags-core/src/controller/stream-source.ts
@@ -14,16 +14,31 @@ export type StreamSourceEvents = {
  * Manages a streaming connection to the flags service.
  * Wraps connectStream() and emits typed events.
  */
+/**
+ * Per-connection state read from the Controller. Each getter is invoked on
+ * every connection attempt so reconnects reflect the latest state.
+ */
+export type StreamSourceHooks = {
+  /** Current revision, sent as X-Revision. */
+  revision: () => number | undefined;
+  /** Current `configUpdatedAt`, sent as X-Config-Updated-At. */
+  configUpdatedAt?: () => number | undefined;
+  /** Minimum required `configUpdatedAt`, sent as X-Config-Min-Updated-At. */
+  minUpdatedAt?: () => number | undefined;
+  /** Whether the state after a message is fresh enough to resolve init. */
+  canResolveInit?: () => boolean;
+};
+
 export class StreamSource extends TypedEmitter<StreamSourceEvents> {
   private options: NormalizedOptions;
-  private revision: () => number | undefined;
+  private hooks: StreamSourceHooks;
   private abortController: AbortController | undefined;
   private promise: Promise<void> | undefined;
 
-  constructor(options: NormalizedOptions, revision: () => number | undefined) {
+  constructor(options: NormalizedOptions, hooks: StreamSourceHooks) {
     super();
     this.options = options;
-    this.revision = revision;
+    this.hooks = hooks;
   }
 
   /**
@@ -58,7 +73,10 @@ export class StreamSource extends TypedEmitter<StreamSourceEvents> {
           resolveToken: () => this.options.auth.resolveToken(),
           abortController,
           fetch: this.options.fetch,
-          revision: this.revision,
+          revision: this.hooks.revision,
+          configUpdatedAt: this.hooks.configUpdatedAt,
+          minUpdatedAt: this.hooks.minUpdatedAt,
+          canResolveInit: this.hooks.canResolveInit,
         },
         {
           onDatafile: (newData) => {

--- a/packages/vercel-flags-core/src/utils/edge-config-versions.test.ts
+++ b/packages/vercel-flags-core/src/utils/edge-config-versions.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { setRequestContext } from '../test-utils';
+import {
+  EDGE_CONFIG_VERSIONS_HEADER,
+  flagsConfigVersionKey,
+  parseFlagsConfigVersion,
+  readFlagsConfigVersion,
+} from './edge-config-versions';
+
+describe('flagsConfigVersionKey', () => {
+  it('should key entries by project id', () => {
+    expect(flagsConfigVersionKey('prj_123')).toBe('flags_prj_123');
+  });
+});
+
+describe('parseFlagsConfigVersion', () => {
+  it('should read the entry for the given project', () => {
+    expect(
+      parseFlagsConfigVersion('flags_prj_123=1726434400000', 'prj_123'),
+    ).toBe(1726434400000);
+  });
+
+  it('should read the entry from a list of semicolon-separated entries', () => {
+    expect(
+      parseFlagsConfigVersion(
+        'ecfg_abc=1726434395818;flags_prj_123=1726434400000;ecfg_def=1726434300000',
+        'prj_123',
+      ),
+    ).toBe(1726434400000);
+  });
+
+  it('should tolerate whitespace around entries', () => {
+    expect(
+      parseFlagsConfigVersion(
+        'ecfg_abc=1 ; flags_prj_123 = 1726434400000 ',
+        'prj_123',
+      ),
+    ).toBe(1726434400000);
+  });
+
+  it('should return undefined when the header is missing', () => {
+    expect(parseFlagsConfigVersion(undefined, 'prj_123')).toBeUndefined();
+  });
+
+  it('should return undefined for an empty header', () => {
+    expect(parseFlagsConfigVersion('', 'prj_123')).toBeUndefined();
+  });
+
+  it('should return undefined when there is no entry for the project', () => {
+    expect(
+      parseFlagsConfigVersion(
+        'ecfg_abc=1726434395818;flags_prj_other=1726434400000',
+        'prj_123',
+      ),
+    ).toBeUndefined();
+  });
+
+  it('should not match a project id by prefix', () => {
+    expect(
+      parseFlagsConfigVersion('flags_prj_1234=1726434400000', 'prj_123'),
+    ).toBeUndefined();
+  });
+
+  it('should return undefined for a non-numeric value', () => {
+    expect(parseFlagsConfigVersion('flags_prj_123=nil', 'prj_123')).toBe(
+      undefined,
+    );
+  });
+
+  it('should return undefined for a missing value', () => {
+    expect(
+      parseFlagsConfigVersion('flags_prj_123=', 'prj_123'),
+    ).toBeUndefined();
+  });
+
+  it('should return undefined for an entry without a separator', () => {
+    expect(parseFlagsConfigVersion('flags_prj_123', 'prj_123')).toBeUndefined();
+  });
+
+  it('should return undefined for a non-positive value', () => {
+    expect(
+      parseFlagsConfigVersion('flags_prj_123=0', 'prj_123'),
+    ).toBeUndefined();
+    expect(
+      parseFlagsConfigVersion('flags_prj_123=-1', 'prj_123'),
+    ).toBeUndefined();
+  });
+
+  it('should return undefined for Infinity', () => {
+    expect(
+      parseFlagsConfigVersion('flags_prj_123=Infinity', 'prj_123'),
+    ).toBeUndefined();
+  });
+});
+
+describe('readFlagsConfigVersion', () => {
+  let cleanup: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+  });
+
+  it('should read the version from the request context headers', () => {
+    cleanup = setRequestContext({
+      [EDGE_CONFIG_VERSIONS_HEADER]: 'flags_prj_123=1726434400000',
+    });
+
+    expect(readFlagsConfigVersion('prj_123')).toBe(1726434400000);
+  });
+
+  it('should return undefined when the header is absent', () => {
+    cleanup = setRequestContext({ 'x-vercel-id': 'abc' });
+
+    expect(readFlagsConfigVersion('prj_123')).toBeUndefined();
+  });
+
+  it('should return undefined without a request context', () => {
+    expect(readFlagsConfigVersion('prj_123')).toBeUndefined();
+  });
+});

--- a/packages/vercel-flags-core/src/utils/edge-config-versions.ts
+++ b/packages/vercel-flags-core/src/utils/edge-config-versions.ts
@@ -1,0 +1,74 @@
+import { getRequestContext } from './request-context';
+
+/**
+ * Request header the Vercel Edge Network attaches to incoming requests. It
+ * lists the last known update timestamp of every config attached to the
+ * current deployment as semicolon-separated `<id>=<updatedAt>` pairs:
+ *
+ * ```
+ * ecfg_abc=1726434395818;flags_prj_123=1726434400000
+ * ```
+ *
+ * The entry describing a project's flag configuration is keyed
+ * `flags_<projectId>` and its value is a millisecond epoch timestamp,
+ * comparable to a datafile's `configUpdatedAt`.
+ *
+ * The header is not guaranteed to be present, and individual values are not
+ * guaranteed to be numeric, so every read must tolerate its absence.
+ */
+export const EDGE_CONFIG_VERSIONS_HEADER = 'x-vercel-edge-config-versions';
+
+/**
+ * The `x-vercel-edge-config-versions` key holding the flag configuration
+ * version of the given project.
+ */
+export function flagsConfigVersionKey(projectId: string): string {
+  return `flags_${projectId}`;
+}
+
+/**
+ * Reads the `flags_<projectId>` entry from an `x-vercel-edge-config-versions`
+ * header value.
+ *
+ * Returns undefined when the header is missing, carries no entry for the
+ * project, or the entry's value is not a positive timestamp.
+ */
+export function parseFlagsConfigVersion(
+  headerValue: string | undefined,
+  projectId: string,
+): number | undefined {
+  if (!headerValue) return undefined;
+
+  const key = flagsConfigVersionKey(projectId);
+
+  for (const entry of headerValue.split(';')) {
+    const separatorIndex = entry.indexOf('=');
+    if (separatorIndex === -1) continue;
+    if (entry.slice(0, separatorIndex).trim() !== key) continue;
+
+    const rawValue = entry.slice(separatorIndex + 1).trim();
+    if (rawValue === '') return undefined;
+
+    const value = Number(rawValue);
+    return Number.isFinite(value) && value > 0 ? value : undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * Reads the flag configuration version the Edge Network advertises for the
+ * given project on the current request.
+ *
+ * Only the resulting timestamp escapes this function — neither the request
+ * context nor its headers are retained anywhere, so module-scoped callers
+ * cannot keep a request alive.
+ */
+export function readFlagsConfigVersion(projectId: string): number | undefined {
+  const { headers } = getRequestContext();
+  if (!headers) return undefined;
+  return parseFlagsConfigVersion(
+    headers[EDGE_CONFIG_VERSIONS_HEADER],
+    projectId,
+  );
+}


### PR DESCRIPTION
## What

When the Vercel Edge Network advertises a flag configuration that is newer than the one a client holds in memory, forward that requirement to the datafile and stream endpoints so the client can catch up instead of silently serving older data.

The requirement comes from the `flags_<projectId>` entry of the `x-vercel-edge-config-versions` request header (semicolon-separated `<id>=<updatedAt>` pairs, values are ms-epoch).

- `X-Config-Min-Updated-At` is sent on `/v1/datafile` fetches (initialization, polling, fallbacks, refresh) and on stream connections whenever a minimum is required.
- `X-Config-Updated-At` reports the `configUpdatedAt` currently held in memory on stream connections.
- `X-Revision` is unchanged and still sent alongside both for the duration of the server-side migration.

## Behavior

- **A response below the minimum does not resolve initialization as fresh.** `connectStream` gained a `canResolveInit` predicate, and polling init goes through `completePollingInit()`, which still starts the poll interval but reports the init as not-fresh.
- **Existing stale fallback is preserved.** Below-minimum data is still returned, reported with `cacheStatus: 'STALE'`, and `stale-if-error` handling is untouched.
- **Warm requests.** Controllers can be module-scoped, so the requirement is re-read from the request context on every `initialize()` / `read()` / `getDatafile()`. A newer requirement arriving on a later warm request triggers exactly one deduplicated background refresh per controller per target, guarded by three counters: `requestedMinUpdatedAt` (already forwarded on a live source request — left to that request rather than duplicated), `refreshedMinUpdatedAt` (already attempted) and `refreshTarget` (in flight).
- **Monotonic.** An older header on a later request never downgrades the requirement and never causes redundant work.
- **No retained request context.** `readFlagsConfigVersion()` destructures `headers` locally and returns only a number; the controller stores only numbers.
- **Build / non-Vercel unchanged.** `syncMinUpdatedAt()` is a no-op during the build step and whenever the header or projectId is absent, and `loadBuildData()` deliberately does not send the header.

## Landing dark

This is inert until [EXP-3414](https://linear.app/vercel/issue/EXP-3414) makes the server honor `X-Config-Min-Updated-At`, and the Edge Network only emits `x-vercel-edge-config-versions` behind the proxy's `internalFlags.edgeConfigHeader` flag. No new public option was added.

One assumption to confirm when EXP-3414 lands: the key is implemented as `flags_<projectId>` exactly as the ticket specifies. The proxy today formats entries from `EdgeConfigInfo.id` (an `ecfg_*` id), while `flags_<projectId>` is the flags Edge Config *slug*. All the key naming lives in `flagsConfigVersionKey()` in one file, so it is a one-line change if EXP-3414 keys it differently.

## Files

Implementation:
- `src/utils/edge-config-versions.ts` (new) — header constant, key builder, parser, request-context read
- `src/controller/index.ts` — requirement tracking, monotonicity, dedup, background refresh, `STALE` reporting, per-call re-read
- `src/controller/stream-connection.ts` — the two new headers, `canResolveInit` gating
- `src/controller/stream-source.ts` — positional `revision` arg replaced by a `StreamSourceHooks` object
- `src/controller/polling-source.ts` — optional `minUpdatedAt` getter
- `src/controller/fetch-datafile.ts` — optional `minUpdatedAt` option → `X-Config-Min-Updated-At`

Tests / docs:
- `src/utils/edge-config-versions.test.ts` (new) — 15 parser/read cases
- `src/controller/stream-connection.test.ts` — header and `canResolveInit` coverage
- `src/black-box.test.ts` — `minimum config freshness` suite (network + controller + warm-request)
- `packages/vercel-flags-core/CLAUDE.md`, `.changeset/quiet-configs-catch-up.md`

## Verification

In `packages/vercel-flags-core`:

- `pnpm test` — 527 passed / 527, 14 files, exit 0
- `pnpm type-check` — exit 0
- `pnpm check` — exit 0, 1 warning (pre-existing on `main` in `src/index.make.test.ts`, verified unchanged via `git stash -u`)

New tests were mutation-tested: five separate mutations of the implementation (dropping each header, forcing `canResolveInit` to `true`, removing the monotonicity guard, removing the dedup guard) are each caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
