### PR TITLE
fix(flags-core): request identity on the stream so Bun receives the first datafile

### DIFF
--- a/.changeset/stream-accept-encoding-gzip.md
+++ b/.changeset/stream-accept-encoding-gzip.md
@@ -2,6 +2,6 @@
 '@vercel/flags-core': patch
 ---
 
-Request `Accept-Encoding: gzip` on the `/v1/stream` connection.
+Request an uncompressed `/v1/stream` body when running on Bun.
 
-The stream is long-lived NDJSON and the server flushes the compressor after every message. Runtimes such as Bun advertise `br` by default but do not surface partially decoded brotli output until the response ends, so the initial datafile never arrived and every flag fell back to its default after the init timeout. gzip streams correctly on Node, Bun, and browsers.
+Bun's `fetch` negotiates brotli or gzip by default, but its streaming decoder withholds small decoded output until more compressed input arrives. The stream's first datafile is followed by silence until the next ping, so on Bun the initial datafile never surfaced, init timed out, and every flag fell back to its default. Sending `Accept-Encoding: identity` on Bun avoids the decoder entirely; other runtimes are unchanged.

--- a/.changeset/stream-accept-encoding-gzip.md
+++ b/.changeset/stream-accept-encoding-gzip.md
@@ -1,0 +1,7 @@
+---
+'@vercel/flags-core': patch
+---
+
+Request `Accept-Encoding: gzip` on the `/v1/stream` connection.
+
+The stream is long-lived NDJSON and the server flushes the compressor after every message. Runtimes such as Bun advertise `br` by default but do not surface partially decoded brotli output until the response ends, so the initial datafile never arrived and every flag fell back to its default after the init timeout. gzip streams correctly on Node, Bun, and browsers.

--- a/packages/vercel-flags-core/src/black-box.test.ts
+++ b/packages/vercel-flags-core/src/black-box.test.ts
@@ -91,7 +91,6 @@ const streamRequestHeaders = Object.freeze({
   Authorization: 'Bearer vf_server_fake',
   'User-Agent': `VercelFlagsCore/${version}`,
   'X-Retry-Attempt': '0',
-  'Accept-Encoding': 'gzip',
   'X-Vercel-Env': 'production',
 });
 

--- a/packages/vercel-flags-core/src/black-box.test.ts
+++ b/packages/vercel-flags-core/src/black-box.test.ts
@@ -91,6 +91,7 @@ const streamRequestHeaders = Object.freeze({
   Authorization: 'Bearer vf_server_fake',
   'User-Agent': `VercelFlagsCore/${version}`,
   'X-Retry-Attempt': '0',
+  'Accept-Encoding': 'gzip',
   'X-Vercel-Env': 'production',
 });
 

--- a/packages/vercel-flags-core/src/controller/stream-connection.test.ts
+++ b/packages/vercel-flags-core/src/controller/stream-connection.test.ts
@@ -888,6 +888,29 @@ describe('connectStream', () => {
     });
   });
 
+  describe('Accept-Encoding header', () => {
+    it('should request gzip so brotli-incapable streaming decoders (Bun) still receive the first message', async () => {
+      fetchMock.mockImplementation(() => ndjsonResponse([datafileMsg()]));
+      const abortController = new AbortController();
+      await connectStream(
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
+        { onDatafile: vi.fn() },
+      );
+
+      const headers = fetchMock.mock.calls[0]![1]!.headers as Record<
+        string,
+        string
+      >;
+      expect(headers['Accept-Encoding']).toBe('gzip');
+      abortController.abort();
+    });
+  });
+
   describe('X-Revision header', () => {
     beforeEach(() => {
       fetchMock.mockImplementation(() => ndjsonResponse([datafileMsg()]));

--- a/packages/vercel-flags-core/src/controller/stream-connection.test.ts
+++ b/packages/vercel-flags-core/src/controller/stream-connection.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isBun } from '../utils/runtime';
 import { connectStream } from './stream-connection';
+
+vi.mock('../utils/runtime', () => ({ isBun: vi.fn(() => false) }));
 
 const HOST = 'https://flags.vercel.com';
 const fetchMock = vi.fn<typeof fetch>();
@@ -7,6 +10,7 @@ const fetchMock = vi.fn<typeof fetch>();
 beforeEach(() => {
   vi.clearAllMocks();
   fetchMock.mockReset();
+  vi.mocked(isBun).mockReturnValue(false);
 });
 
 function createNdjsonStream(
@@ -889,8 +893,12 @@ describe('connectStream', () => {
   });
 
   describe('Accept-Encoding header', () => {
-    it('should request gzip so brotli-incapable streaming decoders (Bun) still receive the first message', async () => {
+    beforeEach(() => {
       fetchMock.mockImplementation(() => ndjsonResponse([datafileMsg()]));
+    });
+
+    it('should request an uncompressed body on Bun, whose streaming decoder withholds small first messages', async () => {
+      vi.mocked(isBun).mockReturnValue(true);
       const abortController = new AbortController();
       await connectStream(
         {
@@ -906,7 +914,27 @@ describe('connectStream', () => {
         string,
         string
       >;
-      expect(headers['Accept-Encoding']).toBe('gzip');
+      expect(headers['Accept-Encoding']).toBe('identity');
+      abortController.abort();
+    });
+
+    it('should leave content negotiation to the runtime when not on Bun', async () => {
+      const abortController = new AbortController();
+      await connectStream(
+        {
+          host: HOST,
+          resolveToken: () => Promise.resolve('vf_test'),
+          abortController,
+          fetch: fetchMock,
+        },
+        { onDatafile: vi.fn() },
+      );
+
+      const headers = fetchMock.mock.calls[0]![1]!.headers as Record<
+        string,
+        string
+      >;
+      expect(headers['Accept-Encoding']).toBeUndefined();
       abortController.abort();
     });
   });

--- a/packages/vercel-flags-core/src/controller/stream-connection.ts
+++ b/packages/vercel-flags-core/src/controller/stream-connection.ts
@@ -127,6 +127,13 @@ export async function connectStream(
           Authorization: `Bearer ${token}`,
           'User-Agent': `VercelFlagsCore/${version}`,
           'X-Retry-Attempt': String(retryCount),
+          // The stream is long-lived NDJSON; the server flushes the compressor
+          // after every message. Some runtimes (Bun) advertise `br` by default
+          // but do not surface partially decoded brotli output until the
+          // response ends, so the first datafile never arrives and init times
+          // out. gzip streams correctly everywhere, so request it explicitly.
+          // See https://github.com/oven-sh/bun/issues/41439
+          'Accept-Encoding': 'gzip',
         };
         const vercelEnv = process.env.VERCEL_ENV;
         if (vercelEnv) {

--- a/packages/vercel-flags-core/src/controller/stream-connection.ts
+++ b/packages/vercel-flags-core/src/controller/stream-connection.ts
@@ -1,5 +1,6 @@
 import { version } from '../../package.json';
 import type { BundledDefinitions } from '../types';
+import { isBun } from '../utils/runtime';
 import { sleep } from '../utils/sleep';
 
 export type PrimedMessage = {
@@ -127,14 +128,17 @@ export async function connectStream(
           Authorization: `Bearer ${token}`,
           'User-Agent': `VercelFlagsCore/${version}`,
           'X-Retry-Attempt': String(retryCount),
-          // The stream is long-lived NDJSON; the server flushes the compressor
-          // after every message. Some runtimes (Bun) advertise `br` by default
-          // but do not surface partially decoded brotli output until the
-          // response ends, so the first datafile never arrives and init times
-          // out. gzip streams correctly everywhere, so request it explicitly.
-          // See https://github.com/oven-sh/bun/issues/41439
-          'Accept-Encoding': 'gzip',
         };
+        // The stream is long-lived NDJSON; the server flushes the compressor
+        // after every message. Bun's fetch negotiates br/gzip by default but
+        // its streaming decoder withholds small decoded output until more
+        // compressed input arrives, so a small first datafile never surfaces
+        // and init times out. Request an uncompressed body on Bun; the stream
+        // carries one datafile plus tiny pings, so compression gains little.
+        // See https://github.com/oven-sh/bun/issues/41439
+        if (isBun()) {
+          headers['Accept-Encoding'] = 'identity';
+        }
         const vercelEnv = process.env.VERCEL_ENV;
         if (vercelEnv) {
           headers['X-Vercel-Env'] = vercelEnv;

--- a/packages/vercel-flags-core/src/utils/runtime.test.ts
+++ b/packages/vercel-flags-core/src/utils/runtime.test.ts
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isBun } from './runtime';
+
+describe('isBun', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns false when the Bun global is absent', () => {
+    expect(isBun()).toBe(false);
+  });
+
+  it('returns true when the Bun global is present', () => {
+    vi.stubGlobal('Bun', { version: '1.3.14' });
+    expect(isBun()).toBe(true);
+  });
+});

--- a/packages/vercel-flags-core/src/utils/runtime.ts
+++ b/packages/vercel-flags-core/src/utils/runtime.ts
@@ -1,0 +1,7 @@
+/**
+ * Detects the Bun runtime. Bun exposes a `Bun` global and `process.versions.bun`;
+ * checking the global avoids depending on `process` being present.
+ */
+export function isBun(): boolean {
+  return typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined';
+}


### PR DESCRIPTION
## Problem

Under Bun, `@vercel/flags-core` never receives the initial `datafile` message from `/v1/stream`, so init times out and every flag falls back to its default value. Reported by the ops team while benchmarking Node 24 vs Bun 1.4.x (see also oven-sh/bun#41439).

Root cause: Bun's `fetch` negotiates a compressed body (`br` by default, `gzip` if requested), and its streaming decoder withholds small decoded output until more compressed input arrives. The stream is long-lived NDJSON: the server flushes the first datafile and then sends nothing until the next ping, so a small datafile never surfaces to the reader. Node's zlib emits whatever a flush produces, which is why Node is unaffected.

An earlier revision of this PR requested `gzip`. That only appeared to work because the test datafiles were 8 KB+; with a small datafile (558 B in the playground project) Bun holds gzip output too. Only `identity` works on Bun regardless of payload size.

## Fix

Detect Bun (`typeof globalThis.Bun !== 'undefined'`) and send `Accept-Encoding: identity` on the stream request only there. Other runtimes are unchanged and keep normal content negotiation. The stream carries one datafile plus 16-byte pings per connection, so skipping compression on Bun costs essentially nothing.

## Verification

Raw `fetch` against live `flags.vercel.com/v1/stream` (558 B datafile), waiting for a complete first NDJSON line:

```
runtime=bun 1.3.14
identity content-encoding=null OK   bytes=558
gzip     content-encoding=gzip HANG bytes=0
br       content-encoding=br   HANG bytes=0
runtime=node v24.16.0
identity/gzip/br all OK, bytes=558
```

Real SDK under Bun against the live endpoint, no fetch wrapper, using the built dist from this branch:

```
before: init timed out after 5000ms (gzip, br, and default negotiation)
after:  bun 1.3.14: initialized in 136ms mode=streaming connection=connected flags=3; SDK sent Accept-Encoding=identity
```

- `pnpm test` (vercel-flags-core): 14 files, 513 tests passed
- `pnpm type-check`: exit 0
- `pnpm check`: exit 0 (1 pre-existing warning, unchanged from main)
