### PR TITLE
docs(flags-core): clarify request-time initialization with OIDC

### DIFF
--- a/packages/vercel-flags-core/README.md
+++ b/packages/vercel-flags-core/README.md
@@ -12,17 +12,38 @@ npm i @vercel/flags-core
 
 ## Usage
 
+Create a shared client at module scope, but evaluate flags inside a request handler when using Vercel OIDC authentication. `evaluate()` and `bulkEvaluate()` initialize the client automatically on first use; you do not need to call `initialize()` first.
+
+For example, in an Express app deployed to Vercel:
+
 ```ts
+import express from 'express';
 import { createClient } from '@vercel/flags-core';
 
-const client = createClient(process.env.FLAGS!);
+const app = express();
+const client = createClient(); // Uses Vercel OIDC; does not initialize yet.
 
-await client.initialize();
-
-const result = await client.evaluate<boolean>('show-new-feature', false, {
-  user: { id: 'user-123' },
+app.get('/api/feature', async (_req, res) => {
+  const result = await client.evaluate<boolean>('show-new-feature', false);
+  res.json({ enabled: result.value });
 });
+
+export default app;
 ```
+
+Outside Vercel, pass an SDK key explicitly: `createClient(process.env.FLAGS)`.
+
+### Initialization and request-scoped OIDC
+
+On Vercel, the OIDC token can be supplied through the current request context (`x-vercel-oidc-token`). It is not guaranteed to be available while modules are loading. Creating the client at module scope is safe, but starting `client.initialize()` there can attempt authentication before a request exists.
+
+Do not store a module-scope initialization promise and await it later in a handler. Calling `initialize()` starts the work immediately; awaiting the promise inside a request does not move that work into the request context. If the promise rejects, every handler awaiting that same promise will reject before reaching evaluation and its fallback handling.
+
+This also applies when definitions are embedded at build time: with OIDC authentication, the client uses the token's `project_id` claim to select the embedded definitions. An importable `@vercel/flags-definitions` module alone is not enough.
+
+For local development, `vercel env pull` writes an OIDC token to `.env.local`. If your local runner loads that file, the environment-variable fallback can make module-scope initialization appear to work, even though request-scoped authentication on a deployment requires deferring it.
+
+Explicit `await client.initialize()` is optional and can be useful when you want to wait for initialization and handle its errors yourself. Only call it once authentication is available: inside a request handler for request-scoped OIDC, or during startup when using an SDK key or an already-available environment token. For normal flag evaluation, prefer calling `evaluate()` or `bulkEvaluate()` directly in the handler.
 
 ## Evaluation Metrics
 

--- a/packages/vercel-flags-core/src/types.ts
+++ b/packages/vercel-flags-core/src/types.ts
@@ -196,9 +196,11 @@ export type FlagsClient<Entities = Record<string, unknown>> = {
     sdkKey?: string;
   };
   /**
-   * Evaluate a feature flag
+   * Evaluate a feature flag.
    *
-   * Requires initialize() to have been called and awaited first.
+   * Initializes the client automatically on first use. Initialization failures
+   * are caught so evaluation can try its fallback sources and defaultValue.
+   * With request-scoped Vercel OIDC, call this inside a request handler.
    *
    * @param flagKey
    * @param defaultValue
@@ -218,7 +220,9 @@ export type FlagsClient<Entities = Record<string, unknown>> = {
    * Avoids the per-flag overhead of separate `evaluate()` invocations (in particular,
    * the parallel promises and repeated datafile reads they would entail).
    *
-   * Requires initialize() to have been called and awaited first.
+   * Initializes the client automatically on first use. Initialization failures
+   * are caught so evaluation can try its fallback sources and default values.
+   * With request-scoped Vercel OIDC, call this inside a request handler.
    *
    * @param flags Array of `{ key, defaultValue? }` entries to evaluate.
    * @param entities Shared entities used for every flag in the bulk call.
@@ -242,7 +246,13 @@ export type FlagsClient<Entities = Record<string, unknown>> = {
     entities?: E;
   }) => Promise<void>;
   /**
-   * Retrieve the latest datafile during startup, and set up subscriptions if needed.
+   * Load flag definitions and set up subscriptions if needed.
+   *
+   * Optional: evaluate() and bulkEvaluate() initialize automatically. This method
+   * rejects if initialization fails, while evaluation can still try fallbacks.
+   * With request-scoped Vercel OIDC, call this inside a request handler, not at
+   * module scope. Creating the client at module scope is safe; starting and
+   * caching an initialization promise there can run before a token is available.
    */
   initialize(): void | Promise<void>;
   /**

--- a/skills/flags-sdk/references/providers.md
+++ b/skills/flags-sdk/references/providers.md
@@ -114,6 +114,25 @@ export const exampleFlag = flag({
 
 Outside Vercel, pass the SDK key: `createClient(process.env.FLAGS)`. Unlike `vercelAdapter()`, `createClient()` does not read `FLAGS` on its own.
 
+### Core client in other frameworks (for example, Express)
+
+For frameworks without a Flags SDK entrypoint, use `@vercel/flags-core` directly. Create a shared client at module scope, but call `evaluate()` or `bulkEvaluate()` inside a request handler. Both initialize the client automatically; do not add a module-scope `client.initialize()` call or cache its promise for handlers to await.
+
+```ts
+// src/flags.ts
+import { createClient } from '@vercel/flags-core';
+
+const client = createClient();
+
+// Call from a request handler, not during module loading.
+export async function getVersion(): Promise<number> {
+  const result = await client.evaluate<number>('version', 0);
+  return result.value;
+}
+```
+
+With Vercel OIDC, the token can come from request context and may not exist during module loading. Even embedded definitions require OIDC to select the entry by the token's `project_id`. Local `.env.local` credentials can hide this timing problem. Explicit initialization is optional and must wait until authentication is available; awaiting an already-started initialization promise later does not move it into request context. See the [core client README](https://github.com/vercel/flags/tree/main/packages/vercel-flags-core#initialization-and-request-scoped-oidc).
+
 ### `vercel flags` CLI
 
 Manage Vercel Flags from the terminal with an authenticated CLI and a targeted project ([Project targeting](../SKILL.md#project-targeting)). SDK installation and `vercel env pull` are app-development steps, not CLI prerequisites (see [Setup](#setup)).


### PR DESCRIPTION
## Summary

- Replace the core README's eager initialization example with an Express handler that calls `evaluate()` at request time while sharing a module-scope client.
- Correct the public `evaluate()` and `bulkEvaluate()` JSDoc: both initialize automatically. Document explicit `initialize()` as optional and authentication-dependent.
- Add the same request-time guidance to the Flags SDK skill's provider reference for non-Next.js/SvelteKit integrations.

